### PR TITLE
chore: setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,22 @@
 version: 2
 updates:
-  # Enable version updates for Python pip dependencies
+  # Python pip dependencies - security updates only
+  # Regular version updates are disabled because we use compatible release
+  # constraints (~=) in pyproject.toml to pin patch versions.
+  # Dependabot Security Updates (enabled in repo settings) bypass these rules.
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
       time: "09:00"
-
+    # Ignore all regular version updates - security updates still come through
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     # Commit message configuration
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
## Description

Configures Dependabot for security-only updates.

**Changes:**
- `.github/dependabot.yml`: Ignore all regular version updates (major, minor, patch) for pip dependencies. Dependabot Security Updates bypass these rules and will still create PRs when CVEs are detected.

**Why:** We use the compatible release operator (`~=`) in `pyproject.toml` to pin patch versions. Regular Dependabot version update PRs propose bumps outside these constraints, creating noise. By relying on [Dependabot Security Updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates), we still receive automatic PRs for CVE fixes while maintaining intentional version control.

## Related Issue

N/A

## Type of Change

Please check the relevant option:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [x] Dependency update

## How to Test

1. Verify `.github/dependabot.yml` has ignore rules for all semver update types
2. Confirm Dependabot Security Updates are enabled in **Settings → Code security and analysis**

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [ ] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

N/A - This is a configuration change only.