### PR TITLE
fix: add sync token secret to sync workflow

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -19,7 +19,7 @@ jobs:
         env:
           EXTERNAL_REPO: https://github.com/SAP/cloud-sdk-python.git
           INTERNAL_REPO: ${{ format('{0}/{1}.git', github.server_url, github.repository) }}
-          INTERNAL_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INTERNAL_TOKEN: ${{ secrets.SYNC_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           echo "Cloning external repository main branch..."
           git clone --single-branch --branch main "$EXTERNAL_REPO" repo-clone


### PR DESCRIPTION
## fix: add sync token secret to sync workflow

- Updated `.github/workflows/sync.yaml` to use `SYNC_TOKEN` secret with fallback to `GITHUB_TOKEN`
- This change allows the sync workflow to use a dedicated token when available, improving flexibility and security
- The fallback ensures backward compatibility if `SYNC_TOKEN` is not configured
