### PR TITLE
feat: enable batch for instrumentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/auto_instrument.py
+++ b/src/sap_cloud_sdk/core/telemetry/auto_instrument.py
@@ -30,12 +30,17 @@ logger = logging.getLogger(__name__)
 
 
 @record_metrics(Module.AICORE, Operation.AICORE_AUTO_INSTRUMENT)
-def auto_instrument():
+def auto_instrument(disable_batch: bool = False):
     """
     Initialize meta-instrumentation for GenAI tracing. Should be initialized before any AI frameworks.
 
     Traces are exported to the OTEL collector endpoint configured in environment with
     OTEL_EXPORTER_OTLP_ENDPOINT, or printed to console when OTEL_TRACES_EXPORTER=console.
+
+    Args:
+        disable_batch: If True, uses SimpleSpanProcessor (synchronous, lower throughput).
+                       Defaults to False, which uses BatchSpanProcessor (asynchronous,
+                       recommended for production workloads).
     """
     otel_endpoint = os.getenv(ENV_OTLP_ENDPOINT, "")
     console_traces = os.getenv(ENV_TRACES_EXPORTER, "").lower() == "console"
@@ -54,7 +59,7 @@ def auto_instrument():
         exporter=exporter,
         resource_attributes=resource,
         should_enrich_metrics=True,
-        disable_batch=True,
+        disable_batch=disable_batch,
     )
 
     _set_baggage_processor()

--- a/src/sap_cloud_sdk/core/telemetry/user-guide.md
+++ b/src/sap_cloud_sdk/core/telemetry/user-guide.md
@@ -210,6 +210,14 @@ Use an OTLP collector:
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otel-collector.example.com"
 ```
 
+### Span processor
+
+By default, `auto_instrument` uses `BatchSpanProcessor`, which exports spans asynchronously in a background thread and is recommended for production workloads. If you need synchronous span processing (e.g. in short-lived scripts or tests where the process may exit before the batch is flushed), pass `disable_batch=True`:
+
+```python
+auto_instrument(disable_batch=True)
+```
+
 ### System role
 
 ```bash

--- a/tests/core/unit/telemetry/test_auto_instrument.py
+++ b/tests/core/unit/telemetry/test_auto_instrument.py
@@ -43,7 +43,7 @@ class TestAutoInstrument:
             call_kwargs = mock_traceloop_components['traceloop'].init.call_args[1]
             assert call_kwargs['app_name'] == 'test-app'
             assert call_kwargs['should_enrich_metrics'] is True
-            assert call_kwargs['disable_batch'] is True
+            assert call_kwargs['disable_batch'] is False
 
     def test_auto_instrument_uses_grpc_exporter_by_default(self, mock_traceloop_components):
         """Test that auto_instrument uses gRPC exporter by default, letting it read endpoint from env."""
@@ -208,6 +208,17 @@ class TestAutoInstrument:
                 mock_logger.warning.assert_called_once()
                 warning_message = mock_logger.warning.call_args[0][0]
                 assert "OTEL_EXPORTER_OTLP_ENDPOINT not set" in warning_message
+
+    def test_auto_instrument_disable_batch_can_be_set_to_true(self, mock_traceloop_components):
+        """Test that disable_batch=True can be explicitly passed to use SimpleSpanProcessor."""
+        mock_traceloop_components['get_app_name'].return_value = 'test-app'
+        mock_traceloop_components['create_resource'].return_value = {}
+
+        with patch.dict('os.environ', {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317'}, clear=True):
+            auto_instrument(disable_batch=True)
+
+            call_kwargs = mock_traceloop_components['traceloop'].init.call_args[1]
+            assert call_kwargs['disable_batch'] is True
 
     def test_auto_instrument_passes_baggage_span_processor(self, mock_traceloop_components):
         """Test that auto_instrument registers a BaggageSpanProcessor on the tracer provider."""

--- a/uv.lock
+++ b/uv.lock
@@ -2424,7 +2424,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "hatchling" },


### PR DESCRIPTION
 ## Description

This PR changes the default to disable_batch=False (async BatchSpanProcessor) and exposes the parameter so users can override it when needed.

auto_instrument was hardcoding disable_batch=True, forcing SimpleSpanProcessor which exports spans synchronously on the request thread. With concurrent workloads, the network round-trip to the OTEL collector adds up directly on the hot path. A user reported response times dropping from ~40s to ~5s under 9 concurrent requests after patching this locally.



## Related Issue

Closes [#40](https://github.com/SAP/cloud-sdk-python/issues/40)

### Type of Change

- Bug fix (non-breaking change that fixes an issue)
- New feature (non-breaking change that adds functionality)
- Documentation update

### How to Test

1. Call auto_instrument() and send concurrent requests to an instrumented agent exporting to an OTLP endpoint
2. Verify response times are not impacted by span export latency
3. Verify auto_instrument(disable_batch=True) still works for cases where synchronous export is needed (e.g. short-lived scripts)

## Checklist

- I have read the Contributing Guidelines
- I have verified that my changes solve the issue
- I have added/updated automated tests to cover my changes
- All tests pass locally
- I have verified that my code follows the Code Guidelines
- I have updated documentation (if applicable)
- I have added type hints for all public APIs
- My code does not contain sensitive information (credentials, tokens, etc.)
- I have followed Conventional Commits for commit messages

## Breaking Changes

None. The new default (disable_batch=False) is a behavior improvement. Users who relied on the previous synchronous behavior can restore it with auto_instrument(disable_batch=True).

## Additional Notes

Trade-offs of BatchSpanProcessor (the new default):
- Spans in the queue are lost if the process is killed abruptly (SIGKILL)
- In short-lived scripts or serverless runtimes, call tracer_provider.force_flush() on shutdown to avoid losing the last batch
- Export errors surface in a background thread (logged, not propagated)

For these cases, disable_batch=True remains available and is documented in the user guide.