### PR TITLE
fix: relative path destination local mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.6.1"
+version = "0.6.2"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/destination/__init__.py
+++ b/src/sap_cloud_sdk/destination/__init__.py
@@ -70,11 +70,8 @@ logger = logging.getLogger(__name__)
 
 
 def _mock_file(name: str) -> str:
-    """Return the absolute path to a mocks/<name> file relative to the repo root."""
-    repo_root = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "..", "..", "..")
-    )
-    return os.path.join(repo_root, "mocks", name)
+    """Return the absolute path to a mocks/<name> file relative to the working directory."""
+    return os.path.join(os.getcwd(), "mocks", name)
 
 
 def create_client(

--- a/src/sap_cloud_sdk/destination/_local_client_base.py
+++ b/src/sap_cloud_sdk/destination/_local_client_base.py
@@ -43,11 +43,7 @@ class LocalDevClientBase(ABC, Generic[T]):
     """
 
     def __init__(self) -> None:
-        # Resolve to repo root and mocks path
-        repo_root = os.path.abspath(
-            os.path.join(os.path.dirname(__file__), "..", "..", "..")
-        )
-        self._file_path = os.path.join(repo_root, "mocks", self.file_name)
+        self._file_path = os.path.join(os.getcwd(), "mocks", self.file_name)
         self._lock = threading.Lock()
         self._ensure_file()
 

--- a/tests/destination/unit/test_local_certificate_client.py
+++ b/tests/destination/unit/test_local_certificate_client.py
@@ -15,8 +15,8 @@ from sap_cloud_sdk.destination.exceptions import DestinationOperationError, Http
 def client(tmp_path, monkeypatch):
     """Create a LocalDevCertificateClient backed by a temp directory."""
     monkeypatch.setattr(
-        "sap_cloud_sdk.destination._local_client_base.os.path.abspath",
-        lambda _: str(tmp_path),
+        "sap_cloud_sdk.destination._local_client_base.os.getcwd",
+        lambda: str(tmp_path),
     )
     return LocalDevCertificateClient()
 

--- a/tests/destination/unit/test_local_destination_client.py
+++ b/tests/destination/unit/test_local_destination_client.py
@@ -15,8 +15,8 @@ from sap_cloud_sdk.destination.exceptions import DestinationOperationError, Http
 def client(tmp_path, monkeypatch):
     """Create a LocalDevDestinationClient backed by a temp directory."""
     monkeypatch.setattr(
-        "sap_cloud_sdk.destination._local_client_base.os.path.abspath",
-        lambda _: str(tmp_path),
+        "sap_cloud_sdk.destination._local_client_base.os.getcwd",
+        lambda: str(tmp_path),
     )
     return LocalDevDestinationClient()
 

--- a/tests/destination/unit/test_local_fragment_client.py
+++ b/tests/destination/unit/test_local_fragment_client.py
@@ -14,8 +14,8 @@ from sap_cloud_sdk.destination.exceptions import DestinationOperationError, Http
 def client(tmp_path, monkeypatch):
     """Create a LocalDevFragmentClient backed by a temp directory."""
     monkeypatch.setattr(
-        "sap_cloud_sdk.destination._local_client_base.os.path.abspath",
-        lambda _: str(tmp_path),
+        "sap_cloud_sdk.destination._local_client_base.os.getcwd",
+        lambda: str(tmp_path),
     )
     return LocalDevFragmentClient()
 


### PR DESCRIPTION
## Description

`LocalDevClientBase.__init__` and the `_mock_file()` helper in `destination/__init__.py` resolved the `mocks/` directory by navigating three levels up from `__file__`:

```python
repo_root = os.path.abspath(
    os.path.join(os.path.dirname(__file__), "..", "..", "..")
)
```

This works in a source checkout (`src/sap_cloud_sdk/destination/` → three levels up → project root), but when the package is installed into a virtual environment it lands at `.venv/lib/python3.x/site-packages/sap_cloud_sdk/destination/`, making three levels up resolve to `.venv/lib/python3.x/` instead of the project root. As a result `get_instance_destination()` silently returns `None`.

Both locations now use `os.getcwd()`, which always resolves to the directory the application is launched from, regardless of install location:

```python
self._file_path = os.path.join(os.getcwd(), "mocks", self.file_name)
```

Unit test fixtures that previously patched `os.path.abspath` were updated to patch `os.getcwd` instead.

## Related Issue

Closes #46

## Type of Change

Please check the relevant option:

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Create a project that uses `sap_cloud_sdk` installed from a virtual environment (not a source checkout).
2. Add `mocks/destination.json` at the project root with at least one destination entry.
3. Run:
   ```python
   from sap_cloud_sdk.destination import create_client
   client = create_client(instance="destination-service")
   print(client._file_path)   # should print <project-root>/mocks/destination.json
   dest = client.get_instance_destination("my-destination")
   print(dest)                # should print the destination object, not None
   ```
4. Confirm `_file_path` points to the project root and `get_instance_destination()` returns the expected destination.

Alternatively, run the unit test suite:
```bash
uv run pytest tests/destination/unit/ -v
```

## Checklist

Before submitting your PR, please review and check the following:

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] I have verified that my changes solve the issue
- [X] I have added/updated automated tests to cover my changes
- [X] All tests pass locally
- [X] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [X] I have added type hints for all public APIs
- [X] My code does not contain sensitive information (credentials, tokens, etc.)
- [X] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. The fix only affects the path resolution for local development mock files. Any project that already placed `mocks/destination.json` at the project root and ran the application from that root will see identical behaviour.

## Additional Notes

The same `__file__`-based pattern was present in two places — `_local_client_base.py` and the `_mock_file()` helper in `destination/__init__.py` — both are fixed.