### PR TITLE
feat: enable OTLP/HTTP for metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.10.1"
+version = "0.11.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -85,7 +85,7 @@ def _create_metric_exporter():
             f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "
             "Supported values are 'grpc' and 'http/protobuf'."
         )
-    temporality = {
+    temporality: dict[type, AggregationTemporality] = {
         Counter: AggregationTemporality.DELTA,
         Histogram: AggregationTemporality.DELTA,
         ObservableCounter: AggregationTemporality.DELTA,

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -1,10 +1,16 @@
 """Internal module for setting up OpenTelemetry meter provider."""
 
 import logging
+import os
 from typing import Optional
 
 from opentelemetry import metrics
-from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
+    OTLPMetricExporter as GRPCMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter as HTTPMetricExporter,
+)
 from opentelemetry.sdk.metrics import (
     MeterProvider,
     Counter,
@@ -23,6 +29,7 @@ from opentelemetry.sdk.resources import Resource
 from sap_cloud_sdk.core.telemetry.config import (
     get_config,
     create_resource_attributes_from_env,
+    ENV_OTLP_PROTOCOL,
 )
 from sap_cloud_sdk.core._version import get_version
 from sap_cloud_sdk.core.telemetry.constants import SDK_PACKAGE_NAME
@@ -84,16 +91,25 @@ def _setup_meter_provider() -> Optional[MeterProvider]:
     try:
         resource = Resource.create(create_resource_attributes_from_env())
 
-        exporter = OTLPMetricExporter(
+        protocol = os.getenv(ENV_OTLP_PROTOCOL, "grpc").lower()
+        exporter_classes = {"grpc": GRPCMetricExporter, "http/protobuf": HTTPMetricExporter}
+        if protocol not in exporter_classes:
+            raise ValueError(
+                f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "
+                "Supported values are 'grpc' and 'http/protobuf'."
+            )
+
+        temporality = {
+            Counter: AggregationTemporality.DELTA,
+            Histogram: AggregationTemporality.DELTA,
+            ObservableCounter: AggregationTemporality.DELTA,
+            ObservableGauge: AggregationTemporality.DELTA,
+            ObservableUpDownCounter: AggregationTemporality.DELTA,
+            UpDownCounter: AggregationTemporality.DELTA,
+        }
+        exporter = exporter_classes[protocol](
             endpoint=config.otlp_endpoint,
-            preferred_temporality={
-                Counter: AggregationTemporality.DELTA,
-                Histogram: AggregationTemporality.DELTA,
-                ObservableCounter: AggregationTemporality.DELTA,
-                ObservableGauge: AggregationTemporality.DELTA,
-                ObservableUpDownCounter: AggregationTemporality.DELTA,
-                UpDownCounter: AggregationTemporality.DELTA,
-            },
+            preferred_temporality=temporality,
         )
 
         # Create metric reader with periodic export
@@ -106,7 +122,8 @@ def _setup_meter_provider() -> Optional[MeterProvider]:
         logger.info(
             f"OpenTelemetry meter provider initialized. "
             f"Service: {config.service_name}, "
-            f"Endpoint: {config.otlp_endpoint}"
+            f"Endpoint: {config.otlp_endpoint}, "
+            f"Protocol: {protocol}"
         )
 
         return provider

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -76,12 +76,28 @@ def shutdown() -> None:
         _meter_provider = None
 
 
-def _setup_meter_provider() -> Optional[MeterProvider]:
-    """Set up the OpenTelemetry meter provider.
+def _create_metric_exporter(endpoint: str):
+    protocol = os.getenv(ENV_OTLP_PROTOCOL, "grpc").lower()
+    exporter_classes = {"grpc": GRPCMetricExporter, "http/protobuf": HTTPMetricExporter}
 
-    Returns:
-        MeterProvider instance if enabled, None if disabled.
-    """
+    if protocol not in exporter_classes:
+        raise ValueError(
+            f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "
+            "Supported values are 'grpc' and 'http/protobuf'."
+        )
+    temporality = {
+        Counter: AggregationTemporality.DELTA,
+        Histogram: AggregationTemporality.DELTA,
+        ObservableCounter: AggregationTemporality.DELTA,
+        ObservableGauge: AggregationTemporality.DELTA,
+        ObservableUpDownCounter: AggregationTemporality.DELTA,
+        UpDownCounter: AggregationTemporality.DELTA,
+    }
+    logger.debug(f"Creating metric exporter with protocol: {protocol}, endpoint: {endpoint}")
+    return exporter_classes[protocol](endpoint=endpoint, preferred_temporality=temporality)
+
+
+def _setup_meter_provider() -> Optional[MeterProvider]:
     config = get_config()
 
     if not config.enabled:
@@ -90,40 +106,15 @@ def _setup_meter_provider() -> Optional[MeterProvider]:
 
     try:
         resource = Resource.create(create_resource_attributes_from_env())
-
-        protocol = os.getenv(ENV_OTLP_PROTOCOL, "grpc").lower()
-        exporter_classes = {"grpc": GRPCMetricExporter, "http/protobuf": HTTPMetricExporter}
-        if protocol not in exporter_classes:
-            raise ValueError(
-                f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "
-                "Supported values are 'grpc' and 'http/protobuf'."
-            )
-
-        temporality = {
-            Counter: AggregationTemporality.DELTA,
-            Histogram: AggregationTemporality.DELTA,
-            ObservableCounter: AggregationTemporality.DELTA,
-            ObservableGauge: AggregationTemporality.DELTA,
-            ObservableUpDownCounter: AggregationTemporality.DELTA,
-            UpDownCounter: AggregationTemporality.DELTA,
-        }
-        exporter = exporter_classes[protocol](
-            endpoint=config.otlp_endpoint,
-            preferred_temporality=temporality,
-        )
-
-        # Create metric reader with periodic export
+        exporter = _create_metric_exporter(config.otlp_endpoint)
         reader = PeriodicExportingMetricReader(exporter=exporter)
-
-        # Create and set meter provider
         provider = MeterProvider(resource=resource, metric_readers=[reader])
 
         metrics.set_meter_provider(provider)
         logger.info(
             f"OpenTelemetry meter provider initialized. "
             f"Service: {config.service_name}, "
-            f"Endpoint: {config.otlp_endpoint}, "
-            f"Protocol: {protocol}"
+            f"Endpoint: {config.otlp_endpoint}"
         )
 
         return provider

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -76,7 +76,7 @@ def shutdown() -> None:
         _meter_provider = None
 
 
-def _create_metric_exporter(endpoint: str):
+def _create_metric_exporter():
     protocol = os.getenv(ENV_OTLP_PROTOCOL, "grpc").lower()
     exporter_classes = {"grpc": GRPCMetricExporter, "http/protobuf": HTTPMetricExporter}
 
@@ -93,8 +93,7 @@ def _create_metric_exporter(endpoint: str):
         ObservableUpDownCounter: AggregationTemporality.DELTA,
         UpDownCounter: AggregationTemporality.DELTA,
     }
-    logger.debug(f"Creating metric exporter with protocol: {protocol}, endpoint: {endpoint}")
-    return exporter_classes[protocol](endpoint=endpoint, preferred_temporality=temporality)
+    return exporter_classes[protocol](preferred_temporality=temporality)
 
 
 def _setup_meter_provider() -> Optional[MeterProvider]:
@@ -106,7 +105,7 @@ def _setup_meter_provider() -> Optional[MeterProvider]:
 
     try:
         resource = Resource.create(create_resource_attributes_from_env())
-        exporter = _create_metric_exporter(config.otlp_endpoint)
+        exporter = _create_metric_exporter()
         reader = PeriodicExportingMetricReader(exporter=exporter)
         provider = MeterProvider(resource=resource, metric_readers=[reader])
 

--- a/src/sap_cloud_sdk/core/telemetry/user-guide.md
+++ b/src/sap_cloud_sdk/core/telemetry/user-guide.md
@@ -210,6 +210,16 @@ Use an OTLP collector:
 export OTEL_EXPORTER_OTLP_ENDPOINT="https://otel-collector.example.com"
 ```
 
+### Transport protocol
+
+Both traces and metrics use gRPC by default. Switch to HTTP/protobuf by setting:
+
+```bash
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
+```
+
+Supported values: `grpc` (default), `http/protobuf`.
+
 ### Span processor
 
 By default, `auto_instrument` uses `BatchSpanProcessor`, which exports spans asynchronously in a background thread and is recommended for production workloads. If you need synchronous span processing (e.g. in short-lived scripts or tests where the process may exit before the batch is flushed), pass `disable_batch=True`:

--- a/tests/core/unit/telemetry/test_provider.py
+++ b/tests/core/unit/telemetry/test_provider.py
@@ -1,116 +1,94 @@
 """Tests for telemetry meter provider."""
 
-import pytest
 from unittest.mock import patch, MagicMock
 
-from opentelemetry.sdk.metrics import Counter, Histogram, ObservableCounter, ObservableGauge, ObservableUpDownCounter, UpDownCounter
+from opentelemetry.sdk.metrics import (
+    Counter,
+    Histogram,
+    ObservableCounter,
+    ObservableGauge,
+    ObservableUpDownCounter,
+    UpDownCounter,
+)
 from opentelemetry.sdk.metrics.export import AggregationTemporality
 
-from sap_cloud_sdk.core.telemetry._provider import (
-    get_meter,
-    shutdown,
-    _setup_meter_provider,
-)
+from sap_cloud_sdk.core.telemetry._provider import get_meter, shutdown, _setup_meter_provider
 from sap_cloud_sdk.core.telemetry.config import InstrumentationConfig
+
+_DELTA_TEMPORALITY = {
+    Counter: AggregationTemporality.DELTA,
+    Histogram: AggregationTemporality.DELTA,
+    ObservableCounter: AggregationTemporality.DELTA,
+    ObservableGauge: AggregationTemporality.DELTA,
+    ObservableUpDownCounter: AggregationTemporality.DELTA,
+    UpDownCounter: AggregationTemporality.DELTA,
+}
+
+_GRPC_EXPORTER = "sap_cloud_sdk.core.telemetry._provider.GRPCMetricExporter"
+_HTTP_EXPORTER = "sap_cloud_sdk.core.telemetry._provider.HTTPMetricExporter"
+_ENABLED_CONFIG = InstrumentationConfig(
+    enabled=True, service_name="test-service", otlp_endpoint="http://localhost:4317"
+)
 
 
 class TestGetMeter:
-    """Test suite for get_meter function."""
-
     def test_get_meter_returns_meter(self):
-        """Test that get_meter returns a meter instance."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
-        # Reset global state
         provider_module._meter_provider = None
         provider_module._meter = None
 
-        with patch('sap_cloud_sdk.core.telemetry._provider._setup_meter_provider') as mock_setup:
-            mock_provider = MagicMock()
-            mock_setup.return_value = mock_provider
-
-            with patch('opentelemetry.metrics.get_meter') as mock_get_meter:
-                mock_meter = MagicMock()
-                mock_get_meter.return_value = mock_meter
-
+        with patch("sap_cloud_sdk.core.telemetry._provider._setup_meter_provider") as mock_setup:
+            mock_setup.return_value = MagicMock()
+            with patch("opentelemetry.metrics.get_meter", return_value=MagicMock()) as mock_get_meter:
                 meter = get_meter()
-
-                assert meter is mock_meter
+                assert meter is mock_get_meter.return_value
                 mock_setup.assert_called_once()
 
     def test_get_meter_returns_singleton(self):
-        """Test that get_meter returns the same meter instance."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
-        # Reset global state
         provider_module._meter_provider = None
         provider_module._meter = None
 
-        with patch('sap_cloud_sdk.core.telemetry._provider._setup_meter_provider') as mock_setup:
-            mock_provider = MagicMock()
-            mock_setup.return_value = mock_provider
-
-            with patch('opentelemetry.metrics.get_meter') as mock_get_meter:
-                mock_meter = MagicMock()
-                mock_get_meter.return_value = mock_meter
-
+        with patch("sap_cloud_sdk.core.telemetry._provider._setup_meter_provider", return_value=MagicMock()):
+            with patch("opentelemetry.metrics.get_meter", return_value=MagicMock()) as mock_get_meter:
                 meter1 = get_meter()
                 meter2 = get_meter()
-
                 assert meter1 is meter2
-                # Setup should only be called once
-                mock_setup.assert_called_once()
 
     def test_get_meter_when_provider_setup_fails(self):
-        """Test that get_meter returns no-op meter when provider setup fails."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
-        # Reset global state
         provider_module._meter_provider = None
         provider_module._meter = None
 
-        with patch('sap_cloud_sdk.core.telemetry._provider._setup_meter_provider', return_value=None):
-            with patch('opentelemetry.metrics.get_meter_provider') as mock_get_provider:
-                mock_no_op_provider = MagicMock()
+        with patch("sap_cloud_sdk.core.telemetry._provider._setup_meter_provider", return_value=None):
+            with patch("opentelemetry.metrics.get_meter_provider") as mock_get_provider:
                 mock_no_op_meter = MagicMock()
-                mock_no_op_provider.get_meter.return_value = mock_no_op_meter
-                mock_get_provider.return_value = mock_no_op_provider
+                mock_get_provider.return_value.get_meter.return_value = mock_no_op_meter
 
                 meter = get_meter()
 
                 assert meter is mock_no_op_meter
-                mock_no_op_provider.get_meter.assert_called_once()
 
     def test_get_meter_initializes_provider_once(self):
-        """Test that provider is only initialized once across multiple get_meter calls."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
-        # Reset global state
         provider_module._meter_provider = None
         provider_module._meter = None
 
-        with patch('sap_cloud_sdk.core.telemetry._provider._setup_meter_provider') as mock_setup:
-            mock_provider = MagicMock()
-            mock_setup.return_value = mock_provider
-
-            with patch('opentelemetry.metrics.get_meter') as mock_get_meter:
-                mock_meter = MagicMock()
-                mock_get_meter.return_value = mock_meter
-
-                # Call get_meter multiple times
+        with patch("sap_cloud_sdk.core.telemetry._provider._setup_meter_provider") as mock_setup:
+            mock_setup.return_value = MagicMock()
+            with patch("opentelemetry.metrics.get_meter", return_value=MagicMock()):
                 get_meter()
                 get_meter()
                 get_meter()
-
-                # Setup should only be called once
                 assert mock_setup.call_count == 1
 
 
 class TestShutdown:
-    """Test suite for shutdown function."""
-
     def test_shutdown_with_active_provider(self):
-        """Test shutdown with an active meter provider."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
         mock_provider = MagicMock()
@@ -122,128 +100,91 @@ class TestShutdown:
         assert provider_module._meter_provider is None
 
     def test_shutdown_with_no_provider(self):
-        """Test shutdown when no provider is active."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
         provider_module._meter_provider = None
-
-        # Should not raise exception
-        shutdown()
+        shutdown()  # should not raise
 
     def test_shutdown_handles_exception(self):
-        """Test that shutdown handles exceptions gracefully."""
         import sap_cloud_sdk.core.telemetry._provider as provider_module
 
         mock_provider = MagicMock()
         mock_provider.shutdown.side_effect = Exception("Shutdown error")
         provider_module._meter_provider = mock_provider
 
-        # Should not raise exception
-        shutdown()
+        shutdown()  # should not raise
 
-        # Provider should still be set to None
         assert provider_module._meter_provider is None
 
 
 class TestSetupMeterProvider:
-    """Test suite for _setup_meter_provider function."""
-
-    def test_setup_meter_provider_disabled(self):
-        """Test that setup returns None when telemetry is disabled."""
+    def test_setup_disabled(self):
         config = InstrumentationConfig(enabled=False)
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=config):
+            assert _setup_meter_provider() is None
 
-        with patch('sap_cloud_sdk.core.telemetry._provider.get_config', return_value=config):
-            provider = _setup_meter_provider()
+    def test_grpc_exporter_by_default(self):
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch(_GRPC_EXPORTER) as mock_grpc:
+                    with patch(_HTTP_EXPORTER) as mock_http:
+                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
+                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
+                                with patch("opentelemetry.metrics.set_meter_provider"):
+                                    _setup_meter_provider()
 
-            assert provider is None
+                        mock_grpc.assert_called_once_with(
+                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
+                            preferred_temporality=_DELTA_TEMPORALITY,
+                        )
+                        mock_http.assert_not_called()
 
-    def test_setup_meter_provider_success(self):
-        """Test successful meter provider setup."""
-        config = InstrumentationConfig(
-            enabled=True,
-            service_name="test-service",
-            otlp_endpoint="http://localhost:4317"
-        )
+    def test_grpc_exporter_explicit(self):
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch(_GRPC_EXPORTER) as mock_grpc:
+                    with patch(_HTTP_EXPORTER) as mock_http:
+                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
+                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
+                                with patch("opentelemetry.metrics.set_meter_provider"):
+                                    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}):
+                                        _setup_meter_provider()
 
-        with patch('sap_cloud_sdk.core.telemetry._provider.get_config', return_value=config):
-            with patch('sap_cloud_sdk.core.telemetry._provider.Resource') as mock_resource_class:
-                with patch('sap_cloud_sdk.core.telemetry._provider.OTLPMetricExporter') as mock_exporter_class:
-                    with patch('sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader') as mock_reader_class:
-                        with patch('sap_cloud_sdk.core.telemetry._provider.MeterProvider') as mock_provider_class:
-                            with patch('opentelemetry.metrics.set_meter_provider') as mock_set_provider:
-                                mock_resource = MagicMock()
-                                mock_exporter = MagicMock()
-                                mock_reader = MagicMock()
-                                mock_provider = MagicMock()
+                        mock_grpc.assert_called_once_with(
+                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
+                            preferred_temporality=_DELTA_TEMPORALITY,
+                        )
+                        mock_http.assert_not_called()
 
-                                mock_resource_class.return_value = mock_resource
-                                mock_exporter_class.return_value = mock_exporter
-                                mock_reader_class.return_value = mock_reader
-                                mock_provider_class.return_value = mock_provider
+    def test_http_protobuf_exporter(self):
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch(_GRPC_EXPORTER) as mock_grpc:
+                    with patch(_HTTP_EXPORTER) as mock_http:
+                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
+                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
+                                with patch("opentelemetry.metrics.set_meter_provider"):
+                                    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}):
+                                        _setup_meter_provider()
 
-                                result = _setup_meter_provider()
+                        mock_http.assert_called_once_with(
+                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
+                            preferred_temporality=_DELTA_TEMPORALITY,
+                        )
+                        mock_grpc.assert_not_called()
 
-                                assert result is mock_provider
+    def test_unsupported_protocol_returns_none(self):
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}):
+                    assert _setup_meter_provider() is None
 
-                                # Verify exporter was created with endpoint and delta temporality
-                                mock_exporter_class.assert_called_once_with(
-                                    endpoint="http://localhost:4317",
-                                    preferred_temporality={
-                                        Counter: AggregationTemporality.DELTA,
-                                        Histogram: AggregationTemporality.DELTA,
-                                        ObservableCounter: AggregationTemporality.DELTA,
-                                        ObservableGauge: AggregationTemporality.DELTA,
-                                        ObservableUpDownCounter: AggregationTemporality.DELTA,
-                                        UpDownCounter: AggregationTemporality.DELTA,
-                                    },
-                                )
-
-                                # Verify reader was created with exporter
-                                mock_reader_class.assert_called_once_with(
-                                    exporter=mock_exporter
-                                )
-
-
-                                # Verify provider was set globally
-                                mock_set_provider.assert_called_once_with(mock_provider)
-
-    def test_setup_meter_provider_with_valid_config(self):
-        """Test setup with various valid configurations."""
-        test_configs = [
-            InstrumentationConfig(
-                enabled=True,
-                service_name="app1",
-                otlp_endpoint="http://collector1:4317"
-            ),
-            InstrumentationConfig(
-                enabled=True,
-                service_name="app2",
-                otlp_endpoint="https://collector2:4318"
-            ),
-        ]
-
-        for config in test_configs:
-            with patch('sap_cloud_sdk.core.telemetry._provider.get_config', return_value=config):
-                with patch('sap_cloud_sdk.core.telemetry._provider.Resource'):
-                    with patch('sap_cloud_sdk.core.telemetry._provider.OTLPMetricExporter') as mock_exporter:
-                        with patch('sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader'):
-                            with patch('sap_cloud_sdk.core.telemetry._provider.MeterProvider') as mock_provider_class:
-                                with patch('opentelemetry.metrics.set_meter_provider'):
-                                    mock_provider = MagicMock()
-                                    mock_provider_class.return_value = mock_provider
-
-                                    result = _setup_meter_provider()
-
-                                    assert result is mock_provider
-                                    # Verify exporter was created with correct endpoint and delta temporality
-                                    mock_exporter.assert_called_with(
-                                        endpoint=config.otlp_endpoint,
-                                        preferred_temporality={
-                                            Counter: AggregationTemporality.DELTA,
-                                            Histogram: AggregationTemporality.DELTA,
-                                            ObservableCounter: AggregationTemporality.DELTA,
-                                            ObservableGauge: AggregationTemporality.DELTA,
-                                            ObservableUpDownCounter: AggregationTemporality.DELTA,
-                                            UpDownCounter: AggregationTemporality.DELTA,
-                                        },
-                                    )
+    def test_returns_configured_provider(self):
+        mock_provider = MagicMock()
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch(_GRPC_EXPORTER):
+                    with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
+                        with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider", return_value=mock_provider):
+                            with patch("opentelemetry.metrics.set_meter_provider"):
+                                assert _setup_meter_provider() is mock_provider

--- a/tests/core/unit/telemetry/test_provider.py
+++ b/tests/core/unit/telemetry/test_provider.py
@@ -34,7 +34,6 @@ _HTTP_EXPORTER = "sap_cloud_sdk.core.telemetry._provider.HTTPMetricExporter"
 _ENABLED_CONFIG = InstrumentationConfig(
     enabled=True, service_name="test-service", otlp_endpoint="http://localhost:4317"
 )
-_ENDPOINT = "http://localhost:4317"
 
 
 class TestGetMeter:
@@ -127,31 +126,31 @@ class TestCreateMetricExporter:
     def test_grpc_by_default(self):
         with patch(_GRPC_EXPORTER) as mock_grpc:
             with patch(_HTTP_EXPORTER) as mock_http:
-                _create_metric_exporter(_ENDPOINT)
-                mock_grpc.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                _create_metric_exporter()
+                mock_grpc.assert_called_once_with(preferred_temporality=_DELTA_TEMPORALITY)
                 mock_http.assert_not_called()
 
     def test_grpc_explicit(self):
         with patch(_GRPC_EXPORTER) as mock_grpc:
             with patch(_HTTP_EXPORTER) as mock_http:
                 with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}):
-                    _create_metric_exporter(_ENDPOINT)
-                mock_grpc.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                    _create_metric_exporter()
+                mock_grpc.assert_called_once_with(preferred_temporality=_DELTA_TEMPORALITY)
                 mock_http.assert_not_called()
 
     def test_http_protobuf(self):
         with patch(_GRPC_EXPORTER) as mock_grpc:
             with patch(_HTTP_EXPORTER) as mock_http:
                 with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}):
-                    _create_metric_exporter(_ENDPOINT)
-                mock_http.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                    _create_metric_exporter()
+                mock_http.assert_called_once_with(preferred_temporality=_DELTA_TEMPORALITY)
                 mock_grpc.assert_not_called()
 
     def test_unsupported_protocol_raises(self):
         import pytest
         with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}):
             with pytest.raises(ValueError, match="Unsupported OTEL_EXPORTER_OTLP_PROTOCOL"):
-                _create_metric_exporter(_ENDPOINT)
+                _create_metric_exporter()
 
 
 class TestSetupMeterProvider:
@@ -170,7 +169,7 @@ class TestSetupMeterProvider:
                             with patch("opentelemetry.metrics.set_meter_provider"):
                                 _setup_meter_provider()
 
-                        mock_create.assert_called_once_with(_ENABLED_CONFIG.otlp_endpoint)
+                        mock_create.assert_called_once_with()
                         mock_reader.assert_called_once_with(exporter=mock_exporter)
 
     def test_unsupported_protocol_returns_none(self):

--- a/tests/core/unit/telemetry/test_provider.py
+++ b/tests/core/unit/telemetry/test_provider.py
@@ -12,7 +12,12 @@ from opentelemetry.sdk.metrics import (
 )
 from opentelemetry.sdk.metrics.export import AggregationTemporality
 
-from sap_cloud_sdk.core.telemetry._provider import get_meter, shutdown, _setup_meter_provider
+from sap_cloud_sdk.core.telemetry._provider import (
+    get_meter,
+    shutdown,
+    _setup_meter_provider,
+    _create_metric_exporter,
+)
 from sap_cloud_sdk.core.telemetry.config import InstrumentationConfig
 
 _DELTA_TEMPORALITY = {
@@ -29,6 +34,7 @@ _HTTP_EXPORTER = "sap_cloud_sdk.core.telemetry._provider.HTTPMetricExporter"
 _ENABLED_CONFIG = InstrumentationConfig(
     enabled=True, service_name="test-service", otlp_endpoint="http://localhost:4317"
 )
+_ENDPOINT = "http://localhost:4317"
 
 
 class TestGetMeter:
@@ -117,61 +123,55 @@ class TestShutdown:
         assert provider_module._meter_provider is None
 
 
+class TestCreateMetricExporter:
+    def test_grpc_by_default(self):
+        with patch(_GRPC_EXPORTER) as mock_grpc:
+            with patch(_HTTP_EXPORTER) as mock_http:
+                _create_metric_exporter(_ENDPOINT)
+                mock_grpc.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                mock_http.assert_not_called()
+
+    def test_grpc_explicit(self):
+        with patch(_GRPC_EXPORTER) as mock_grpc:
+            with patch(_HTTP_EXPORTER) as mock_http:
+                with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}):
+                    _create_metric_exporter(_ENDPOINT)
+                mock_grpc.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                mock_http.assert_not_called()
+
+    def test_http_protobuf(self):
+        with patch(_GRPC_EXPORTER) as mock_grpc:
+            with patch(_HTTP_EXPORTER) as mock_http:
+                with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}):
+                    _create_metric_exporter(_ENDPOINT)
+                mock_http.assert_called_once_with(endpoint=_ENDPOINT, preferred_temporality=_DELTA_TEMPORALITY)
+                mock_grpc.assert_not_called()
+
+    def test_unsupported_protocol_raises(self):
+        import pytest
+        with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}):
+            with pytest.raises(ValueError, match="Unsupported OTEL_EXPORTER_OTLP_PROTOCOL"):
+                _create_metric_exporter(_ENDPOINT)
+
+
 class TestSetupMeterProvider:
     def test_setup_disabled(self):
         config = InstrumentationConfig(enabled=False)
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=config):
             assert _setup_meter_provider() is None
 
-    def test_grpc_exporter_by_default(self):
+    def test_delegates_to_create_metric_exporter(self):
+        mock_exporter = MagicMock()
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
             with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch(_GRPC_EXPORTER) as mock_grpc:
-                    with patch(_HTTP_EXPORTER) as mock_http:
-                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
-                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
-                                with patch("opentelemetry.metrics.set_meter_provider"):
-                                    _setup_meter_provider()
+                with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter", return_value=mock_exporter) as mock_create:
+                    with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader") as mock_reader:
+                        with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
+                            with patch("opentelemetry.metrics.set_meter_provider"):
+                                _setup_meter_provider()
 
-                        mock_grpc.assert_called_once_with(
-                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
-                            preferred_temporality=_DELTA_TEMPORALITY,
-                        )
-                        mock_http.assert_not_called()
-
-    def test_grpc_exporter_explicit(self):
-        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
-            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch(_GRPC_EXPORTER) as mock_grpc:
-                    with patch(_HTTP_EXPORTER) as mock_http:
-                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
-                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
-                                with patch("opentelemetry.metrics.set_meter_provider"):
-                                    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"}):
-                                        _setup_meter_provider()
-
-                        mock_grpc.assert_called_once_with(
-                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
-                            preferred_temporality=_DELTA_TEMPORALITY,
-                        )
-                        mock_http.assert_not_called()
-
-    def test_http_protobuf_exporter(self):
-        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
-            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch(_GRPC_EXPORTER) as mock_grpc:
-                    with patch(_HTTP_EXPORTER) as mock_http:
-                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
-                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
-                                with patch("opentelemetry.metrics.set_meter_provider"):
-                                    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"}):
-                                        _setup_meter_provider()
-
-                        mock_http.assert_called_once_with(
-                            endpoint=_ENABLED_CONFIG.otlp_endpoint,
-                            preferred_temporality=_DELTA_TEMPORALITY,
-                        )
-                        mock_grpc.assert_not_called()
+                        mock_create.assert_called_once_with(_ENABLED_CONFIG.otlp_endpoint)
+                        mock_reader.assert_called_once_with(exporter=mock_exporter)
 
     def test_unsupported_protocol_returns_none(self):
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
@@ -183,7 +183,7 @@ class TestSetupMeterProvider:
         mock_provider = MagicMock()
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
             with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch(_GRPC_EXPORTER):
+                with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter"):
                     with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
                         with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider", return_value=mock_provider):
                             with patch("opentelemetry.metrics.set_meter_provider"):

--- a/uv.lock
+++ b/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.10.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

Enabled configuring protocol for metering via the `OTEL_EXPORTER_OTLP_PROTOCOL` env var

## Type of Change

Please check the relevant option:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Add environment variable OTEL_EXPORTER_OTLP_PROTOCOL="http/protobuf"
2. Emit metrics by set_aicore_config() using SAP Cloud SDK
3. Metrics will be exported using HTTP protocol

## Checklist

Before submitting your PR, please review and check the following:

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] I have verified that my changes solve the issue
- [X] I have added/updated automated tests to cover my changes
- [X] All tests pass locally
- [X] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [X] I have updated documentation (if applicable)
- [X] I have added type hints for all public APIs
- [X] My code does not contain sensitive information (credentials, tokens, etc.)
- [X] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages