### PR TITLE
fix: fall back to OTEL_SERVICE_NAME when APPFND_CONHOS_APP_NAME is not set

### DIFF
--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -26,6 +26,7 @@ ENV_REGION = "APPFND_CONHOS_REGION"
 ENV_ENVIRONMENT = "APPFND_CONHOS_ENVIRONMENT"
 ENV_SUBACCOUNT_ID = "APPFND_CONHOS_SUBACCOUNTID"
 ENV_APP_NAME = "APPFND_CONHOS_APP_NAME"
+ENV_OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME"
 ENV_HOSTNAME = "HOSTNAME"
 ENV_SYSTEM_ROLE = "APPFND_CONHOS_SYSTEM_ROLE"
 
@@ -53,7 +54,7 @@ def _get_subaccount_id() -> str:
 
 def _get_app_name() -> str:
     """Get application name from environment or return default."""
-    return os.getenv(ENV_APP_NAME, DEFAULT_UNKNOWN)
+    return os.getenv(ENV_APP_NAME) or os.getenv(ENV_OTEL_SERVICE_NAME, DEFAULT_UNKNOWN)
 
 
 def _get_hostname() -> str:

--- a/tests/core/unit/telemetry/test_telemetry.py
+++ b/tests/core/unit/telemetry/test_telemetry.py
@@ -70,6 +70,16 @@ class TestEnvironmentHelpers:
         with patch.dict('os.environ', {'APPFND_CONHOS_APP_NAME': 'my-app'}, clear=True):
             assert _get_app_name() == 'my-app'
 
+    def test_get_app_name_falls_back_to_otel_service_name(self):
+        """Test that OTEL_SERVICE_NAME is used when APPFND_CONHOS_APP_NAME is not set."""
+        with patch.dict('os.environ', {'OTEL_SERVICE_NAME': 'my-agent'}, clear=True):
+            assert _get_app_name() == 'my-agent'
+
+    def test_get_app_name_prefers_appfnd_over_otel(self):
+        """Test that APPFND_CONHOS_APP_NAME takes precedence over OTEL_SERVICE_NAME."""
+        with patch.dict('os.environ', {'APPFND_CONHOS_APP_NAME': 'appfnd-name', 'OTEL_SERVICE_NAME': 'otel-name'}, clear=True):
+            assert _get_app_name() == 'appfnd-name'
+
     def test_get_app_name_default(self):
         """Test getting app name default when not set."""
         with patch.dict('os.environ', {}, clear=True):


### PR DESCRIPTION
## Summary
- `_get_app_name()` now checks `OTEL_SERVICE_NAME` as a fallback when `APPFND_CONHOS_APP_NAME` is not set
- `APPFND_CONHOS_APP_NAME` still takes precedence — no behavior change for existing deployments

## Why
When agents are deployed with OTel auto-instrumentation, the OTel Operator webhook injects `OTEL_SERVICE_NAME` into pods automatically. The SDK was ignoring this standard env var and defaulting to `"unknown"`, causing all spans to show `resource.service.name = "unknown"` in CLS.

## Test plan
- [ ] Deploy to agent5 cluster and verify spans show correct `service.name` instead of `"unknown"`