### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.11.0"
+version = "0.11.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` version `0.11.0` → `0.11.1`

## Related
- Fixes `service.name = "unknown"` by falling back to `OTEL_SERVICE_NAME`: #65