### PR TITLE
feat: add tenant parameter to label management operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.11.1"
+version = "0.11.2"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/destination/certificate_client.py
+++ b/src/sap_cloud_sdk/destination/certificate_client.py
@@ -307,13 +307,17 @@ class CertificateClient:
 
     @record_metrics(Module.DESTINATION, Operation.CERTIFICATE_GET_LABELS)
     def get_certificate_labels(
-        self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> List[Label]:
         """Get labels for a certificate.
 
         Args:
             name: Certificate name.
             level: Scope to query (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Returns:
             List of labels assigned to the certificate. Returns empty list if none assigned.
@@ -323,7 +327,7 @@ class CertificateClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels")
+            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(
@@ -341,7 +345,11 @@ class CertificateClient:
 
     @record_metrics(Module.DESTINATION, Operation.CERTIFICATE_UPDATE_LABELS)
     def update_certificate_labels(
-        self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        labels: List[Label],
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Replace all labels for a certificate.
 
@@ -349,6 +357,7 @@ class CertificateClient:
             name: Certificate name.
             labels: List of labels to set (replaces existing labels).
             level: Scope where the certificate exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -360,6 +369,7 @@ class CertificateClient:
             self._http.put(
                 f"{API_V1}/{path}/{name}/labels",
                 body=[lbl.to_dict() for lbl in labels],
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise
@@ -370,7 +380,11 @@ class CertificateClient:
 
     @record_metrics(Module.DESTINATION, Operation.CERTIFICATE_PATCH_LABELS)
     def patch_certificate_labels(
-        self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        patch: PatchLabels,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Add or remove labels for a certificate.
 
@@ -378,6 +392,7 @@ class CertificateClient:
             name: Certificate name.
             patch: PatchLabels with action ("ADD" or "DELETE") and labels to apply.
             level: Scope where the certificate exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -389,6 +404,7 @@ class CertificateClient:
             self._http.patch(
                 f"{API_V1}/{path}/{name}/labels",
                 body=patch.to_dict(),
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise

--- a/src/sap_cloud_sdk/destination/certificate_client.py
+++ b/src/sap_cloud_sdk/destination/certificate_client.py
@@ -327,7 +327,9 @@ class CertificateClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
+            resp = self._http.get(
+                f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant
+            )
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(

--- a/src/sap_cloud_sdk/destination/client.py
+++ b/src/sap_cloud_sdk/destination/client.py
@@ -522,13 +522,17 @@ class DestinationClient:
 
     @record_metrics(Module.DESTINATION, Operation.DESTINATION_GET_LABELS)
     def get_destination_labels(
-        self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> List[Label]:
         """Get labels for a destination.
 
         Args:
             name: Destination name.
             level: Scope to query (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Returns:
             List of labels assigned to the destination. Returns empty list if none assigned.
@@ -538,7 +542,7 @@ class DestinationClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels")
+            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(
@@ -556,7 +560,11 @@ class DestinationClient:
 
     @record_metrics(Module.DESTINATION, Operation.DESTINATION_UPDATE_LABELS)
     def update_destination_labels(
-        self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        labels: List[Label],
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Replace all labels for a destination.
 
@@ -564,6 +572,7 @@ class DestinationClient:
             name: Destination name.
             labels: List of labels to set (replaces existing labels).
             level: Scope where the destination exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -575,6 +584,7 @@ class DestinationClient:
             self._http.put(
                 f"{API_V1}/{path}/{name}/labels",
                 body=[lbl.to_dict() for lbl in labels],
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise
@@ -585,7 +595,11 @@ class DestinationClient:
 
     @record_metrics(Module.DESTINATION, Operation.DESTINATION_PATCH_LABELS)
     def patch_destination_labels(
-        self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        patch: PatchLabels,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Add or remove labels for a destination.
 
@@ -593,6 +607,7 @@ class DestinationClient:
             name: Destination name.
             patch: PatchLabels with action ("ADD" or "DELETE") and labels to apply.
             level: Scope where the destination exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -604,6 +619,7 @@ class DestinationClient:
             self._http.patch(
                 f"{API_V1}/{path}/{name}/labels",
                 body=patch.to_dict(),
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise

--- a/src/sap_cloud_sdk/destination/client.py
+++ b/src/sap_cloud_sdk/destination/client.py
@@ -542,7 +542,9 @@ class DestinationClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
+            resp = self._http.get(
+                f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant
+            )
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(

--- a/src/sap_cloud_sdk/destination/fragment_client.py
+++ b/src/sap_cloud_sdk/destination/fragment_client.py
@@ -290,13 +290,17 @@ class FragmentClient:
 
     @record_metrics(Module.DESTINATION, Operation.FRAGMENT_GET_LABELS)
     def get_fragment_labels(
-        self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> List[Label]:
         """Get labels for a fragment.
 
         Args:
             name: Fragment name.
             level: Scope to query (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Returns:
             List of labels assigned to the fragment. Returns empty list if none assigned.
@@ -306,7 +310,7 @@ class FragmentClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels")
+            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(
@@ -324,7 +328,11 @@ class FragmentClient:
 
     @record_metrics(Module.DESTINATION, Operation.FRAGMENT_UPDATE_LABELS)
     def update_fragment_labels(
-        self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        labels: List[Label],
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Replace all labels for a fragment.
 
@@ -332,6 +340,7 @@ class FragmentClient:
             name: Fragment name.
             labels: List of labels to set (replaces existing labels).
             level: Scope where the fragment exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -343,6 +352,7 @@ class FragmentClient:
             self._http.put(
                 f"{API_V1}/{path}/{name}/labels",
                 body=[lbl.to_dict() for lbl in labels],
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise
@@ -353,7 +363,11 @@ class FragmentClient:
 
     @record_metrics(Module.DESTINATION, Operation.FRAGMENT_PATCH_LABELS)
     def patch_fragment_labels(
-        self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT
+        self,
+        name: str,
+        patch: PatchLabels,
+        level: Optional[Level] = Level.SUB_ACCOUNT,
+        tenant: Optional[str] = None,
     ) -> None:
         """Add or remove labels for a fragment.
 
@@ -361,6 +375,7 @@ class FragmentClient:
             name: Fragment name.
             patch: PatchLabels with action ("ADD" or "DELETE") and labels to apply.
             level: Scope where the fragment exists (subaccount by default).
+            tenant: Optional subscriber tenant subdomain. If provided, the request is scoped to that tenant.
 
         Raises:
             HttpError: Propagated for HTTP errors.
@@ -372,6 +387,7 @@ class FragmentClient:
             self._http.patch(
                 f"{API_V1}/{path}/{name}/labels",
                 body=patch.to_dict(),
+                tenant_subdomain=tenant,
             )
         except HttpError:
             raise

--- a/src/sap_cloud_sdk/destination/fragment_client.py
+++ b/src/sap_cloud_sdk/destination/fragment_client.py
@@ -310,7 +310,9 @@ class FragmentClient:
         """
         try:
             path = self._sub_path_for_level(level)
-            resp = self._http.get(f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant)
+            resp = self._http.get(
+                f"{API_V1}/{path}/{name}/labels", tenant_subdomain=tenant
+            )
             data = resp.json()
             if not isinstance(data, list):
                 raise DestinationOperationError(

--- a/src/sap_cloud_sdk/destination/user-guide.md
+++ b/src/sap_cloud_sdk/destination/user-guide.md
@@ -71,6 +71,21 @@ certificate_client.delete_certificate("my-cert.pem", level=Level.SUB_ACCOUNT, te
 certificate_client.create_certificate(new_cert, level=Level.SUB_ACCOUNT)
 certificate_client.update_certificate(new_cert, level=Level.SUB_ACCOUNT)
 certificate_client.delete_certificate("my-cert.pem", level=Level.SUB_ACCOUNT)
+
+# Label management with tenant (subscriber context)
+from sap_cloud_sdk.destination import Label, PatchLabels
+labels = [Label(key="env", values=["prod", "eu"])]
+
+client.update_destination_labels("my-dest", labels, level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+client.patch_destination_labels("my-dest", PatchLabels(action="ADD", labels=labels), level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+retrieved = client.get_destination_labels("my-dest", level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+
+fragment_client.update_fragment_labels("my-fragment", labels, level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+certificate_client.get_certificate_labels("my-cert.pem", level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+
+# Label management without tenant (provider context)
+client.update_destination_labels("my-dest", labels, level=Level.SUB_ACCOUNT)
+client.patch_destination_labels("my-dest", PatchLabels(action="DELETE", labels=labels), level=Level.SUB_ACCOUNT)
 ```
 
 ## Concepts
@@ -103,6 +118,9 @@ class DestinationClient:
     def create_destination(self, dest: Destination, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def update_destination(self, dest: Destination, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def delete_destination(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def get_destination_labels(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> List[Label]: ...
+    def update_destination_labels(self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def patch_destination_labels(self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
 
     # V2 Runtime API - Destination consumption with automatic token retrieval
     def get_destination(self, name: str, level: Optional[Level] = None, options: Optional[ConsumptionOptions] = None, proxy_enabled: Optional[bool] = None) -> Optional[Destination | TransparentProxyDestination]: ...
@@ -116,11 +134,14 @@ The fragment client produced by `create_fragment_client()` exposes the following
 class FragmentClient:
     def get_instance_fragment(self, name: str) -> Optional[Fragment]: ...
     def get_subaccount_fragment(self, name: str, access_strategy: AccessStrategy = AccessStrategy.SUBSCRIBER_FIRST, tenant: Optional[str] = None) -> Optional[Fragment]: ...
-    def list_instance_fragments(self) -> List[Fragment]: ...
-    def list_subaccount_fragments(self, access_strategy: AccessStrategy = AccessStrategy.SUBSCRIBER_FIRST, tenant: Optional[str] = None) -> List[Fragment]: ...
+    def list_instance_fragments(self, filter: Optional[ListOptions] = None) -> List[Fragment]: ...
+    def list_subaccount_fragments(self, access_strategy: AccessStrategy = AccessStrategy.SUBSCRIBER_FIRST, tenant: Optional[str] = None, filter: Optional[ListOptions] = None) -> List[Fragment]: ...
     def create_fragment(self, fragment: Fragment, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def update_fragment(self, fragment: Fragment, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def delete_fragment(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def get_fragment_labels(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> List[Label]: ...
+    def update_fragment_labels(self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def patch_fragment_labels(self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
 ```
 
 ### Certificate Client
@@ -136,6 +157,9 @@ class CertificateClient:
     def create_certificate(self, certificate: Certificate, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def update_certificate(self, certificate: Certificate, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
     def delete_certificate(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def get_certificate_labels(self, name: str, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> List[Label]: ...
+    def update_certificate_labels(self, name: str, labels: List[Label], level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
+    def patch_certificate_labels(self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
 ```
 
 ### Models
@@ -164,7 +188,9 @@ class CertificateClient:
 - `DestinationConfig(url, token_url, client_id, client_secret, identityzone)`
 - `TransparentProxy(proxy_name: str, namespace: str)` - Configuration for transparent proxy routing
 - `TransparentProxyDestination(name: str, url: str, headers: dict[str, str])` - Destination configured for transparent proxy access
-- `ListOptions(name?: str, $skip?: int, $top?: int)` - For pagination and filtering list operations
+- `Label(key: str, values: List[str])` - Key-value metadata tag for filtering and organizing resources
+- `PatchLabels(action: str, labels: List[Label])` - Incremental label update; `action` is `"ADD"` (upsert) or `"DELETE"` (remove)
+- `ListOptions(filter_names?: List[str], filter_labels?: List[Label], page?: int, page_size?: int, page_count?: bool, entity_count?: bool)` - Filtering and pagination for list operations; `filter_labels` uses an OData `Label HAS` expression
 - `PagedResult[T](items: list[T], pagination?: PaginationInfo)` - Contains results and optional pagination metadata
 - `PaginationInfo(next_cursor?: str, total_count?: int)` - Pagination metadata from response headers
 
@@ -423,14 +449,87 @@ This ensures only valid headers are used with transparent proxy destinations.
   - `get_subaccount_destination()` - V1 API for subaccount-level destinations with access strategies
   - `get_destination()` - V2 API for runtime consumption with automatic token retrieval
 
+## Label Management
+
+Labels are key-value metadata tags that can be attached to destinations, fragments, and certificates. They enable filtering resources by label values using `ListOptions.filter_labels`.
+
+### Models
+
+- `Label(key: str, values: List[str])` — a label with one or more string values (e.g., `Label(key="env", values=["prod", "eu"])`)
+- `PatchLabels(action: str, labels: List[Label])` — incremental update; `action="ADD"` upserts label values, `action="DELETE"` removes them
+
+### Operations
+
+Each client (DestinationClient, FragmentClient, CertificateClient) exposes three label methods:
+
+| Method                                         | HTTP  | Description                     |
+| ---------------------------------------------- | ----- | ------------------------------- |
+| `get_*_labels(name, level, tenant)`            | GET   | Returns current labels          |
+| `update_*_labels(name, labels, level, tenant)` | PUT   | Replaces all labels atomically  |
+| `patch_*_labels(name, patch, level, tenant)`   | PATCH | Adds or removes specific labels |
+
+All three accept an optional `tenant` parameter (like the create/update/delete methods) to scope the request to a subscriber context.
+
+### Examples
+
+```python
+from sap_cloud_sdk.destination import (
+    create_client, create_fragment_client, create_certificate_client,
+    Label, PatchLabels, ListOptions, Level
+)
+
+client = create_client(instance="default")
+fragment_client = create_fragment_client(instance="default")
+certificate_client = create_certificate_client(instance="default")
+
+# Get labels for a destination (provider context)
+labels = client.get_destination_labels("my-dest", level=Level.SUB_ACCOUNT)
+
+# Get labels in subscriber context
+labels = client.get_destination_labels("my-dest", level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+
+# Replace all labels (PUT)
+new_labels = [Label(key="env", values=["prod"]), Label(key="team", values=["platform"])]
+client.update_destination_labels("my-dest", new_labels, level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+
+# Add labels incrementally (PATCH ADD — upserts existing keys)
+client.patch_destination_labels(
+    "my-dest",
+    PatchLabels(action="ADD", labels=[Label(key="region", values=["eu"])]),
+    level=Level.SUB_ACCOUNT,
+    tenant="tenant-subdomain",
+)
+
+# Remove specific labels (PATCH DELETE)
+client.patch_destination_labels(
+    "my-dest",
+    PatchLabels(action="DELETE", labels=[Label(key="region", values=["eu"])]),
+    level=Level.SUB_ACCOUNT,
+)
+
+# Fragment and certificate label operations follow the same pattern
+fragment_client.update_fragment_labels("my-fragment", new_labels, level=Level.SUB_ACCOUNT, tenant="tenant-subdomain")
+certificate_client.patch_certificate_labels(
+    "my-cert.pem",
+    PatchLabels(action="ADD", labels=[Label(key="env", values=["staging"])]),
+    level=Level.SUB_ACCOUNT,
+)
+
+# Filter list results by label
+from sap_cloud_sdk.destination import ListOptions
+filter_opts = ListOptions(filter_labels=[Label(key="env", values=["prod"])])
+result = client.list_subaccount_destinations(filter=filter_opts)
+fragments = fragment_client.list_instance_fragments(filter=filter_opts)
+```
+
 ## Local Development Mode
 
 When a `mocks/<resource>.json` file is present at the repository root, the factory functions automatically return a local in-memory client backed by that file instead of connecting to the SAP BTP Destination Service. No credentials or network access are required.
 
-| Factory | Mock file |
-|---|---|
-| `create_client()` | `mocks/destination.json` |
-| `create_fragment_client()` | `mocks/fragments.json` |
+| Factory                       | Mock file                 |
+| ----------------------------- | ------------------------- |
+| `create_client()`             | `mocks/destination.json`  |
+| `create_fragment_client()`    | `mocks/fragments.json`    |
 | `create_certificate_client()` | `mocks/certificates.json` |
 
 > **WARNING: Local mode is for local development only.**

--- a/tests/destination/unit/test_certificate_client.py
+++ b/tests/destination/unit/test_certificate_client.py
@@ -984,7 +984,7 @@ class TestCertificateClientLabels:
 
         assert len(labels) == 1
         assert labels[0].key == "env"
-        mock_http.get.assert_called_once_with("v1/instanceCertificates/cert1/labels")
+        mock_http.get.assert_called_once_with("v1/instanceCertificates/cert1/labels", tenant_subdomain=None)
 
     def test_get_certificate_labels_subaccount(self, certificate_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -994,7 +994,7 @@ class TestCertificateClientLabels:
         labels = certificate_client.get_certificate_labels("cert1", Level.SUB_ACCOUNT)
 
         assert labels[0].key == "team"
-        mock_http.get.assert_called_once_with("v1/subaccountCertificates/cert1/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountCertificates/cert1/labels", tenant_subdomain=None)
 
     def test_get_certificate_labels_default_level_is_subaccount(self, certificate_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -1003,7 +1003,7 @@ class TestCertificateClientLabels:
 
         certificate_client.get_certificate_labels("cert1")
 
-        mock_http.get.assert_called_once_with("v1/subaccountCertificates/cert1/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountCertificates/cert1/labels", tenant_subdomain=None)
 
     def test_get_certificate_labels_non_list_response_raises(self, certificate_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -1027,6 +1027,7 @@ class TestCertificateClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/instanceCertificates/cert1/labels",
             body=[{"key": "env", "values": ["prod"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_certificate_labels_subaccount(self, certificate_client, mock_http):
@@ -1037,6 +1038,7 @@ class TestCertificateClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/subaccountCertificates/cert1/labels",
             body=[{"key": "env", "values": ["staging"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_certificate_labels_http_error_propagates(self, certificate_client, mock_http):
@@ -1053,6 +1055,7 @@ class TestCertificateClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/instanceCertificates/cert1/labels",
             body={"action": "ADD", "labels": [{"key": "env", "values": ["prod"]}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_certificate_labels_subaccount(self, certificate_client, mock_http):
@@ -1063,6 +1066,7 @@ class TestCertificateClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/subaccountCertificates/cert1/labels",
             body={"action": "DELETE", "labels": [{"key": "env", "values": []}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_certificate_labels_http_error_propagates(self, certificate_client, mock_http):
@@ -1070,3 +1074,43 @@ class TestCertificateClientLabels:
 
         with pytest.raises(HttpError):
             certificate_client.patch_certificate_labels("cert1", PatchLabels(action="ADD", labels=[]), Level.SUB_ACCOUNT)
+
+    def test_get_certificate_labels_with_tenant(self, certificate_client, mock_http):
+        mock_http.get.return_value.json.return_value = []
+
+        certificate_client.get_certificate_labels("cert1", tenant="test-tenant")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_get_certificate_labels_without_tenant_uses_provider_context(self, certificate_client, mock_http):
+        mock_http.get.return_value.json.return_value = []
+
+        certificate_client.get_certificate_labels("cert1")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_update_certificate_labels_with_tenant(self, certificate_client, mock_http):
+        certificate_client.update_certificate_labels("cert1", [], tenant="test-tenant")
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_update_certificate_labels_without_tenant_uses_provider_context(self, certificate_client, mock_http):
+        certificate_client.update_certificate_labels("cert1", [])
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_patch_certificate_labels_with_tenant(self, certificate_client, mock_http):
+        certificate_client.patch_certificate_labels("cert1", PatchLabels(action="ADD", labels=[]), tenant="test-tenant")
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_patch_certificate_labels_without_tenant_uses_provider_context(self, certificate_client, mock_http):
+        certificate_client.patch_certificate_labels("cert1", PatchLabels(action="ADD", labels=[]))
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] is None

--- a/tests/destination/unit/test_client.py
+++ b/tests/destination/unit/test_client.py
@@ -1871,7 +1871,7 @@ class TestDestinationClientLabels:
 
         assert len(labels) == 1
         assert labels[0].key == "env"
-        mock_http.get.assert_called_once_with("v1/instanceDestinations/destA/labels")
+        mock_http.get.assert_called_once_with("v1/instanceDestinations/destA/labels", tenant_subdomain=None)
 
     def test_get_destination_labels_subaccount(self):
         mock_http = MagicMock()
@@ -1881,7 +1881,7 @@ class TestDestinationClientLabels:
         labels = client.get_destination_labels("destA", Level.SUB_ACCOUNT)
 
         assert labels[0].key == "team"
-        mock_http.get.assert_called_once_with("v1/subaccountDestinations/destA/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountDestinations/destA/labels", tenant_subdomain=None)
 
     def test_get_destination_labels_default_level_is_subaccount(self):
         mock_http = MagicMock()
@@ -1890,7 +1890,7 @@ class TestDestinationClientLabels:
 
         client.get_destination_labels("destA")
 
-        mock_http.get.assert_called_once_with("v1/subaccountDestinations/destA/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountDestinations/destA/labels", tenant_subdomain=None)
 
     def test_get_destination_labels_non_list_response_raises(self):
         mock_http = MagicMock()
@@ -1918,6 +1918,7 @@ class TestDestinationClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/instanceDestinations/destA/labels",
             body=[{"key": "env", "values": ["prod"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_destination_labels_subaccount(self):
@@ -1930,6 +1931,7 @@ class TestDestinationClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/subaccountDestinations/destA/labels",
             body=[{"key": "env", "values": ["staging"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_destination_labels_http_error_propagates(self):
@@ -1950,6 +1952,7 @@ class TestDestinationClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/instanceDestinations/destA/labels",
             body={"action": "ADD", "labels": [{"key": "env", "values": ["prod"]}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_destination_labels_subaccount(self):
@@ -1962,6 +1965,7 @@ class TestDestinationClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/subaccountDestinations/destA/labels",
             body={"action": "DELETE", "labels": [{"key": "env", "values": []}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_destination_labels_http_error_propagates(self):
@@ -1971,3 +1975,59 @@ class TestDestinationClientLabels:
 
         with pytest.raises(HttpError):
             client.patch_destination_labels("destA", PatchLabels(action="ADD", labels=[]), Level.SUB_ACCOUNT)
+
+    def test_get_destination_labels_with_tenant(self):
+        mock_http = MagicMock()
+        mock_http.get.return_value.json.return_value = []
+        client = DestinationClient(mock_http)
+
+        client.get_destination_labels("destA", tenant="test-tenant")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_get_destination_labels_without_tenant_uses_provider_context(self):
+        mock_http = MagicMock()
+        mock_http.get.return_value.json.return_value = []
+        client = DestinationClient(mock_http)
+
+        client.get_destination_labels("destA")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_update_destination_labels_with_tenant(self):
+        mock_http = MagicMock()
+        client = DestinationClient(mock_http)
+
+        client.update_destination_labels("destA", [], tenant="test-tenant")
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_update_destination_labels_without_tenant_uses_provider_context(self):
+        mock_http = MagicMock()
+        client = DestinationClient(mock_http)
+
+        client.update_destination_labels("destA", [])
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_patch_destination_labels_with_tenant(self):
+        mock_http = MagicMock()
+        client = DestinationClient(mock_http)
+
+        client.patch_destination_labels("destA", PatchLabels(action="ADD", labels=[]), tenant="test-tenant")
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_patch_destination_labels_without_tenant_uses_provider_context(self):
+        mock_http = MagicMock()
+        client = DestinationClient(mock_http)
+
+        client.patch_destination_labels("destA", PatchLabels(action="ADD", labels=[]))
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] is None

--- a/tests/destination/unit/test_fragment_client.py
+++ b/tests/destination/unit/test_fragment_client.py
@@ -830,7 +830,7 @@ class TestFragmentClientLabels:
         assert len(labels) == 1
         assert labels[0].key == "env"
         assert labels[0].values == ["prod"]
-        mock_http.get.assert_called_once_with("v1/instanceDestinationFragments/fragA/labels")
+        mock_http.get.assert_called_once_with("v1/instanceDestinationFragments/fragA/labels", tenant_subdomain=None)
 
     def test_get_fragment_labels_subaccount(self, fragment_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -840,7 +840,7 @@ class TestFragmentClientLabels:
         labels = fragment_client.get_fragment_labels("fragA", Level.SUB_ACCOUNT)
 
         assert labels[0].key == "team"
-        mock_http.get.assert_called_once_with("v1/subaccountDestinationFragments/fragA/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountDestinationFragments/fragA/labels", tenant_subdomain=None)
 
     def test_get_fragment_labels_default_level_is_subaccount(self, fragment_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -849,7 +849,7 @@ class TestFragmentClientLabels:
 
         fragment_client.get_fragment_labels("fragA")
 
-        mock_http.get.assert_called_once_with("v1/subaccountDestinationFragments/fragA/labels")
+        mock_http.get.assert_called_once_with("v1/subaccountDestinationFragments/fragA/labels", tenant_subdomain=None)
 
     def test_get_fragment_labels_non_list_response_raises(self, fragment_client, mock_http):
         mock_response = Mock(spec=Response)
@@ -873,6 +873,7 @@ class TestFragmentClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/instanceDestinationFragments/fragA/labels",
             body=[{"key": "env", "values": ["prod"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_fragment_labels_subaccount(self, fragment_client, mock_http):
@@ -883,6 +884,7 @@ class TestFragmentClientLabels:
         mock_http.put.assert_called_once_with(
             "v1/subaccountDestinationFragments/fragA/labels",
             body=[{"key": "env", "values": ["staging"]}],
+            tenant_subdomain=None,
         )
 
     def test_update_fragment_labels_http_error_propagates(self, fragment_client, mock_http):
@@ -899,6 +901,7 @@ class TestFragmentClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/instanceDestinationFragments/fragA/labels",
             body={"action": "ADD", "labels": [{"key": "env", "values": ["prod"]}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_fragment_labels_subaccount(self, fragment_client, mock_http):
@@ -909,6 +912,7 @@ class TestFragmentClientLabels:
         mock_http.patch.assert_called_once_with(
             "v1/subaccountDestinationFragments/fragA/labels",
             body={"action": "DELETE", "labels": [{"key": "env", "values": []}]},
+            tenant_subdomain=None,
         )
 
     def test_patch_fragment_labels_http_error_propagates(self, fragment_client, mock_http):
@@ -916,3 +920,43 @@ class TestFragmentClientLabels:
 
         with pytest.raises(HttpError):
             fragment_client.patch_fragment_labels("fragA", PatchLabels(action="ADD", labels=[]), Level.SUB_ACCOUNT)
+
+    def test_get_fragment_labels_with_tenant(self, fragment_client, mock_http):
+        mock_http.get.return_value.json.return_value = []
+
+        fragment_client.get_fragment_labels("fragA", tenant="test-tenant")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_get_fragment_labels_without_tenant_uses_provider_context(self, fragment_client, mock_http):
+        mock_http.get.return_value.json.return_value = []
+
+        fragment_client.get_fragment_labels("fragA")
+
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_update_fragment_labels_with_tenant(self, fragment_client, mock_http):
+        fragment_client.update_fragment_labels("fragA", [], tenant="test-tenant")
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_update_fragment_labels_without_tenant_uses_provider_context(self, fragment_client, mock_http):
+        fragment_client.update_fragment_labels("fragA", [])
+
+        _, kwargs = mock_http.put.call_args
+        assert kwargs["tenant_subdomain"] is None
+
+    def test_patch_fragment_labels_with_tenant(self, fragment_client, mock_http):
+        fragment_client.patch_fragment_labels("fragA", PatchLabels(action="ADD", labels=[]), tenant="test-tenant")
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] == "test-tenant"
+
+    def test_patch_fragment_labels_without_tenant_uses_provider_context(self, fragment_client, mock_http):
+        fragment_client.patch_fragment_labels("fragA", PatchLabels(action="ADD", labels=[]))
+
+        _, kwargs = mock_http.patch.call_args
+        assert kwargs["tenant_subdomain"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.1"
+version = "0.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },

--- a/uv.lock
+++ b/uv.lock
@@ -2598,7 +2598,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.0"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

Add `tenant: Optional[str] = None` parameter to all 9 label management methods across `DestinationClient`, `FragmentClient`, and `CertificateClient` — bringing them in line with the existing `create_*`, `update_*`, and `delete_*` methods which already support tenant context.

Also updates the user guide to document label management (introduced in v0.9.0 but never documented), fix the `ListOptions` model description, and correct the `FragmentClient` list method signatures to include the `filter` parameter.

## Related Issue

N/A

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## How to Test

1. Run the destination unit tests: `uv run python -m pytest tests/destination/unit/ -q`
2. All 630 tests should pass, including 18 new tenant tests for label operations

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. The `tenant` parameter is optional with a `None` default, making this fully backwards-compatible.
