### PR TITLE
fix(telemetry): propagate invoke_agent identity via OTEL Baggage (#55)

### DIFF
--- a/scripts/verify_invoke_agent_jaeger_integration.py
+++ b/scripts/verify_invoke_agent_jaeger_integration.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+End-to-end check: OTLP export to Jaeger UI with propagate=True vs propagate=False.
+
+Requires Jaeger all-in-one with OTLP gRPC on localhost:4317 and UI on localhost:16686, e.g.:
+
+    docker compose -f cluster-observability-verification/local-otel-jaeger-test/docker-compose.yml up -d
+
+Then from cloud-sdk-python repo root:
+
+    PYTHONPATH=src python scripts/verify_invoke_agent_jaeger_integration.py
+
+Each OTLP/Jaeger scenario runs in a **fresh Python subprocess** so TracerProvider can initialize
+(OpenTelemetry forbids overriding the provider in-process).
+
+Exit code 0 only if both scenarios pass Jaeger assertions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+# Imports below are only needed in worker process (lazy in _worker_main)
+DEFAULT_OTLP = "http://localhost:4317"
+DEFAULT_UI = "http://localhost:16686"
+
+
+def _grpc_host_port(endpoint: str) -> str:
+    u = endpoint.strip()
+    if u.startswith("http://"):
+        u = u[7:]
+    elif u.startswith("https://"):
+        u = u[8:]
+    return u.split("/")[0]
+
+
+def _tags_dict(span: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for t in span.get("tags") or []:
+        key = t.get("key")
+        if key:
+            out[key] = t.get("value")
+    return out
+
+
+def _fetch_trace_for_service(ui_base: str, service: str, timeout_sec: float = 45.0) -> Optional[dict]:
+    q = urllib.parse.urlencode({"service": service, "limit": "5"})
+    url = f"{ui_base.rstrip('/')}/api/traces?{q}"
+    deadline = time.monotonic() + timeout_sec
+    last_err: Optional[Exception] = None
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(url, headers={"Accept": "application/json"})
+            with urllib.request.urlopen(req, timeout=5.0) as resp:
+                data = json.loads(resp.read().decode())
+            traces = data.get("data") or []
+            if traces:
+                return traces[0]
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError) as e:
+            last_err = e
+        time.sleep(0.8)
+    if last_err:
+        print(f"WARN: Jaeger poll error: {last_err}", file=sys.stderr)
+    return None
+
+
+def _worker_main() -> int:
+    """Single-process OTLP emit + Jaeger assert (import OTEL only here)."""
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.trace import SpanKind
+
+    from sap_cloud_sdk.core.telemetry.tracer import invoke_agent_span
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--worker", action="store_true")
+    p.add_argument("--propagate", type=lambda x: x.lower() == "true", required=True)
+    p.add_argument("--run-id", required=True)
+    p.add_argument("--otlp-endpoint", default=DEFAULT_OTLP)
+    p.add_argument("--jaeger-ui", default=DEFAULT_UI)
+    p.add_argument("--agent-name", default="currency-agent-local")
+    p.add_argument("--agent-id", default="f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde")
+    args = p.parse_args()
+
+    propagate = args.propagate
+    svc = f"sdk-prop-{'true' if propagate else 'false'}-{args.run_id}"
+
+    resource = Resource.create({"service.name": svc})
+    exporter = OTLPSpanExporter(endpoint=_grpc_host_port(args.otlp_endpoint), insecure=True)
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    external = trace.get_tracer("langchain")
+
+    with invoke_agent_span(
+        provider="sap",
+        agent_name=args.agent_name,
+        agent_id=args.agent_id,
+        kind=SpanKind.INTERNAL,
+        propagate=propagate,
+    ):
+        with external.start_as_current_span("invoke_agent"):
+            pass
+
+    provider.shutdown()
+
+    trace_data = _fetch_trace_for_service(args.jaeger_ui, svc)
+    if not trace_data:
+        print(
+            f"FAIL: No trace in Jaeger for service={svc!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    inner: Optional[dict] = None
+    for sp in trace_data.get("spans", []):
+        if sp.get("operationName") == "invoke_agent":
+            inner = sp
+            break
+    if not inner:
+        print(f"FAIL: No span invoke_agent in trace for {svc}", file=sys.stderr)
+        return 1
+
+    tags = _tags_dict(inner)
+    name_tag = tags.get("gen_ai.agent.name")
+    id_tag = tags.get("gen_ai.agent.id")
+
+    if propagate:
+        if name_tag != args.agent_name or id_tag != args.agent_id:
+            print(
+                f"FAIL propagate=True: expected name={args.agent_name!r} id={args.agent_id!r}; "
+                f"got name={name_tag!r} id={id_tag!r} tags={tags}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"PASS propagate=True: Jaeger shows gen_ai.agent.* on nested span ({svc})", flush=True)
+        return 0
+
+    if name_tag is not None or id_tag is not None:
+        print(
+            f"FAIL propagate=False: expected no gen_ai.agent.* on nested span; "
+            f"got name={name_tag!r} id={id_tag!r}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"PASS propagate=False: nested span has no gen_ai.agent.* ({svc})", flush=True)
+    return 0
+
+
+def orchestrator_main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--otlp-endpoint", default=DEFAULT_OTLP)
+    parser.add_argument("--jaeger-ui", default=DEFAULT_UI)
+    parser.add_argument("--agent-name", default="currency-agent-local")
+    parser.add_argument("--agent-id", default="f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde")
+    args = parser.parse_args()
+
+    run_id = str(int(time.time() * 1000) % 10_000_000)
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parents[1]
+
+    py = sys.executable
+    env = os.environ.copy()
+    src = str(repo_root / "src")
+    env["PYTHONPATH"] = env.get("PYTHONPATH", "") + os.pathsep + src if env.get("PYTHONPATH") else src
+
+    print(
+        f"Jaeger UI: {args.jaeger_ui} | OTLP: {args.otlp_endpoint}\n"
+        "Ensure Jaeger all-in-one is running (OTLP :4317, UI :16686).\n",
+        flush=True,
+    )
+
+    base_cmd = [
+        py,
+        str(script_path),
+        "--worker",
+        "--run-id",
+        run_id,
+        "--otlp-endpoint",
+        args.otlp_endpoint,
+        "--jaeger-ui",
+        args.jaeger_ui,
+        "--agent-name",
+        args.agent_name,
+        "--agent-id",
+        args.agent_id,
+    ]
+
+    for propagate, label in ((False, "disabled (propagate=False)"), (True, "enabled (propagate=True)")):
+        cmd = base_cmd + ["--propagate", str(propagate).lower()]
+        print(f"\n=== {label} ===", flush=True)
+        r = subprocess.run(cmd, env=env, cwd=str(repo_root))
+        if r.returncode != 0:
+            print(
+                "\nTip: start Jaeger:\n"
+                "  docker compose -f "
+                "<repo>/generic/cluster-observability-verification/"
+                "local-otel-jaeger-test/docker-compose.yml up -d\n",
+                file=sys.stderr,
+            )
+            return r.returncode
+
+    print("\nAll Jaeger integration checks passed.", flush=True)
+    return 0
+
+
+def main() -> int:
+    if "--worker" in sys.argv:
+        return _worker_main()
+    return orchestrator_main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sap_cloud_sdk/core/telemetry/tracer.py
+++ b/src/sap_cloud_sdk/core/telemetry/tracer.py
@@ -9,6 +9,8 @@ by auto_instrument().
 from contextlib import contextmanager, nullcontext
 from typing import Optional, Dict, Any
 
+from opentelemetry import baggage as otel_baggage
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode, Span
 
@@ -44,6 +46,32 @@ def _propagate_attributes(attrs: Dict[str, Any]):
         yield
     finally:
         _propagated_attrs_var.reset(token)
+
+
+@contextmanager
+def _otel_baggage_for_invoke_agent(span_attrs: Dict[str, Any]):
+    """Mirror gen_ai.agent.* identity into W3C Baggage for the duration of the context.
+
+    Third-party instrumentations (e.g. LangGraph / Traceloop) create spans without merging
+    :func:`get_propagated_attributes`. :class:`~opentelemetry.processor.baggage.BaggageSpanProcessor`
+    (registered by :func:`sap_cloud_sdk.core.telemetry.auto_instrument.auto_instrument`) copies
+    baggage onto every started span, so agent id/name stay consistent on those spans.
+    """
+    keys = (
+        _ATTR_GEN_AI_AGENT_NAME,
+        _ATTR_GEN_AI_AGENT_ID,
+        _ATTR_GEN_AI_AGENT_DESCRIPTION,
+    )
+    ctx = otel_context.get_current()
+    for key in keys:
+        val = span_attrs.get(key)
+        if val is not None:
+            ctx = otel_baggage.set_baggage(key, str(val), ctx)
+    token = otel_context.attach(ctx)
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 
 @contextmanager
@@ -280,7 +308,10 @@ def invoke_agent_span(
         kind: Span kind; CLIENT for remote agents, INTERNAL for in-process.
         attributes: Optional dict of extra attributes to add or override on the span.
         propagate: If True, this span's attributes are passed to all nested spans
-                   within its scope as the lowest-priority layer.
+                   within its scope as the lowest-priority layer. Additionally,
+                   ``gen_ai.agent.{name,id,description}`` are attached as OpenTelemetry
+                   **Baggage** so spans created by external instrumentations still receive
+                   those attributes when BaggageSpanProcessor is active.
 
     Yields:
         The created Span (e.g. to set usage, response attributes).
@@ -324,19 +355,23 @@ def invoke_agent_span(
     propagated = get_propagated_attributes()
     span_attrs = {**propagated, **(attributes or {}), **base_attrs}
 
-    ctx = _propagate_attributes(span_attrs) if propagate else nullcontext()
-    with ctx:
-        with tracer.start_as_current_span(
-            span_name,
-            kind=kind,
-            attributes=span_attrs,
-        ) as span:
-            try:
-                yield span
-            except Exception as e:
-                span.set_status(Status(StatusCode.ERROR, str(e)))
-                span.record_exception(e)
-                raise
+    ctx_prop = _propagate_attributes(span_attrs) if propagate else nullcontext()
+    ctx_baggage = (
+        _otel_baggage_for_invoke_agent(span_attrs) if propagate else nullcontext()
+    )
+    with ctx_prop:
+        with ctx_baggage:
+            with tracer.start_as_current_span(
+                span_name,
+                kind=kind,
+                attributes=span_attrs,
+            ) as span:
+                try:
+                    yield span
+                except Exception as e:
+                    span.set_status(Status(StatusCode.ERROR, str(e)))
+                    span.record_exception(e)
+                    raise
 
 
 def get_current_span() -> Span:

--- a/tests/core/unit/telemetry/test_tracer.py
+++ b/tests/core/unit/telemetry/test_tracer.py
@@ -895,6 +895,30 @@ class TestInvokeAgentSpan:
             f"stderr={result.stderr}\nstdout={result.stdout}"
         )
 
+    def test_invoke_agent_propagate_false_skips_baggage_for_external_tracer_span_subprocess(
+        self,
+    ):
+        """Baggage mirroring for agent identity runs only when propagate=True."""
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[4]
+        script = root / "tests/core/unit/telemetry/verify_invoke_agent_baggage.py"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(root / "src")
+        result = subprocess.run(
+            [sys.executable, str(script), "--propagate-false"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr}\nstdout={result.stdout}"
+        )
+
 
 class TestPropagate:
     """Test suite for propagate=True attribute propagation across nested spans."""

--- a/tests/core/unit/telemetry/test_tracer.py
+++ b/tests/core/unit/telemetry/test_tracer.py
@@ -873,6 +873,28 @@ class TestInvokeAgentSpan:
 
         mock_span.add_event.assert_called_once_with("agent_step")
 
+    def test_invoke_agent_propagate_baggage_applies_to_external_tracer_span_subprocess(self):
+        """Regression SAP/cloud-sdk-python#55: third-party spans get gen_ai.agent.* via Baggage."""
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[4]
+        script = root / "tests/core/unit/telemetry/verify_invoke_agent_baggage.py"
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(root / "src")
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, (
+            f"stderr={result.stderr}\nstdout={result.stdout}"
+        )
+
 
 class TestPropagate:
     """Test suite for propagate=True attribute propagation across nested spans."""

--- a/tests/core/unit/telemetry/verify_invoke_agent_baggage.py
+++ b/tests/core/unit/telemetry/verify_invoke_agent_baggage.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Subprocess helper: invoke_agent_span(propagate=True) + BaggageSpanProcessor + external tracer.
+
+Run from repo root with PYTHONPATH=src (see test_tracer.py).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# src layout
+_ROOT = Path(__file__).resolve().parents[4]
+_SRC = _ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from opentelemetry import trace
+from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+from sap_cloud_sdk.core.telemetry.tracer import invoke_agent_span
+
+
+def main() -> int:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    external_tracer = trace.get_tracer("third_party_simulating_langgraph")
+
+    with invoke_agent_span(
+        provider="openai",
+        agent_name="currency-agent-local",
+        agent_id="f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde",
+        kind=SpanKind.INTERNAL,
+        propagate=True,
+    ):
+        with external_tracer.start_as_current_span("invoke_agent"):
+            pass
+
+    spans = {s.name: dict(s.attributes or {}) for s in exporter.get_finished_spans()}
+    inner = spans.get("invoke_agent")
+    if not inner:
+        print("FAIL: no inner invoke_agent span", spans, file=sys.stderr)
+        return 1
+    if inner.get("gen_ai.agent.name") != "currency-agent-local":
+        print("FAIL: gen_ai.agent.name", inner, file=sys.stderr)
+        return 1
+    if inner.get("gen_ai.agent.id") != "f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde":
+        print("FAIL: gen_ai.agent.id", inner, file=sys.stderr)
+        return 1
+    print("OK: external child span carries gen_ai.agent.name and gen_ai.agent.id via baggage")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/core/unit/telemetry/verify_invoke_agent_baggage.py
+++ b/tests/core/unit/telemetry/verify_invoke_agent_baggage.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
-"""Subprocess helper: invoke_agent_span(propagate=True) + BaggageSpanProcessor + external tracer.
+"""Subprocess helper: Baggage propagation on invoke_agent_span + external tracer.
 
 Run from repo root with PYTHONPATH=src (see test_tracer.py).
+
+Modes:
+  default           — propagate=True expects gen_ai.agent.* on nested span
+  --propagate-false — propagate=False expects nested span WITHOUT those attrs from Baggage
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -26,6 +31,15 @@ from sap_cloud_sdk.core.telemetry.tracer import invoke_agent_span
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--propagate-false",
+        action="store_true",
+        help="Verify Baggage is NOT applied to external span when propagate=False",
+    )
+    args = parser.parse_args()
+    propagate = not args.propagate_false
+
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
@@ -39,23 +53,38 @@ def main() -> int:
         agent_name="currency-agent-local",
         agent_id="f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde",
         kind=SpanKind.INTERNAL,
-        propagate=True,
+        propagate=propagate,
     ):
         with external_tracer.start_as_current_span("invoke_agent"):
             pass
 
     spans = {s.name: dict(s.attributes or {}) for s in exporter.get_finished_spans()}
-    inner = spans.get("invoke_agent")
-    if not inner:
+    if "invoke_agent" not in spans:
         print("FAIL: no inner invoke_agent span", spans, file=sys.stderr)
         return 1
-    if inner.get("gen_ai.agent.name") != "currency-agent-local":
-        print("FAIL: gen_ai.agent.name", inner, file=sys.stderr)
+    inner = spans["invoke_agent"]
+
+    if propagate:
+        if inner.get("gen_ai.agent.name") != "currency-agent-local":
+            print("FAIL: gen_ai.agent.name", inner, file=sys.stderr)
+            return 1
+        if inner.get("gen_ai.agent.id") != "f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde":
+            print("FAIL: gen_ai.agent.id", inner, file=sys.stderr)
+            return 1
+        print(
+            "OK: external child span carries gen_ai.agent.name and gen_ai.agent.id via baggage"
+        )
+        return 0
+
+    # propagate=False: SDK must not inject agent identity into Baggage for this scope
+    if inner.get("gen_ai.agent.name") is not None or inner.get("gen_ai.agent.id") is not None:
+        print(
+            "FAIL: propagate=False but nested span has gen_ai.agent.* (should not):",
+            inner,
+            file=sys.stderr,
+        )
         return 1
-    if inner.get("gen_ai.agent.id") != "f268d3fd-096f-4ebc-b7ed-6fc03dfb3dde":
-        print("FAIL: gen_ai.agent.id", inner, file=sys.stderr)
-        return 1
-    print("OK: external child span carries gen_ai.agent.name and gen_ai.agent.id via baggage")
+    print("OK: propagate=False — nested span has no gen_ai.agent.* from Baggage injection")
     return 0
 
 


### PR DESCRIPTION
## Description

When `invoke_agent_span(..., propagate=True)` is used, span attributes are merged into nested spans **only** for code paths that call `get_propagated_attributes()` (SDK helpers). Third-party instrumentations (e.g. LangGraph / Traceloop) create spans that never receive `gen_ai.agent.name` / `gen_ai.agent.id`, which breaks consistent GenAI semantic attributes (reported in #55).

This change mirrors `gen_ai.agent.{name,id,description}` into **W3C OpenTelemetry Baggage** for the duration of the `invoke_agent_span` context when `propagate=True`. The existing **`BaggageSpanProcessor`** registered by `auto_instrument()` then applies those entries to **every** started span in scope—including spans from external instrumentations.

## Related Issue

Closes #55

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. `uv sync --group dev` (or equivalent venv)
2. `pytest tests/core/unit/telemetry/test_tracer.py -q`
3. Optional subprocess check: `PYTHONPATH=src python tests/core/unit/telemetry/verify_invoke_agent_baggage.py` (expects `OK:`)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally (`tests/core/unit/telemetry/test_tracer.py`)
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable) — docstrings updated for `propagate` on `invoke_agent_span`
- [x] I have added type hints for all public APIs — no new public surface
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None.

## Additional Notes

**SAP internal / process:** Link related Jira ticket here when applicable (not available in this draft).

Requires **`auto_instrument()`** so `BaggageSpanProcessor` is registered; matches Kyma/agent runtime guidance.
