### PR TITLE
docs: improve installation snippets formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,22 @@ The Python SDK offers a clean, type-safe API following Python best practices whi
 
 ### Installation
 
-```python
-# uv
+
+#### uv
+
+```bash
 uv add sap-cloud-sdk
+```
 
-# Poetry
+#### Poetry
+
+```bash
 poetry add sap-cloud-sdk
+```
 
-# Pip
+#### pip
+
+```bash
 pip install sap-cloud-sdk
 ````
 


### PR DESCRIPTION
## Description

Split the installation code snippets in `README.md` into separate `bash` code blocks with individual subheadings (`#### uv`, `#### Poetry`, `#### pip`) to facilitate the use of copy-paste functionality on GitHub and improve readability.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Open `README.md` and navigate to the **Installation** section
2. Verify each package manager (`uv`, `Poetry`, `pip`) has its own subheading and `bash` code block
3. Confirm the rendered output on GitHub looks clean and readable

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

No functional or API changes — purely a documentation formatting improvement.