### PR TITLE
feat(telemetry): add mlflow.experiment_id and sap.solution_area resource attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.11.5"
+version = "0.11.6"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -15,6 +15,8 @@ from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_SAP_SDK_NAME,
     ATTR_SAP_SDK_LANGUAGE,
     ATTR_SAP_SDK_VERSION,
+    ATTR_SAP_SOLUTION_AREA,
+    ATTR_MLFLOW_EXPERIMENT_ID,
     SDK_NAME,
 )
 
@@ -29,6 +31,8 @@ ENV_APP_NAME = "APPFND_CONHOS_APP_NAME"
 ENV_OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME"
 ENV_HOSTNAME = "HOSTNAME"
 ENV_SYSTEM_ROLE = "APPFND_CONHOS_SYSTEM_ROLE"
+ENV_SOLUTION_AREA = "SAP_SOLUTION_AREA"
+ENV_MLFLOW_EXPERIMENT_ID = "MLFLOW_EXPERIMENT_ID"
 
 # OTEL environment variable keys
 ENV_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
@@ -72,6 +76,28 @@ def _get_system_role() -> str:
     return os.getenv(ENV_SYSTEM_ROLE, DEFAULT_UNKNOWN)
 
 
+def _get_solution_area() -> str:
+    """Get SAP Solution Area code from environment or return default.
+
+    Returns:
+        Solution area from SAP_SOLUTION_AREA environment variable,
+        or "unknown" if not set.
+    """
+    return os.getenv(ENV_SOLUTION_AREA, DEFAULT_UNKNOWN)
+
+
+def _get_mlflow_experiment_id() -> Optional[str]:
+    """Get MLflow experiment ID from environment.
+
+    Returns:
+        Value of MLFLOW_EXPERIMENT_ID, or None if the env var is missing
+        or empty. No placeholder default is used so the attribute can be
+        omitted from the resource entirely when unset.
+    """
+    value = os.getenv(ENV_MLFLOW_EXPERIMENT_ID)
+    return value if value else None
+
+
 def create_resource_attributes_from_env() -> dict:
     """Create OpenTelemetry Resource with SDK attributes.
 
@@ -90,6 +116,8 @@ def create_resource_attributes_from_env() -> dict:
         - sap.cloud_sdk.name (constant: "SAP Cloud SDK for Python")
         - sap.cloud_sdk.language (constant: "python")
         - sap.cloud_sdk.version (from package version)
+        - sap.solution_area (from SAP_SOLUTION_AREA, defaults to "unknown")
+        - mlflow.experiment_id (from MLFLOW_EXPERIMENT_ID, omitted when unset or empty)
     """
 
     attributes = {
@@ -103,7 +131,12 @@ def create_resource_attributes_from_env() -> dict:
         ATTR_SAP_SDK_NAME: SDK_NAME,
         ATTR_SAP_SDK_LANGUAGE: "python",
         ATTR_SAP_SDK_VERSION: get_version(),
+        ATTR_SAP_SOLUTION_AREA: _get_solution_area(),
     }
+
+    mlflow_experiment_id = _get_mlflow_experiment_id()
+    if mlflow_experiment_id is not None:
+        attributes[ATTR_MLFLOW_EXPERIMENT_ID] = mlflow_experiment_id
 
     return attributes
 

--- a/src/sap_cloud_sdk/core/telemetry/constants.py
+++ b/src/sap_cloud_sdk/core/telemetry/constants.py
@@ -22,6 +22,10 @@ ATTR_SAP_SYSTEM_ROLE = "sap.cld.system_role"
 ATTR_SAP_SDK_NAME = "sap.cloud_sdk.name"
 ATTR_SAP_SDK_LANGUAGE = "sap.cloud_sdk.language"
 ATTR_SAP_SDK_VERSION = "sap.cloud_sdk.version"
+ATTR_SAP_SOLUTION_AREA = "sap.solution_area"
+
+# Attribute keys - MLflow
+ATTR_MLFLOW_EXPERIMENT_ID = "mlflow.experiment_id"
 
 # Attribute keys - SAP App Foundation specific
 ATTR_CAPABILITY = "sap.cloud_sdk.capability"

--- a/src/sap_cloud_sdk/core/telemetry/user-guide.md
+++ b/src/sap_cloud_sdk/core/telemetry/user-guide.md
@@ -233,3 +233,9 @@ auto_instrument(disable_batch=True)
 ```bash
 export APPFND_CONHOS_SYSTEM_ROLE="S4HC"
 ```
+
+### Solution area
+
+```bash
+export SAP_SOLUTION_AREA="AFND"
+```

--- a/tests/core/unit/telemetry/test_config.py
+++ b/tests/core/unit/telemetry/test_config.py
@@ -1,13 +1,16 @@
 """Tests for telemetry configuration."""
 
-import pytest
 from unittest.mock import patch
 
 from sap_cloud_sdk.core.telemetry.config import (
     InstrumentationConfig,
+    create_resource_attributes_from_env,
     get_config,
     set_config,
-    _config
+)
+from sap_cloud_sdk.core.telemetry.constants import (
+    ATTR_MLFLOW_EXPERIMENT_ID,
+    ATTR_SAP_SOLUTION_AREA,
 )
 
 
@@ -169,3 +172,64 @@ class TestGlobalConfig:
 
         assert get_config() is config2
         assert get_config() is not config1
+
+
+class TestCreateResourceAttributesFromEnv:
+    """Test suite for create_resource_attributes_from_env."""
+
+    def test_solution_area_defaults_to_unknown(self):
+        """sap.solution_area defaults to 'unknown' when env var is unset."""
+        with patch.dict('os.environ', {}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_SAP_SOLUTION_AREA] == "unknown"
+
+    def test_mlflow_experiment_id_omitted_when_unset(self):
+        """mlflow.experiment_id is omitted entirely when env var is unset.
+
+        We deliberately do not emit a placeholder value because that would
+        pollute MLflow and mislead downstream routing logic.
+        """
+        with patch.dict('os.environ', {}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert ATTR_MLFLOW_EXPERIMENT_ID not in attrs
+
+    def test_mlflow_experiment_id_omitted_when_empty(self):
+        """mlflow.experiment_id is omitted when env var is an empty string."""
+        with patch.dict('os.environ', {'MLFLOW_EXPERIMENT_ID': ''}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert ATTR_MLFLOW_EXPERIMENT_ID not in attrs
+
+    def test_solution_area_read_from_env(self):
+        """sap.solution_area resource attribute is read from SAP_SOLUTION_AREA."""
+        with patch.dict('os.environ', {'SAP_SOLUTION_AREA': 'HCM'}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_SAP_SOLUTION_AREA] == "HCM"
+
+    def test_mlflow_experiment_id_read_from_env(self):
+        """mlflow.experiment_id resource attribute is read from MLFLOW_EXPERIMENT_ID."""
+        with patch.dict('os.environ', {'MLFLOW_EXPERIMENT_ID': '42'}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_MLFLOW_EXPERIMENT_ID] == "42"
+
+    def test_both_new_attributes_read_together(self):
+        """Both new attributes are populated independently from their env vars."""
+        with patch.dict('os.environ', {
+            'SAP_SOLUTION_AREA': 'FIN',
+            'MLFLOW_EXPERIMENT_ID': 'exp-123',
+        }, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_SAP_SOLUTION_AREA] == "FIN"
+            assert attrs[ATTR_MLFLOW_EXPERIMENT_ID] == "exp-123"
+
+    def test_solution_area_key_always_present(self):
+        """sap.solution_area is always emitted (defaults to 'unknown')."""
+        with patch.dict('os.environ', {}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert "sap.solution_area" in attrs

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.4"
+version = "0.11.6"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Summary

Adds two new OpenTelemetry resource attributes so that downstream trace consumers can dynamically fan traces out to the correct Databricks data area and MLflow experiment:

- `sap.solution_area` — read from the `SAP_SOLUTION_AREA` env var. Defaults to `"unknown"` when unset (consistent with existing resource attributes such as `cloud.region`, `sap.cld.subaccount_id`).
- `mlflow.experiment_id` — read from the `MLFLOW_EXPERIMENT_ID` env var. **Omitted entirely** from the resource when the env var is missing or empty — a placeholder value would pollute MLflow and mislead the downstream routing logic.

### Why

SAP internal trace consumers (such as Octoroute routing traces to Databricks) need two pieces of metadata on every span/metric:

1. The **SAP Solution Area** code to route telemetry to the correct Databricks data area.
2. The **MLflow experiment ID** to route agent traces to the correct MLflow experiment per app-foundation agent.

Since these are static per-process configuration (not per-span), they are added as OpenTelemetry resource attributes rather than span attributes.

### How

Both attributes are wired inside `create_resource_attributes_from_env()`, the single source of truth already consumed by:

- `auto_instrument.py` → trace provider (primary consumer)
- `_provider.py` → metric provider
- `auditlog_ng/client.py` → audit log resource

So both attributes automatically flow into traces, metrics, and audit logs without any per-call changes.

## Changes

- `src/sap_cloud_sdk/core/telemetry/constants.py` — adds `ATTR_SAP_SOLUTION_AREA` (`"sap.solution_area"`) and `ATTR_MLFLOW_EXPERIMENT_ID` (`"mlflow.experiment_id"`).
- `src/sap_cloud_sdk/core/telemetry/config.py` — adds env-var keys `SAP_SOLUTION_AREA` / `MLFLOW_EXPERIMENT_ID`, helpers `_get_solution_area()` and `_get_mlflow_experiment_id()` (returns `Optional[str]`), and conditional wiring in `create_resource_attributes_from_env()`.
- `src/sap_cloud_sdk/core/telemetry/user-guide.md` — adds a concise "Solution area" subsection next to the existing "System role" subsection. `mlflow.experiment_id` is intentionally not documented publicly yet (internal use only; public docs will follow once the contract is finalized).
- `tests/core/unit/telemetry/test_config.py` — adds `TestCreateResourceAttributesFromEnv` with 7 tests covering: solution area defaulting, mlflow omission when unset, mlflow omission when empty string, env-var reads for both, combined reads, and key presence. Also cleans up two pre-existing unused imports in the same file that ruff was flagging (`pytest`, `_config`).
- `pyproject.toml` / `uv.lock` — bumps version `0.11.5 → 0.11.6`.

## Test plan

- [x] `uv run pytest tests/core/unit/telemetry/test_config.py` — 20/20 pass (7 new)
- [x] `uv run pytest tests/core/unit/telemetry/` — 214/214 pass (no regressions)
- [x] `uv run ruff check` on all modified files — clean (pre-existing ruff errors in other test files are unrelated)
- [x] `uv sync` — lockfile regenerated at `sap-cloud-sdk==0.11.6`
- [ ] Manual verification by a maintainer that the new attributes appear in exported trace/metric resource attributes when the env vars are set, and that `mlflow.experiment_id` is absent when its env var is unset.

Closes #78