### PR TITLE
fix(telemetry): merge resource attrs onto wrapper-installed TracerProvider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.11.6"
+version = "0.11.7"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/auto_instrument.py
+++ b/src/sap_cloud_sdk/core/telemetry/auto_instrument.py
@@ -1,25 +1,27 @@
 import logging
 import os
+from collections.abc import Mapping
 
+from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter as GRPCSpanExporter,
 )
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter as HTTPSpanExporter,
 )
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.processor.baggage import ALLOW_ALL_BAGGAGE_KEYS, BaggageSpanProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SpanExporter
 from traceloop.sdk import Traceloop
 
 from sap_cloud_sdk.core.telemetry import Module, Operation
 from sap_cloud_sdk.core.telemetry.config import (
-    create_resource_attributes_from_env,
-    _get_app_name,
     ENV_OTLP_ENDPOINT,
-    ENV_TRACES_EXPORTER,
     ENV_OTLP_PROTOCOL,
+    ENV_TRACES_EXPORTER,
+    _get_app_name,
+    create_resource_attributes_from_env,
 )
 from sap_cloud_sdk.core.telemetry.genai_attribute_transformer import (
     GenAIAttributeTransformer,
@@ -62,6 +64,8 @@ def auto_instrument(disable_batch: bool = False):
         disable_batch=disable_batch,
     )
 
+    _merge_resource_attrs_into_active_provider_if_wrapper_installed(resource)
+
     _set_baggage_processor()
 
     logger.info("Cloud auto instrumentation initialized successfully")
@@ -96,3 +100,33 @@ def _set_baggage_processor():
 
     provider.add_span_processor(BaggageSpanProcessor(ALLOW_ALL_BAGGAGE_KEYS))
     logger.info("Registered BaggageSpanProcessor for extension attribute propagation")
+
+
+def _merge_resource_attrs_into_active_provider_if_wrapper_installed(
+    sap_attrs: dict,
+) -> None:
+    """Merge sap-cloud-sdk resource attrs onto the active TracerProvider's
+    Resource when an OTel auto-instrumentation wrapper has pre-installed it.
+
+    Resource.merge direction puts ``sap_attrs`` on the right, so colliding
+    keys (e.g. ``service.name``) are won by the sap-cloud-sdk side (e.g. the
+    APPFND_CONHOS_APP_NAME-derived value beats the operator's
+    k8s-deployment-derived default).
+
+    Mutates ``provider._resource`` because OTel SDK exposes no public API
+    to swap a TracerProvider's Resource post-construction.
+    """
+    provider = trace.get_tracer_provider()
+    if not isinstance(provider, TracerProvider):
+        return
+    existing_attrs = getattr(provider.resource, "attributes", None)
+    if not isinstance(existing_attrs, Mapping):
+        return
+    if "telemetry.auto.version" not in existing_attrs:
+        return
+
+    provider._resource = provider.resource.merge(Resource.create(sap_attrs))
+    logger.info(
+        "Merged sap-cloud-sdk resource attrs onto wrapper-installed "
+        "TracerProvider (marker: telemetry.auto.version)"
+    )

--- a/tests/core/unit/telemetry/test_auto_instrument.py
+++ b/tests/core/unit/telemetry/test_auto_instrument.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import patch, MagicMock, create_autospec
 from contextlib import ExitStack
 
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
 
 from sap_cloud_sdk.core.telemetry.auto_instrument import auto_instrument
@@ -232,3 +233,85 @@ class TestAutoInstrument:
 
             mock_traceloop_components['baggage_processor'].assert_called_once()
             mock_traceloop_components['get_tracer_provider'].return_value.add_span_processor.assert_called_once_with(mock_processor_instance)
+
+    def test_auto_instrument_merges_resource_when_wrapper_installed(self, mock_traceloop_components):
+        """When an OTel auto-instrumentation wrapper (e.g. an OpenTelemetry-Operator
+        init-container injection) has pre-installed a TracerProvider whose Resource
+        carries the standard `telemetry.auto.version` marker, auto_instrument merges
+        sap-cloud-sdk attrs onto that provider's existing Resource — preserving the
+        operator-supplied attrs and adding our SAP enrichment on top."""
+        mock_traceloop_components['get_app_name'].return_value = 'cloud-sdk-app'
+        sap_attrs = {
+            'service.name': 'cloud-sdk-app',
+            'sap.cloud_sdk.name': 'SAP Cloud SDK for Python',
+            'sap.cloud_sdk.language': 'python',
+            'sap.solution_area': 'fina',
+            'mlflow.experiment_id': '1635264705567712',
+        }
+        mock_traceloop_components['create_resource'].return_value = sap_attrs
+
+        wrapper_provider = SDKTracerProvider(
+            resource=Resource.create({
+                'telemetry.auto.version': '0.62b1',
+                'k8s.deployment.name': 'cloud-sdk-app-deployment',
+                'service.name': 'cloud-sdk-app-deployment',
+            })
+        )
+        mock_traceloop_components['get_tracer_provider'].return_value = wrapper_provider
+
+        with patch.dict('os.environ', {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317'}, clear=True):
+            auto_instrument()
+
+            merged_attrs = wrapper_provider.resource.attributes
+            # Operator-supplied attrs are preserved.
+            assert merged_attrs['telemetry.auto.version'] == '0.62b1'
+            assert merged_attrs['k8s.deployment.name'] == 'cloud-sdk-app-deployment'
+            # sap-cloud-sdk attrs are added.
+            assert merged_attrs['sap.cloud_sdk.name'] == 'SAP Cloud SDK for Python'
+            assert merged_attrs['sap.cloud_sdk.language'] == 'python'
+            assert merged_attrs['sap.solution_area'] == 'fina'
+            assert merged_attrs['mlflow.experiment_id'] == '1635264705567712'
+
+    def test_auto_instrument_skips_merge_when_no_wrapper_marker(self, mock_traceloop_components):
+        """When the active TracerProvider's Resource lacks the
+        `telemetry.auto.version` marker (e.g. a self-installed provider, or no
+        wrapper at all), auto_instrument does not mutate the provider's Resource."""
+        mock_traceloop_components['get_app_name'].return_value = 'cloud-sdk-app'
+        mock_traceloop_components['create_resource'].return_value = {
+            'sap.cloud_sdk.name': 'SAP Cloud SDK for Python',
+            'sap.solution_area': 'fina',
+        }
+
+        initial_resource = Resource.create({'service.name': 'self-installed'})
+        plain_provider = SDKTracerProvider(resource=initial_resource)
+        mock_traceloop_components['get_tracer_provider'].return_value = plain_provider
+
+        with patch.dict('os.environ', {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317'}, clear=True):
+            auto_instrument()
+
+            # Resource is the original instance — no merge took place.
+            assert plain_provider.resource is initial_resource
+            assert 'sap.cloud_sdk.name' not in plain_provider.resource.attributes
+            assert 'sap.solution_area' not in plain_provider.resource.attributes
+
+    def test_auto_instrument_merge_overrides_colliding_service_name(self, mock_traceloop_components):
+        """On a wrapper-installed provider, sap-cloud-sdk attrs override colliding
+        keys: service.name from APPFND_CONHOS_APP_NAME wins over the operator's
+        k8s-deployment-derived service.name."""
+        mock_traceloop_components['get_app_name'].return_value = 'cloud-sdk-app'
+        mock_traceloop_components['create_resource'].return_value = {
+            'service.name': 'cloud-sdk-app',
+        }
+
+        wrapper_provider = SDKTracerProvider(
+            resource=Resource.create({
+                'telemetry.auto.version': '0.62b1',
+                'service.name': 'operator-supplied-name',
+            })
+        )
+        mock_traceloop_components['get_tracer_provider'].return_value = wrapper_provider
+
+        with patch.dict('os.environ', {'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317'}, clear=True):
+            auto_instrument()
+
+            assert wrapper_provider.resource.attributes['service.name'] == 'cloud-sdk-app'

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.6"
+version = "0.11.7"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

When `auto_instrument()` runs on a Python process whose OTel `TracerProvider` was already installed by an upstream auto-instrumentation wrapper (e.g. an [OpenTelemetry-Operator](https://github.com/open-telemetry/opentelemetry-operator)-injected init-container, common on managed-Kubernetes runtimes — [SAP App Foundation's runtime is one such environment](https://jira.tools.sap/browse/AFSDK-2840), see *App Foundation runtime trigger path* below for the trigger path), [`Traceloop.init`'s `set_tracer_provider` call](https://github.com/SAP/cloud-sdk-python/blob/main/src/sap_cloud_sdk/core/telemetry/auto_instrument.py#L57-L63) silently no-ops because OTel's `_TRACER_PROVIDER_SET_ONCE` guard is already tripped (first set wins, no `override` parameter exists upstream). The resource attrs we pass to `Traceloop.init` never reach the globally active provider, so `sap.cloud_sdk.*`, `sap.solution_area`, `mlflow.experiment_id`, `sap.cld.*`, `deployment.environment.name`, and `cloud.region` are missing from emitted spans.

This PR adds a `_merge_resource_attrs_into_active_provider_if_wrapper_installed(...)` helper called from `auto_instrument()` immediately after `Traceloop.init`. It detects the wrapper-installed provider via the standard upstream marker `telemetry.auto.version` on its `Resource`, and merges the sap-cloud-sdk resource attrs onto it via `provider._resource = provider.resource.merge(Resource.create(sap_attrs))`. Right-side wins on collisions, so SAP-supplied keys (e.g. `service.name` from `APPFND_CONHOS_APP_NAME`) override colliding operator-supplied keys.

When no wrapper is detected (proxy default, or a self-installed `TracerProvider` without the marker), the helper is a no-op — existing single-tenant flows are unchanged. No new public API; no parameter additions to `auto_instrument()`. Existing callers pick up the fix transparently on upgrade.

### App Foundation runtime trigger path

The wrapper injection that triggers this bug for SAP App Foundation tenants follows this chain. Tracking ticket on the platform side: [AFSDK-2840](https://jira.tools.sap/browse/AFSDK-2840).

1. **CI label injection.** [`ci-cd-workflow/.github/actions/detect-otel-runtime/detect.py`](https://github.tools.sap/application-foundation/ci-cd-workflow/blob/main/.github/actions/detect-otel-runtime/detect.py) auto-detects Python from `pyproject.toml` / `requirements.txt`, then [`inject-otel-app-yaml/inject.py:39-47`](https://github.tools.sap/application-foundation/ci-cd-workflow/blob/main/.github/actions/inject-otel-app-yaml/inject.py#L39-L47) stamps `otel.instrumentation/enabled: python` onto the workload CR's `metadata.labels`. Default-on for every Python workload.
2. **Chart label propagation.** [`helm-templates/charts/agent/templates/_helpers.tpl:170-193`](https://github.tools.sap/app-fnd-runtime/helm-templates/blob/main/charts/agent/templates/_helpers.tpl#L170-L193) propagates the CR label onto both the rendered `Deployment.metadata.labels` and the `Deployment.spec.template.metadata.labels`. The chart comment explicitly says "Kyverno matches Deployment labels".
3. **Cluster mutation + operator injection.** A Kyverno ClusterPolicy `otel-inject-python-pod` matches the pod label and triggers the OpenTelemetry-Operator webhook to attach an init-container that copies its bundled OTel Python SDK to `/otel-auto-instrumentation-python`, prepends that path to `PYTHONPATH`, and stamps `telemetry.auto.version` on the active `TracerProvider`'s `Resource`. By the time `auto_instrument()` runs, `set_tracer_provider` has already been called — and the bug above kicks in.

The fix in this PR neutralises step 3's effect on resource attrs without requiring any change at steps 1–2 (which are platform-owned and out of scope for this repo).

## Related Issue

Closes #81 

## Type of Change

Please check the relevant option:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

**Unit tests:**

1. `git checkout fix/telemetry-merge-resource-with-wrapper-provider`
2. `uv run pytest tests/core/unit/telemetry/test_auto_instrument.py -v`
3. Expected: 18 passed (15 existing + 3 new — `test_auto_instrument_merges_resource_when_wrapper_installed`, `test_auto_instrument_skips_merge_when_no_wrapper_marker`, `test_auto_instrument_merge_overrides_colliding_service_name`).

**End-to-end on a wrapper-injected pod (e.g. App Foundation runtime):**

1. Deploy any sap-cloud-sdk-using Python agent to a cluster where the OpenTelemetry-Operator (or equivalent) auto-injects an `instrumentation.opentelemetry.io/inject-python` init-container.
2. Call `sap_cloud_sdk.core.telemetry.auto_instrument()` from the agent's startup path (as usual).
3. Read `trace.get_tracer_provider().resource.attributes` — e.g. via a `/_debug/tracing` route or a print statement.
4. Expected: the active provider's `Resource` carries both the operator-supplied attrs (`telemetry.auto.version`, `k8s.*`, `service.namespace`, …) **and** sap-cloud-sdk's full enrichment (`sap.cloud_sdk.*`, `sap.solution_area`, `mlflow.experiment_id`, `sap.cld.*`, `deployment.environment.name`, `cloud.region`). Colliding `service.name` is won by SAP side. Validated on a deployed [App Foundation buyer-agent](https://github.tools.sap/AppFoundation/fsm-codebasedagents) — see _Additional Notes_ below for the before/after JSON.

**Lint, format, type-check, coverage:**

- `uv run ruff check .` — clean.
- `uv run ruff format --check --diff .` — clean (`tests/` excluded per the existing `pyproject.toml [tool.ruff].exclude`).
- `uv run ty check --output-format github --python-version 3.11 .` — exit 0.
- `uv run pytest -m "not integration" --cov=src/sap_cloud_sdk` — 1160 passed, 80 deselected, total coverage 93%; `auto_instrument.py` at 93%.

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue (validated end-to-end on a deployed pod — see _Additional Notes_)
- [x] I have added/updated automated tests to cover my changes (3 new tests in `test_auto_instrument.py`)
- [x] All tests pass locally (1160 passed)
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable) — N/A; no public API change, no user-facing knob to document
- [x] I have added type hints for all public APIs (helper is private; type-hinted regardless: `sap_attrs: dict -> None`)
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages — `fix(telemetry): merge resource attrs onto wrapper-installed TracerProvider`

## Breaking Changes

None. The merge is auto-detected via the upstream `telemetry.auto.version` marker, which is only present when an OTel-Operator-class wrapper has installed the active provider. Self-installed user providers don't carry this marker, so the helper short-circuits and behaviour is identical to today. `auto_instrument()`'s signature is unchanged.

## Additional Notes

### Validation evidence — before/after on a wrapper-active pod

Resource Attributes on a deployed App Foundation Kyma pod with OpenTelemetry-Operator-injected auto-instrumentation active.

**Before — `auto_instrument()` ran but resource attrs were dropped (15 attrs, no SAP enrichment):**

```json
{
  "resource_attribute_count": 15,
  "resource_attributes": {
    "telemetry.sdk.language": "python",
    "telemetry.sdk.name": "opentelemetry",
    "telemetry.sdk.version": "1.41.1",
    "service.version": "0.0.1",
    "sap.service.display_name": "buyer-agent-evals-fina",
    "k8s.container.name": "buyer-agent-evals-fina",
    "k8s.deployment.name": "buyer-agent-evals-fina-deployment",
    "k8s.namespace.name": "buyer-agent-evals-fsmcba",
    "k8s.node.name": "ip-10-250-152-52.eu-central-1.compute.internal",
    "k8s.pod.name": "buyer-agent-evals-fina-deployment-97d4f6795-7r2vz",
    "k8s.replicaset.name": "buyer-agent-evals-fina-deployment-97d4f6795",
    "service.instance.id": "buyer-agent-evals-fsmcba.buyer-agent-evals-fina-deployment-97d4f6795-7r2vz.buyer-agent-evals-fina",
    "service.namespace": "buyer-agent-evals-fsmcba",
    "service.name": "buyer-agent-evals-fina-deployment",
    "telemetry.auto.version": "0.62b1"
  }
}
```

`mlflow.experiment_id`, `sap.cloud_sdk.*`, `sap.solution_area`, `sap.cld.*`, `deployment.environment.name`, `cloud.region` — all absent. `service.name` is the operator's `OTEL_SERVICE_NAME` value (`<appname>-deployment`) rather than `APPFND_CONHOS_APP_NAME`.

**After — same pod, with this PR's merge fix applied (24 attrs, full SAP enrichment):**

```json
{
  "resource_attribute_count": 24,
  "resource_attributes": {
    "telemetry.sdk.language": "python",
    "telemetry.sdk.name": "opentelemetry",
    "telemetry.sdk.version": "1.41.1",
    "service.version": "0.0.1",
    "sap.service.display_name": "buyer-agent-evals-fina",
    "k8s.container.name": "buyer-agent-evals-fina",
    "k8s.deployment.name": "buyer-agent-evals-fina-deployment",
    "k8s.namespace.name": "buyer-agent-evals-fsmcba",
    "k8s.node.name": "ip-10-250-84-103.eu-central-1.compute.internal",
    "k8s.pod.name": "buyer-agent-evals-fina-deployment-7746997958-rbh6z",
    "k8s.replicaset.name": "buyer-agent-evals-fina-deployment-7746997958",
    "service.instance.id": "buyer-agent-evals-fina-deployment-7746997958-rbh6z",
    "service.namespace": "buyer-agent-evals-fsmcba",
    "service.name": "buyer-agent-evals-fina",
    "telemetry.auto.version": "0.62b1",
    "deployment.environment.name": "canary",
    "cloud.region": "eu12",
    "sap.cld.subaccount_id": "ac5d447e-af4b-4c64-abf5-90e71f770c07",
    "sap.cld.system_role": "unknown",
    "sap.cloud_sdk.name": "SAP Cloud SDK for Python",
    "sap.cloud_sdk.language": "python",
    "sap.cloud_sdk.version": "0.11.6",
    "sap.solution_area": "fina",
    "mlflow.experiment_id": "1635264705567712"
  }
}
```

Operator-supplied `k8s.*`, `service.namespace`, `service.version`, `sap.service.display_name`, `telemetry.*` all preserved. SAP attrs added on top. `service.name` collision won by SAP side — `buyer-agent-evals-fina` from `APPFND_CONHOS_APP_NAME` drops the redundant `-deployment` suffix the operator picked up from the k8s deployment name.

### Design notes for reviewers

- **`Traceloop.init` still runs.** Even when the merge will fire, we keep the `Traceloop.init` call above untouched — it's the only way to install Traceloop's third-party autoinstrumentation hooks (langchain, openai, …) which emit spans via `trace.get_tracer(...)` and flow through whichever provider is globally active. Cost in the wrapper-active case is one orphaned `TracerProvider` allocation at startup; acceptable.

### Files changed

- [`src/sap_cloud_sdk/core/telemetry/auto_instrument.py`](https://github.com/SAP/cloud-sdk-python/blob/fix/telemetry-merge-resource-with-wrapper-provider/src/sap_cloud_sdk/core/telemetry/auto_instrument.py) — adds `Mapping` and `Resource` imports; calls the new helper after `Traceloop.init`; defines `_merge_resource_attrs_into_active_provider_if_wrapper_installed`.
- [`tests/core/unit/telemetry/test_auto_instrument.py`](https://github.com/SAP/cloud-sdk-python/blob/fix/telemetry-merge-resource-with-wrapper-provider/tests/core/unit/telemetry/test_auto_instrument.py) — three new tests covering merge-fires, marker-absent-skip, and SAP-side-wins-on-collision.
- `pyproject.toml` + `uv.lock` — version `0.11.6` → `0.11.7` (required by [`check-version-bump.yaml`](https://github.com/SAP/cloud-sdk-python/blob/main/.github/workflows/check-version-bump.yaml) when `src/` changes).
