### PR TITLE
feat: read ORD ID from environment variables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.11.7"
+version = "0.11.8"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -17,6 +17,7 @@ from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_SAP_SDK_VERSION,
     ATTR_SAP_SOLUTION_AREA,
     ATTR_MLFLOW_EXPERIMENT_ID,
+    ATTR_SAP_ORD_ID,
     SDK_NAME,
 )
 
@@ -33,6 +34,7 @@ ENV_HOSTNAME = "HOSTNAME"
 ENV_SYSTEM_ROLE = "APPFND_CONHOS_SYSTEM_ROLE"
 ENV_SOLUTION_AREA = "SAP_SOLUTION_AREA"
 ENV_MLFLOW_EXPERIMENT_ID = "MLFLOW_EXPERIMENT_ID"
+ENV_ORD_DOCUMENT_ID = "ORD_DOCUMENT_ID"
 
 # OTEL environment variable keys
 ENV_OTLP_ENDPOINT = "OTEL_EXPORTER_OTLP_ENDPOINT"
@@ -98,6 +100,16 @@ def _get_mlflow_experiment_id() -> Optional[str]:
     return value if value else None
 
 
+def _get_ord_id() -> Optional[str]:
+    """Get ORD document ID from environment.
+
+    Returns:
+        Value of ORD_DOCUMENT_ID, or None if the env var is missing or empty.
+    """
+    value = os.getenv(ENV_ORD_DOCUMENT_ID)
+    return value if value else None
+
+
 def create_resource_attributes_from_env() -> dict:
     """Create OpenTelemetry Resource with SDK attributes.
 
@@ -118,6 +130,7 @@ def create_resource_attributes_from_env() -> dict:
         - sap.cloud_sdk.version (from package version)
         - sap.solution_area (from SAP_SOLUTION_AREA, defaults to "unknown")
         - mlflow.experiment_id (from MLFLOW_EXPERIMENT_ID, omitted when unset or empty)
+        - sap.ord.id (from ORD_DOCUMENT_ID, omitted when unset or empty)
     """
 
     attributes = {
@@ -137,6 +150,10 @@ def create_resource_attributes_from_env() -> dict:
     mlflow_experiment_id = _get_mlflow_experiment_id()
     if mlflow_experiment_id is not None:
         attributes[ATTR_MLFLOW_EXPERIMENT_ID] = mlflow_experiment_id
+
+    ord_id = _get_ord_id()
+    if ord_id is not None:
+        attributes[ATTR_SAP_ORD_ID] = ord_id
 
     return attributes
 

--- a/src/sap_cloud_sdk/core/telemetry/constants.py
+++ b/src/sap_cloud_sdk/core/telemetry/constants.py
@@ -27,6 +27,9 @@ ATTR_SAP_SOLUTION_AREA = "sap.solution_area"
 # Attribute keys - MLflow
 ATTR_MLFLOW_EXPERIMENT_ID = "mlflow.experiment_id"
 
+# Attribute keys - ORD
+ATTR_SAP_ORD_ID = "sap.ord.id"
+
 # Attribute keys - SAP App Foundation specific
 ATTR_CAPABILITY = "sap.cloud_sdk.capability"
 ATTR_FUNCTIONALITY = "sap.cloud_sdk.functionality"

--- a/src/sap_cloud_sdk/core/telemetry/user-guide.md
+++ b/src/sap_cloud_sdk/core/telemetry/user-guide.md
@@ -239,3 +239,9 @@ export APPFND_CONHOS_SYSTEM_ROLE="S4HC"
 ```bash
 export SAP_SOLUTION_AREA="AFND"
 ```
+
+### ORD document ID
+
+```bash
+export ORD_DOCUMENT_ID="sap.foo:ord-doc:v1"
+```

--- a/tests/core/unit/telemetry/test_config.py
+++ b/tests/core/unit/telemetry/test_config.py
@@ -11,6 +11,7 @@ from sap_cloud_sdk.core.telemetry.config import (
 from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_MLFLOW_EXPERIMENT_ID,
     ATTR_SAP_SOLUTION_AREA,
+    ATTR_SAP_ORD_ID,
 )
 
 
@@ -233,3 +234,35 @@ class TestCreateResourceAttributesFromEnv:
             attrs = create_resource_attributes_from_env()
 
             assert "sap.solution_area" in attrs
+
+    def test_ord_id_omitted_when_unset(self):
+        """sap.ord.id is omitted entirely when ORD_DOCUMENT_ID is unset."""
+        with patch.dict('os.environ', {}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert ATTR_SAP_ORD_ID not in attrs
+
+    def test_ord_id_omitted_when_empty(self):
+        """sap.ord.id is omitted when ORD_DOCUMENT_ID is an empty string."""
+        with patch.dict('os.environ', {'ORD_DOCUMENT_ID': ''}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert ATTR_SAP_ORD_ID not in attrs
+
+    def test_ord_id_read_from_env(self):
+        """sap.ord.id resource attribute is read from ORD_DOCUMENT_ID."""
+        with patch.dict('os.environ', {'ORD_DOCUMENT_ID': 'sap.foo:ord-doc:v1'}, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_SAP_ORD_ID] == "sap.foo:ord-doc:v1"
+
+    def test_ord_id_independent_of_other_attributes(self):
+        """sap.ord.id is populated independently from other optional attributes."""
+        with patch.dict('os.environ', {
+            'ORD_DOCUMENT_ID': 'my-ord-id',
+            'MLFLOW_EXPERIMENT_ID': 'exp-99',
+        }, clear=True):
+            attrs = create_resource_attributes_from_env()
+
+            assert attrs[ATTR_SAP_ORD_ID] == "my-ord-id"
+            assert attrs[ATTR_MLFLOW_EXPERIMENT_ID] == "exp-99"

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.7"
+version = "0.11.8"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

Reading ORD ID from environment variable `ORD_DOCUMENT_ID` if present

## Type of Change

Please check the relevant option:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

Describe how reviewers can test your changes:

1. Run agent with ORD_DOCUMENT_ID env var populated
2. Instrument with auto_instrument()
3. Run any action that generates telemetry
4. See resource attribute generated with sap.ord.id

## Checklist

Before submitting your PR, please review and check the following:

- [X] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] I have verified that my changes solve the issue
- [X] I have added/updated automated tests to cover my changes
- [X] All tests pass locally
- [X] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [X] I have updated documentation (if applicable)
- [X] I have added type hints for all public APIs
- [X] My code does not contain sensitive information (credentials, tokens, etc.)
- [X] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages