### PR TITLE
fix(auditlog-ng): select OTLP transport from OTEL_EXPORTER_OTLP_PROTOCOL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.12.0"
+version = "0.12.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/auditlog_ng/client.py
+++ b/src/sap_cloud_sdk/core/auditlog_ng/client.py
@@ -27,6 +27,7 @@ from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
 from opentelemetry.exporter.otlp.proto.http._log_exporter import (
     OTLPLogExporter as HTTPLogExporter,
 )
+from opentelemetry.exporter.otlp.proto.http import Compression as HTTPCompression
 from opentelemetry._logs.severity import SeverityNumber
 
 from sap_cloud_sdk.core.auditlog_ng.config import (
@@ -56,7 +57,17 @@ def _create_log_exporter(
             ),
         )
     elif protocol == "http/protobuf":
-        return HTTPLogExporter(endpoint=config.endpoint)
+        return HTTPLogExporter(
+            endpoint=config.endpoint,
+            certificate_file=config.ca_file,
+            client_key_file=config.key_file,
+            client_certificate_file=config.cert_file,
+            compression=(
+                HTTPCompression.Gzip
+                if config.compression
+                else HTTPCompression.NoCompression
+            ),
+        )
     else:
         raise ValueError(
             f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "

--- a/src/sap_cloud_sdk/core/auditlog_ng/client.py
+++ b/src/sap_cloud_sdk/core/auditlog_ng/client.py
@@ -1,10 +1,11 @@
 """Audit Log OTLP Client.
 
-Sends audit log events as OpenTelemetry LogRecords over gRPC.
-Supports mTLS (client certificates) and insecure (no-auth) modes.
+Sends audit log events as OpenTelemetry LogRecords over gRPC or HTTP.
+Supports mTLS (client certificates) and insecure (no-auth) modes for gRPC.
 """
 
 import json
+import os
 import uuid
 from typing import Optional
 
@@ -20,7 +21,12 @@ from opentelemetry.sdk._logs.export import (
     BatchLogRecordProcessor,
 )
 from opentelemetry.sdk.resources import Resource
-from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
+    OTLPLogExporter as GRPCLogExporter,
+)
+from opentelemetry.exporter.otlp.proto.http._log_exporter import (
+    OTLPLogExporter as HTTPLogExporter,
+)
 from opentelemetry._logs.severity import SeverityNumber
 
 from sap_cloud_sdk.core.auditlog_ng.config import (
@@ -29,6 +35,33 @@ from sap_cloud_sdk.core.auditlog_ng.config import (
 )
 from sap_cloud_sdk.core.auditlog_ng.exceptions import ValidationError
 from sap_cloud_sdk.core.telemetry import Module
+from sap_cloud_sdk.core.telemetry.config import ENV_OTLP_PROTOCOL
+
+
+def _create_log_exporter(
+    config: AuditLogNGConfig,
+    credentials: Optional[grpc.ChannelCredentials],
+):
+    """Create an OTLP log exporter based on OTEL_EXPORTER_OTLP_PROTOCOL."""
+    protocol = os.getenv(ENV_OTLP_PROTOCOL, "grpc").lower()
+    if protocol == "grpc":
+        return GRPCLogExporter(
+            endpoint=config.endpoint,
+            insecure=config.insecure,
+            credentials=credentials,
+            compression=(
+                grpc.Compression.Gzip
+                if config.compression
+                else grpc.Compression.NoCompression
+            ),
+        )
+    elif protocol == "http/protobuf":
+        return HTTPLogExporter(endpoint=config.endpoint)
+    else:
+        raise ValueError(
+            f"Unsupported OTEL_EXPORTER_OTLP_PROTOCOL: '{protocol}'. "
+            "Supported values are 'grpc' and 'http/protobuf'."
+        )
 
 
 class AuditClient:
@@ -74,16 +107,7 @@ class AuditClient:
         credentials = self._build_credentials(config)
 
         # Create OTLP exporter
-        self._exporter = OTLPLogExporter(
-            endpoint=config.endpoint,
-            insecure=config.insecure,
-            credentials=credentials,
-            compression=(
-                grpc.Compression.Gzip
-                if config.compression
-                else grpc.Compression.NoCompression
-            ),
-        )
+        self._exporter = _create_log_exporter(config, credentials)
 
         # Create logger provider
         self._provider = LoggerProvider(

--- a/tests/core/unit/auditlog_ng/unit/test_client.py
+++ b/tests/core/unit/auditlog_ng/unit/test_client.py
@@ -1,4 +1,5 @@
 """Tests for AuditClient."""
+
 from __future__ import annotations
 
 import json
@@ -39,7 +40,9 @@ def _make_config(**overrides: Unpack[ConfigKwargs]) -> AuditLogNGConfig:
 
 @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
 @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-def _make_mocked_client(mock_provider_cls, mock_exporter_cls, *, validate_side_effect=None):
+def _make_mocked_client(
+    mock_provider_cls, mock_exporter_cls, *, validate_side_effect=None
+):
     mock_logger = Mock()
     mock_provider = Mock()
     mock_provider.get_logger.return_value = mock_logger
@@ -54,7 +57,14 @@ def _make_mocked_client(mock_provider_cls, mock_exporter_cls, *, validate_side_e
     )
     mock_validate = validate_patcher.start()
 
-    return client, mock_logger, mock_provider, mock_validate, validate_patcher, mock_provider_cls
+    return (
+        client,
+        mock_logger,
+        mock_provider,
+        mock_validate,
+        validate_patcher,
+        mock_provider_cls,
+    )
 
 
 def _make_mock_event(tenant_id="tenant-123", descriptor_name="DataAccess"):
@@ -66,7 +76,6 @@ def _make_mock_event(tenant_id="tenant-123", descriptor_name="DataAccess"):
 
 
 class TestAuditClientInit:
-
     @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
     def test_creates_insecure_client(self, mock_provider_cls, mock_exporter_cls):
@@ -107,7 +116,6 @@ class TestAuditClientInit:
 
 
 class TestAuditClientSend:
-
     def test_send_binary_success(self):
         client, mock_logger, _, mock_validate, patcher, _ = _make_mocked_client()
         try:
@@ -121,7 +129,10 @@ class TestAuditClientSend:
             _, kwargs = mock_logger.emit.call_args
             assert kwargs["event_name"] == "sap.als.AuditEvent.DataAccess.v2"
             assert kwargs["body"] == b"\x00\x01\x02"
-            assert kwargs["attributes"]["sap.auditlogging.mime_type"] == "application/protobuf"
+            assert (
+                kwargs["attributes"]["sap.auditlogging.mime_type"]
+                == "application/protobuf"
+            )
             assert kwargs["attributes"]["sap.tenancy.tenant_id"] == "tenant-123"
             assert "cloudevents.event_id" in kwargs["attributes"]
         finally:
@@ -137,7 +148,9 @@ class TestAuditClientSend:
             mock_logger.emit.assert_called_once()
 
             _, kwargs = mock_logger.emit.call_args
-            assert kwargs["attributes"]["sap.auditlogging.mime_type"] == "application/json"
+            assert (
+                kwargs["attributes"]["sap.auditlogging.mime_type"] == "application/json"
+            )
             assert isinstance(kwargs["body"], str)
         finally:
             patcher.stop()
@@ -197,7 +210,6 @@ class TestAuditClientSend:
 
 
 class TestAuditClientLifecycle:
-
     def test_flush(self):
         client, _, mock_provider, _, patcher, _ = _make_mocked_client()
         patcher.stop()
@@ -234,26 +246,52 @@ class TestAuditClientLifecycle:
 
 
 class TestAuditClientProtocol:
-
     @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_grpc_is_default(self, mock_provider_cls, mock_grpc_exporter_cls, monkeypatch):
+    def test_grpc_is_default(
+        self, mock_provider_cls, mock_grpc_exporter_cls, monkeypatch
+    ):
         monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
         AuditClient(_make_config())
         mock_grpc_exporter_cls.assert_called_once()
 
     @patch("sap_cloud_sdk.core.auditlog_ng.client.HTTPLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_http_protobuf_protocol(self, mock_provider_cls, mock_http_exporter_cls, monkeypatch):
+    def test_http_protobuf_protocol(
+        self, mock_provider_cls, mock_http_exporter_cls, monkeypatch
+    ):
         monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
-        AuditClient(_make_config())
+        AuditClient(
+            _make_config(
+                cert_file="client.pem", key_file="client.key", ca_file="ca.pem"
+            )
+        )
         mock_http_exporter_cls.assert_called_once()
         _, kwargs = mock_http_exporter_cls.call_args
         assert kwargs["endpoint"] == "localhost:4317"
+        assert kwargs["client_certificate_file"] == "client.pem"
+        assert kwargs["client_key_file"] == "client.key"
+        assert kwargs["certificate_file"] == "ca.pem"
+
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.HTTPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
+    def test_http_compression(
+        self, mock_provider_cls, mock_http_exporter_cls, monkeypatch
+    ):
+        from opentelemetry.exporter.otlp.proto.http import (
+            Compression as HTTPCompression,
+        )
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        AuditClient(_make_config(compression=True))
+        _, kwargs = mock_http_exporter_cls.call_args
+        assert kwargs["compression"] == HTTPCompression.Gzip
 
     @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_unsupported_protocol_raises(self, mock_provider_cls, mock_exporter_cls, monkeypatch):
+    def test_unsupported_protocol_raises(
+        self, mock_provider_cls, mock_exporter_cls, monkeypatch
+    ):
         monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json")
         with pytest.raises(ValueError, match="Unsupported OTEL_EXPORTER_OTLP_PROTOCOL"):
             AuditClient(_make_config())

--- a/tests/core/unit/auditlog_ng/unit/test_client.py
+++ b/tests/core/unit/auditlog_ng/unit/test_client.py
@@ -37,7 +37,7 @@ def _make_config(**overrides: Unpack[ConfigKwargs]) -> AuditLogNGConfig:
     return AuditLogNGConfig(**defaults)
 
 
-@patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+@patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
 @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
 def _make_mocked_client(mock_provider_cls, mock_exporter_cls, *, validate_side_effect=None):
     mock_logger = Mock()
@@ -67,7 +67,7 @@ def _make_mock_event(tenant_id="tenant-123", descriptor_name="DataAccess"):
 
 class TestAuditClientInit:
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
     def test_creates_insecure_client(self, mock_provider_cls, mock_exporter_cls):
         config = _make_config(insecure=True)
@@ -78,7 +78,7 @@ class TestAuditClientInit:
         _, kwargs = mock_exporter_cls.call_args
         assert kwargs["insecure"] is True
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
     def test_sets_schema_url_on_logger(self, mock_provider_cls, mock_exporter_cls):
         mock_provider = Mock()
@@ -92,7 +92,7 @@ class TestAuditClientInit:
         _, kwargs = mock_provider.get_logger.call_args
         assert kwargs["schema_url"] == SCHEMA_URL
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
     def test_sets_resource_attributes(self, mock_provider_cls, mock_exporter_cls):
         config = _make_config(service_name="my-svc")
@@ -231,3 +231,29 @@ class TestAuditClientLifecycle:
 
         assert client._closed is True
         mock_provider.shutdown.assert_called_once()
+
+
+class TestAuditClientProtocol:
+
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
+    def test_grpc_is_default(self, mock_provider_cls, mock_grpc_exporter_cls, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+        AuditClient(_make_config())
+        mock_grpc_exporter_cls.assert_called_once()
+
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.HTTPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
+    def test_http_protobuf_protocol(self, mock_provider_cls, mock_http_exporter_cls, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        AuditClient(_make_config())
+        mock_http_exporter_cls.assert_called_once()
+        _, kwargs = mock_http_exporter_cls.call_args
+        assert kwargs["endpoint"] == "localhost:4317"
+
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.GRPCLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
+    def test_unsupported_protocol_raises(self, mock_provider_cls, mock_exporter_cls, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json")
+        with pytest.raises(ValueError, match="Unsupported OTEL_EXPORTER_OTLP_PROTOCOL"):
+            AuditClient(_make_config())

--- a/tests/core/unit/auditlog_ng/unit/test_create_client.py
+++ b/tests/core/unit/auditlog_ng/unit/test_create_client.py
@@ -10,9 +10,9 @@ from sap_cloud_sdk.core.auditlog_ng.exceptions import ClientCreationError
 
 class TestCreateClient:
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client._create_log_exporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_create_client_with_config(self, mock_provider_cls, mock_exporter_cls):
+    def test_create_client_with_config(self, mock_provider_cls, mock_exporter_fn):
         mock_provider = Mock()
         mock_provider.get_logger.return_value = Mock()
         mock_provider_cls.return_value = mock_provider
@@ -28,9 +28,9 @@ class TestCreateClient:
 
         assert isinstance(client, AuditClient)
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client._create_log_exporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_create_client_with_keyword_args(self, mock_provider_cls, mock_exporter_cls):
+    def test_create_client_with_keyword_args(self, mock_provider_cls, mock_exporter_fn):
         mock_provider = Mock()
         mock_provider.get_logger.return_value = Mock()
         mock_provider_cls.return_value = mock_provider
@@ -68,10 +68,10 @@ class TestCreateClient:
                 namespace="ns-1",
             )
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client._create_log_exporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
     def test_create_client_unexpected_exception_wraps_in_client_creation_error(
-        self, mock_provider_cls, mock_exporter_cls
+        self, mock_provider_cls, mock_exporter_fn
     ):
         mock_provider_cls.side_effect = RuntimeError("Unexpected failure")
 
@@ -83,9 +83,9 @@ class TestCreateClient:
                 insecure=True,
             )
 
-    @patch("sap_cloud_sdk.core.auditlog_ng.client.OTLPLogExporter")
+    @patch("sap_cloud_sdk.core.auditlog_ng.client._create_log_exporter")
     @patch("sap_cloud_sdk.core.auditlog_ng.client.LoggerProvider")
-    def test_config_keyword_args_are_forwarded(self, mock_provider_cls, mock_exporter_cls):
+    def test_config_keyword_args_are_forwarded(self, mock_provider_cls, mock_exporter_fn):
         mock_provider = Mock()
         mock_provider.get_logger.return_value = Mock()
         mock_provider_cls.return_value = mock_provider

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.11.8"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

The `auditlog_ng` client hardcoded the gRPC OTLP log exporter, ignoring `OTEL_EXPORTER_OTLP_PROTOCOL`. This PR extracts a `_create_log_exporter()` function that reads the env var (defaulting to `grpc`) and instantiates either `GRPCLogExporter` or `HTTPLogExporter` — the same pattern used for metrics in `_provider.py` (PR #63).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` and instantiate an `AuditClient` — the HTTP exporter is used
2. Leave the env var unset (or set to `grpc`) — the gRPC exporter is used as before
3. Run `uv run pytest tests/core/unit/auditlog_ng/unit/test_client.py -v`
4. Expected: all 17 tests pass, including the 3 new `TestAuditClientProtocol` tests

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. Defaults to `grpc`, preserving existing behaviour for users who do not set `OTEL_EXPORTER_OTLP_PROTOCOL`.

## Additional Notes

Mirrors the pattern introduced for metrics in PR #63.