### PR TITLE
feat: add consumption destination and fragment level

### DIFF
--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -36,7 +36,7 @@ Create `PULL_REQUEST.md` at the repo root following the structure of `.github/pu
 Create `RELEASE.md` at the repo root using this exact template structure:
 
 ```
-## [vX.Y.Z] - YYYY-MM-DD
+## [vX.Y.Z] - MM DD, YYYY
 
 ### What's New
 - ...

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,0 +1,65 @@
+Prepare a release for the changes on the current branch. Do the following steps in order:
+
+## Step 1 — Understand the changes
+
+Run `git diff main...HEAD` and `git log main...HEAD --oneline` to understand what was changed on this branch. Read all modified source files to understand the nature of the changes (new feature, bug fix, breaking change, docs, etc.).
+
+## Step 2 — Determine the new version
+
+Read `pyproject.toml` to get the current version. Apply SemVer rules based on the changes:
+- PATCH bump: bug fixes, docs, refactors, non-breaking improvements
+- MINOR bump: new non-breaking features or new public API surface
+- MAJOR bump: breaking changes (changes to existing public API signatures or behavior)
+
+Compute the new version string (no leading `v`).
+
+## Step 3 — Bump version in pyproject.toml
+
+Edit `pyproject.toml` and update `version = "..."` to the new version.
+
+## Step 4 — Create PULL_REQUEST.md
+
+Create `PULL_REQUEST.md` at the repo root following the structure of `.github/pull_request_template.md`. Fill it in based on what you learned from the diff:
+
+- **Description**: clear summary of what changed and why
+- **Related Issue**: leave as `Closes #` with a note to fill in the issue number
+- **Type of Change**: check the relevant boxes (use `[x]`)
+- **How to Test**: concrete steps to verify the change works
+- **Checklist**: check all boxes that apply given the changes made
+- **Breaking Changes**: fill in if applicable, otherwise remove the section
+- **Additional Notes**: any relevant context for reviewers
+
+> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.
+
+## Step 5 — Create RELEASE.md
+
+Create `RELEASE.md` at the repo root using this exact template structure:
+
+```
+## [vX.Y.Z] - YYYY-MM-DD
+
+### What's New
+- ...
+
+### Improvements
+- ...
+
+### Bug Fixes
+- ...
+
+### Breaking Changes
+> ⚠️ **Important**: This section is critical for users upgrading from previous versions
+- **[Breaking Change]**: ...
+
+### Contributors
+...
+```
+
+Fill in the version and today's date. Remove sections that don't apply. Infer the content from the diff — be specific about what changed (class names, method names, parameter names) so that users upgrading know exactly what to update.
+
+## Step 6 — Summarize
+
+Tell the user:
+- The old and new version
+- Which files were created/updated
+- Any sections in PULL_REQUEST.md or RELEASE.md that still need manual input (e.g. issue number, contributors)

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ test-results.*
 
 # Local Mode
 mocks/
+
+# Generated files
+PULL_REQUEST.md
+RELEASE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.13.0"
+version = "0.14.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/destination/__init__.py
+++ b/src/sap_cloud_sdk/destination/__init__.py
@@ -29,6 +29,7 @@ from typing import Optional
 from sap_cloud_sdk.destination._models import (
     Destination,
     AuthToken,
+    ConsumptionLevel,
     ConsumptionOptions,
     Fragment,
     Certificate,
@@ -208,6 +209,7 @@ __all__ = [
     # Public types
     "Destination",
     "AuthToken",
+    "ConsumptionLevel",
     "ConsumptionOptions",
     "Fragment",
     "Certificate",

--- a/src/sap_cloud_sdk/destination/_models.py
+++ b/src/sap_cloud_sdk/destination/_models.py
@@ -84,6 +84,25 @@ class AccessStrategy(Enum):
     PROVIDER_FIRST = "PROVIDER_FIRST"
 
 
+class ConsumptionLevel(Enum):
+    """Level hint for the v2 consumption API (get_destination).
+
+    Appended as @level to the destination name or fragment name in the API request,
+    allowing the caller to hint which scope to search.
+
+    Attributes:
+        PROVIDER_SUBACCOUNT: Provider subaccount scope
+        PROVIDER_INSTANCE: Provider service instance scope
+        SUBACCOUNT: Subscriber subaccount scope
+        INSTANCE: Subscriber service instance scope
+    """
+
+    PROVIDER_SUBACCOUNT = "provider_subaccount"
+    PROVIDER_INSTANCE = "provider_instance"
+    SUBACCOUNT = "subaccount"
+    INSTANCE = "instance"
+
+
 class DestinationType(Enum):
     """Destination type (subset of v1)."""
 
@@ -412,6 +431,9 @@ class ConsumptionOptions:
         fragment_name: Name of the destination fragment used to override/extend destination
             properties (X-fragment-name). In case of overlapping properties, fragment values
             take priority.
+        fragment_level: Level hint for the fragment lookup. When set, appended to the fragment
+            name as @level (e.g., "my-fragment@provider_subaccount"). Only effective when
+            fragment_name is also provided.
         fragment_optional: When True, if the fragment specified by fragment_name does not
             exist the destination is returned without it. When False (default), a missing
             fragment causes an error (X-fragment-optional).
@@ -488,6 +510,7 @@ class ConsumptionOptions:
     """
 
     fragment_name: Optional[str] = None
+    fragment_level: Optional[ConsumptionLevel] = None
     fragment_optional: Optional[bool] = None
     tenant: Optional[str] = None
     user_token: Optional[str] = None

--- a/src/sap_cloud_sdk/destination/client.py
+++ b/src/sap_cloud_sdk/destination/client.py
@@ -8,6 +8,7 @@ from sap_cloud_sdk.core.telemetry import Module, Operation, record_metrics
 from sap_cloud_sdk.destination._http import DestinationHttp, API_V1, API_V2
 from sap_cloud_sdk.destination._models import (
     AccessStrategy,
+    ConsumptionLevel,
     ConsumptionOptions,
     Destination,
     Label,
@@ -31,9 +32,6 @@ T = TypeVar("T")
 
 _SUBACCOUNT_COLLECTION = "subaccountDestinations"
 _INSTANCE_COLLECTION = "instanceDestinations"
-
-_SUBACCOUNT_LEVEL = "subaccount"
-_INSTANCE_LEVEL = "instance"
 
 
 class DestinationClient:
@@ -279,7 +277,7 @@ class DestinationClient:
     def get_destination(
         self,
         name: str,
-        level: Optional[Level] = None,
+        level: Optional[ConsumptionLevel] = None,
         options: Optional[ConsumptionOptions] = None,
         proxy_enabled: Optional[bool] = None,
         tenant: Optional[str] = None,
@@ -296,8 +294,9 @@ class DestinationClient:
 
         Args:
             name: Destination name.
-            level: Optional level hint (subaccount or instance) to optimize lookup. If not
-                provided, the API will search on instance level.
+            level: Optional level hint to narrow the lookup scope. When provided, appended to
+                the destination name as @level (e.g., "my-dest@provider_subaccount"). Supported
+                values: PROVIDER_SUBACCOUNT, PROVIDER_INSTANCE, SUBACCOUNT, INSTANCE.
             options: Optional ConsumptionOptions controlling request headers sent to the
                 Destination Service. See ConsumptionOptions for the full list of supported
                 headers (fragment merging, token exchange, SAML, OAuth2 flows, chains, etc.).
@@ -324,7 +323,7 @@ class DestinationClient:
             dest = client.get_destination("my-api")
 
             # With level hint
-            dest = client.get_destination("my-api", level=Level.SERVICE_INSTANCE)
+            dest = client.get_destination("my-api", level=ConsumptionLevel.PROVIDER_SUBACCOUNT)
 
             # Fragment merging
             dest = client.get_destination("my-api", options=ConsumptionOptions(fragment_name="prod"))
@@ -359,7 +358,10 @@ class DestinationClient:
 
             if options:
                 if options.fragment_name:
-                    headers["X-fragment-name"] = options.fragment_name
+                    frag = options.fragment_name
+                    if options.fragment_level:
+                        frag = f"{frag}@{options.fragment_level.value}"
+                    headers["X-fragment-name"] = frag
                 if options.fragment_optional is not None:
                     headers["X-fragment-optional"] = str(
                         options.fragment_optional
@@ -393,11 +395,11 @@ class DestinationClient:
                         headers[f"X-chain-var-{var_name}"] = var_value
 
             # Build path with optional level hint
-            if level:
-                level_str = self._map_level_to_api(level)
-                path = f"{API_V2}/destinations/{name}@{level_str}"
-            else:
-                path = f"{API_V2}/destinations/{name}"
+            path = (
+                f"{API_V2}/destinations/{name}@{level.value}"
+                if level
+                else f"{API_V2}/destinations/{name}"
+            )
 
             resp = self._http.get(path, headers=headers, tenant_subdomain=tenant)
             data = resp.json()
@@ -821,8 +823,3 @@ class DestinationClient:
             if level == Level.SERVICE_INSTANCE
             else _SUBACCOUNT_COLLECTION
         )
-
-    @staticmethod
-    def _map_level_to_api(level: Level) -> str:
-        """Return the v2 API level string for the given level."""
-        return _INSTANCE_LEVEL if level == Level.SERVICE_INSTANCE else _SUBACCOUNT_LEVEL

--- a/src/sap_cloud_sdk/destination/user-guide.md
+++ b/src/sap_cloud_sdk/destination/user-guide.md
@@ -14,7 +14,9 @@ from sap_cloud_sdk.destination import (
     create_fragment_client,
     create_certificate_client,
     Level,
-    AccessStrategy
+    AccessStrategy,
+    ConsumptionLevel,
+    ConsumptionOptions,
 )
 
 # Auto-detection based on environment; in cloud mode it will load credentials
@@ -100,9 +102,15 @@ client.patch_destination_labels("my-dest", PatchLabels(action="DELETE", labels=l
 
 ## Concepts
 
-- Level:
+- Level (v1 admin API — write operations, label operations):
   - SERVICE_INSTANCE: Operates on instance destinations
   - SUB_ACCOUNT: Operates on subaccount destinations
+
+- ConsumptionLevel (v2 consumption API — `get_destination` only):
+  - PROVIDER_SUBACCOUNT: Provider subaccount scope
+  - PROVIDER_INSTANCE: Provider service instance scope
+  - SUBACCOUNT: Subscriber subaccount scope
+  - INSTANCE: Subscriber service instance scope
 
 - AccessStrategy (applies to subaccount reads):
   - SUBSCRIBER_ONLY: Only subscriber (tenant required)
@@ -133,7 +141,7 @@ class DestinationClient:
     def patch_destination_labels(self, name: str, patch: PatchLabels, level: Optional[Level] = Level.SUB_ACCOUNT, tenant: Optional[str] = None) -> None: ...
 
     # V2 Runtime API - Destination consumption with automatic token retrieval
-    def get_destination(self, name: str, level: Optional[Level] = None, options: Optional[ConsumptionOptions] = None, proxy_enabled: Optional[bool] = None, tenant: Optional[str] = None) -> Optional[Destination | TransparentProxyDestination]: ...
+    def get_destination(self, name: str, level: Optional[ConsumptionLevel] = None, options: Optional[ConsumptionOptions] = None, proxy_enabled: Optional[bool] = None, tenant: Optional[str] = None) -> Optional[Destination | TransparentProxyDestination]: ...
 ```
 
 ### Fragment Client
@@ -178,6 +186,7 @@ class CertificateClient:
   - `auth_tokens` and `certificates` are populated by the v2 consumption API
 - `ConsumptionOptions` - Options for v2 destination consumption, controls HTTP headers sent to the Destination Service:
   - `fragment_name?: str` - Fragment to merge into the destination (`X-fragment-name`)
+  - `fragment_level?: ConsumptionLevel` - Level hint for the fragment lookup; appended to `fragment_name` as `@level` (e.g., `"my-frag@provider_subaccount"`). Only effective when `fragment_name` is also provided.
   - `fragment_optional?: bool` - If `True`, a missing fragment does not cause an error (`X-fragment-optional`)
   - `tenant?: str` - Tenant subdomain for token retrieval (`X-tenant`)
   - `user_token?: str` - User JWT for OAuth2UserTokenExchange / OAuth2JWTBearer / OAuth2SAMLBearerAssertion (`X-user-token`)
@@ -323,16 +332,25 @@ dest = client.get_destination("my-api", options=options, proxy_enabled=False)
 
 # Example 8: V2 API with level parameter for optimized lookup
 client = create_client(instance="default")
-# Search only at instance level
-dest = client.get_destination("my-api", level=Level.SERVICE_INSTANCE)
-# Search only at subaccount level
-dest = client.get_destination("my-api", level=Level.SUB_ACCOUNT)
-# No level specified - searches at instance level as default
+# Search only at provider subaccount level
+dest = client.get_destination("my-api", level=ConsumptionLevel.PROVIDER_SUBACCOUNT)
+# Search only at subscriber subaccount level
+dest = client.get_destination("my-api", level=ConsumptionLevel.SUBACCOUNT)
+# Search only at service instance level
+dest = client.get_destination("my-api", level=ConsumptionLevel.INSTANCE)
+# No level specified - API resolves automatically
 dest = client.get_destination("my-api")
 
 # Example 9: Combine level with options
 options = ConsumptionOptions(fragment_name="production", tenant="tenant-1")
-dest = client.get_destination("my-api", level=Level.SUB_ACCOUNT, options=options)
+dest = client.get_destination("my-api", level=ConsumptionLevel.SUBACCOUNT, options=options)
+
+# Example 9b: Fragment with level hint
+options = ConsumptionOptions(
+    fragment_name="my-fragment",
+    fragment_level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
+)
+dest = client.get_destination("my-api", options=options)
 
 # Example 10: Optional fragment (no error if fragment does not exist)
 options = ConsumptionOptions(fragment_name="maybe-exists", fragment_optional=True)

--- a/tests/destination/unit/test_client.py
+++ b/tests/destination/unit/test_client.py
@@ -10,6 +10,7 @@ from sap_cloud_sdk.destination._models import (
     Label,
     Level,
     AccessStrategy,
+    ConsumptionLevel,
     DestinationType,
     ListOptions,
     PatchLabels,
@@ -380,7 +381,7 @@ class TestDestinationClientReadOperations:
         assert result.auth_tokens[0].scope == "openid profile"
 
     def test_get_destination_with_level_instance(self):
-        """Test get_destination with level=SERVICE_INSTANCE uses @instance in path."""
+        """Test get_destination with level=INSTANCE uses @instance in path."""
         mock_http = MagicMock()
         resp = MagicMock(spec=Response)
         resp.status_code = 200
@@ -396,7 +397,7 @@ class TestDestinationClientReadOperations:
         mock_http.get.return_value = resp
 
         client = DestinationClient(mock_http)
-        result = client.get_destination("my-api", level=Level.SERVICE_INSTANCE)
+        result = client.get_destination("my-api", level=ConsumptionLevel.INSTANCE)
 
         assert result is not None
         assert result.name == "my-api"
@@ -406,7 +407,7 @@ class TestDestinationClientReadOperations:
         assert args[0] == "v2/destinations/my-api@instance"
 
     def test_get_destination_with_level_subaccount(self):
-        """Test get_destination with level=SUB_ACCOUNT uses @subaccount in path."""
+        """Test get_destination with level=SUBACCOUNT uses @subaccount in path."""
         mock_http = MagicMock()
         resp = MagicMock(spec=Response)
         resp.status_code = 200
@@ -422,7 +423,7 @@ class TestDestinationClientReadOperations:
         mock_http.get.return_value = resp
 
         client = DestinationClient(mock_http)
-        result = client.get_destination("my-api", level=Level.SUB_ACCOUNT)
+        result = client.get_destination("my-api", level=ConsumptionLevel.SUBACCOUNT)
 
         assert result is not None
         assert result.name == "my-api"
@@ -449,7 +450,7 @@ class TestDestinationClientReadOperations:
 
         client = DestinationClient(mock_http)
         options = ConsumptionOptions(fragment_name="production", tenant="tenant-1")
-        result = client.get_destination("my-api", level=Level.SUB_ACCOUNT, options=options)
+        result = client.get_destination("my-api", level=ConsumptionLevel.SUBACCOUNT, options=options)
 
         assert result is not None
 
@@ -458,6 +459,130 @@ class TestDestinationClientReadOperations:
         assert args[0] == "v2/destinations/my-api@subaccount"
         assert kwargs["headers"]["X-fragment-name"] == "production"
         assert kwargs["headers"]["X-tenant"] == "tenant-1"
+
+    def test_get_destination_with_level_provider_subaccount(self):
+        """Test get_destination with level=PROVIDER_SUBACCOUNT uses @provider_subaccount in path."""
+        mock_http = MagicMock()
+        resp = MagicMock(spec=Response)
+        resp.status_code = 200
+        resp.json.return_value = {
+            "destinationConfiguration": {
+                "name": "my-api",
+                "type": "HTTP",
+                "url": "https://api.example.com"
+            },
+            "authTokens": [],
+            "certificates": []
+        }
+        mock_http.get.return_value = resp
+
+        client = DestinationClient(mock_http)
+        result = client.get_destination("my-api", level=ConsumptionLevel.PROVIDER_SUBACCOUNT)
+
+        assert result is not None
+        args, kwargs = mock_http.get.call_args
+        assert args[0] == "v2/destinations/my-api@provider_subaccount"
+
+    def test_get_destination_with_level_provider_instance(self):
+        """Test get_destination with level=PROVIDER_INSTANCE uses @provider_instance in path."""
+        mock_http = MagicMock()
+        resp = MagicMock(spec=Response)
+        resp.status_code = 200
+        resp.json.return_value = {
+            "destinationConfiguration": {
+                "name": "my-api",
+                "type": "HTTP",
+                "url": "https://api.example.com"
+            },
+            "authTokens": [],
+            "certificates": []
+        }
+        mock_http.get.return_value = resp
+
+        client = DestinationClient(mock_http)
+        result = client.get_destination("my-api", level=ConsumptionLevel.PROVIDER_INSTANCE)
+
+        assert result is not None
+        args, kwargs = mock_http.get.call_args
+        assert args[0] == "v2/destinations/my-api@provider_instance"
+
+    def test_get_destination_with_fragment_level(self):
+        """Test that fragment_level appends @level to X-fragment-name header."""
+        mock_http = MagicMock()
+        resp = MagicMock(spec=Response)
+        resp.status_code = 200
+        resp.json.return_value = {
+            "destinationConfiguration": {
+                "name": "my-api",
+                "type": "HTTP",
+                "url": "https://api.example.com"
+            },
+            "authTokens": [],
+            "certificates": []
+        }
+        mock_http.get.return_value = resp
+
+        client = DestinationClient(mock_http)
+        options = ConsumptionOptions(
+            fragment_name="my-frag",
+            fragment_level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
+        )
+        result = client.get_destination("my-api", options=options)
+
+        assert result is not None
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["headers"]["X-fragment-name"] == "my-frag@provider_subaccount"
+
+    def test_get_destination_with_fragment_name_and_level_combined(self):
+        """Test fragment_name and fragment_level combine correctly into the header."""
+        mock_http = MagicMock()
+        resp = MagicMock(spec=Response)
+        resp.status_code = 200
+        resp.json.return_value = {
+            "destinationConfiguration": {
+                "name": "my-api",
+                "type": "HTTP",
+                "url": "https://api.example.com"
+            },
+            "authTokens": [],
+            "certificates": []
+        }
+        mock_http.get.return_value = resp
+
+        client = DestinationClient(mock_http)
+        options = ConsumptionOptions(
+            fragment_name="prod-frag",
+            fragment_level=ConsumptionLevel.INSTANCE,
+        )
+        result = client.get_destination("my-api", options=options)
+
+        assert result is not None
+        _, kwargs = mock_http.get.call_args
+        assert kwargs["headers"]["X-fragment-name"] == "prod-frag@instance"
+
+    def test_get_destination_fragment_level_without_fragment_name_has_no_effect(self):
+        """Test that fragment_level alone (no fragment_name) does not add X-fragment-name header."""
+        mock_http = MagicMock()
+        resp = MagicMock(spec=Response)
+        resp.status_code = 200
+        resp.json.return_value = {
+            "destinationConfiguration": {
+                "name": "my-api",
+                "type": "HTTP",
+                "url": "https://api.example.com"
+            },
+            "authTokens": [],
+            "certificates": []
+        }
+        mock_http.get.return_value = resp
+
+        client = DestinationClient(mock_http)
+        options = ConsumptionOptions(fragment_level=ConsumptionLevel.PROVIDER_INSTANCE)
+        result = client.get_destination("my-api", options=options)
+
+        assert result is not None
+        _, kwargs = mock_http.get.call_args
+        assert "X-fragment-name" not in kwargs["headers"]
 
     def test_get_destination_empty_auth_tokens_and_certificates(self):
         """Test consumption with no auth tokens or certificates."""

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Adds first-class `ConsumptionLevel` support to `get_destination` (v2 runtime API), eliminating the need for manual string concatenation when specifying a level hint for the destination name or fragment name.

Previously, consumers had to manually append `@<level>` to the destination or fragment name:
```python
dest = client.get_destination(f"{dest_name}@provider_subaccount", options=options)
```

After this change:
```python
dest = client.get_destination(dest_name, level=ConsumptionLevel.PROVIDER_SUBACCOUNT)
# or for fragment level:
dest = client.get_destination(dest_name, options=ConsumptionOptions(
    fragment_name="my-frag",
    fragment_level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
))
```

Changes:
- New `ConsumptionLevel` enum in `_models.py` with 4 values: `PROVIDER_SUBACCOUNT`, `PROVIDER_INSTANCE`, `SUBACCOUNT`, `INSTANCE`
- New `fragment_level: Optional[ConsumptionLevel]` field on `ConsumptionOptions`
- `get_destination` `level` parameter type changed from `Optional[Level]` to `Optional[ConsumptionLevel]`
- `ConsumptionLevel` exported from the top-level `sap_cloud_sdk.destination` package
- `user-guide.md` updated with new enum docs, updated API reference, and new usage examples
- 8 new unit tests; 3 existing level tests updated

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Install the package from this branch
2. Create a destination client: `client = create_client()`
3. Call `get_destination` with a `ConsumptionLevel` value:
   ```python
   from sap_cloud_sdk.destination import create_client, ConsumptionLevel, ConsumptionOptions

   client = create_client()

   # Level on destination name
   dest = client.get_destination("my-dest", level=ConsumptionLevel.PROVIDER_SUBACCOUNT)

   # Level on fragment name
   dest = client.get_destination("my-dest", options=ConsumptionOptions(
       fragment_name="my-frag",
       fragment_level=ConsumptionLevel.INSTANCE,
   ))
   ```
4. Verify the HTTP request path contains `@provider_subaccount` or the `X-fragment-name` header contains `my-frag@instance`
5. Run unit tests: `uv run pytest tests/destination/unit/test_client.py -v`

Expected result: all 136 unit tests pass; no `@level` suffix required in the destination name string.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. The `level` parameter type change from `Optional[Level]` to `Optional[ConsumptionLevel]` is a breaking change **only** if callers were already passing `Level.SERVICE_INSTANCE` or `Level.SUB_ACCOUNT` to `get_destination`. In practice this was not the intended usage (those values were incorrectly typed for a v2 API that uses different level strings), so the impact is considered minimal. Callers relying on the old behavior should migrate:

| Before | After |
|--------|-------|
| `level=Level.SERVICE_INSTANCE` | `level=ConsumptionLevel.INSTANCE` |
| `level=Level.SUB_ACCOUNT` | `level=ConsumptionLevel.SUBACCOUNT` |

## Additional Notes

The old `_map_level_to_api` private helper and the `_SUBACCOUNT_LEVEL`/`_INSTANCE_LEVEL` string constants in `client.py` were removed as they are no longer needed — `ConsumptionLevel.value` is already the correct API string.
