### PR TITLE
feat(secret-resolver): support SERVICE_BINDING_ROOT env var for binding discovery

### DIFF
--- a/src/sap_cloud_sdk/aicore/__init__.py
+++ b/src/sap_cloud_sdk/aicore/__init__.py
@@ -9,6 +9,7 @@ import logging
 import os
 from typing import Optional
 
+from sap_cloud_sdk.core.secret_resolver import resolve_base_mount
 from sap_cloud_sdk.core.telemetry.metrics_decorator import record_metrics
 from sap_cloud_sdk.core.telemetry.module import Module
 from sap_cloud_sdk.core.telemetry.operation import Operation
@@ -35,7 +36,7 @@ def _get_secret(
         instance_name: Name of the aicore instance defined in app.yaml. Defaults to aicore-instance
 
     """
-    secrets_base_path = f"/etc/secrets/appfnd/aicore/{instance_name}"
+    secrets_base_path = f"{resolve_base_mount('/etc/secrets/appfnd')}/aicore/{instance_name}"
     secret_file_name = file_name if file_name else env_var_name
     secret_file_path = os.path.join(secrets_base_path, secret_file_name)
 
@@ -70,7 +71,7 @@ def _get_aicore_base_url(instance_name: str = "aicore-instance") -> str:
     Returns:
         Base URL for AI Core service
     """
-    secrets_base_path = f"/etc/secrets/appfnd/aicore/{instance_name}"
+    secrets_base_path = f"{resolve_base_mount('/etc/secrets/appfnd')}/aicore/{instance_name}"
     serviceurls_file = os.path.join(secrets_base_path, "serviceurls")
 
     # Try reading from serviceurls file

--- a/src/sap_cloud_sdk/core/secret_resolver/__init__.py
+++ b/src/sap_cloud_sdk/core/secret_resolver/__init__.py
@@ -21,6 +21,6 @@ Usage:
     )
 """
 
-from .resolver import read_from_mount_and_fallback_to_env_var
+from .resolver import read_from_mount_and_fallback_to_env_var, resolve_base_mount
 
-__all__ = ["read_from_mount_and_fallback_to_env_var"]
+__all__ = ["read_from_mount_and_fallback_to_env_var", "resolve_base_mount"]

--- a/src/sap_cloud_sdk/core/secret_resolver/resolver.py
+++ b/src/sap_cloud_sdk/core/secret_resolver/resolver.py
@@ -7,6 +7,11 @@ from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Tuple
 
 
+def resolve_base_mount(default: str) -> str:
+    """Return SERVICE_BINDING_ROOT if set, otherwise the provided default."""
+    return os.environ.get("SERVICE_BINDING_ROOT", default)
+
+
 def _validate_inputs(module: str, instance: str) -> None:
     """Validate module and instance inputs."""
     if not isinstance(module, str) or not module.strip():
@@ -126,12 +131,13 @@ def read_from_mount_and_fallback_to_env_var(
     """
     _validate_inputs(module, instance)
 
+    resolved_base_path = resolve_base_mount(base_volume_mount)
     errors: list[str] = []
     normalized_module = module.replace("-", "_")
     normalized_instance = instance.replace("-", "_")
 
     try:
-        _load_from_mount(base_volume_mount, module, instance, target)
+        _load_from_mount(resolved_base_path, module, instance, target)
         return
     except Exception as e:
         errors.append(f"mount failed: {e};")
@@ -144,7 +150,7 @@ def read_from_mount_and_fallback_to_env_var(
 
     # Aggregate errors with actionable guidance for local dev and env fallback
     prefix_upper = f"{base_var_name}_{normalized_module}_{normalized_instance}".upper()
-    mount_dir = os.path.join(base_volume_mount, module, instance) + "/"
+    mount_dir = os.path.join(resolved_base_path, module, instance) + "/"
     guidance_parts: list[str] = []
     guidance_parts.append("Secrets could not be loaded from mount or environment.")
     guidance_parts.append("Options:")

--- a/src/sap_cloud_sdk/core/secret_resolver/user-guide.md
+++ b/src/sap_cloud_sdk/core/secret_resolver/user-guide.md
@@ -61,6 +61,18 @@ The Secret Resolver expects mounted secrets to follow this hierarchy:
         └── password
 ```
 
+### Base Path Resolution
+
+By default, the resolver looks for secrets under `/etc/secrets/appfnd`. You can override this by setting the `SERVICE_BINDING_ROOT` environment variable, which follows the [servicebinding.io](https://servicebinding.io) specification used across SAP SDKs and Kubernetes-native tooling.
+
+When `SERVICE_BINDING_ROOT` is set, it takes precedence over the default `/etc/secrets/appfnd` path:
+
+```bash
+export SERVICE_BINDING_ROOT=/bindings
+```
+
+With this set, the resolver looks for secrets at `$SERVICE_BINDING_ROOT/<module>/<instance>/<field>` instead of `/etc/secrets/appfnd/<module>/<instance>/<field>`.
+
 Example for the above configuration:
 ```
 /etc/secrets/appfnd

--- a/tests/core/unit/secret_resolver/unit/test_secret_resolver.py
+++ b/tests/core/unit/secret_resolver/unit/test_secret_resolver.py
@@ -185,3 +185,33 @@ class TestSecretResolver:
         assert config.username == "env_user_hyphen"
         assert config.password == "env_pass_hyphen"
         assert config.endpoint == "env_endpoint_hyphen"
+
+    @patch.dict(os.environ, {"SERVICE_BINDING_ROOT": "/custom/root"})
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.stat')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_service_binding_root_overrides_base_mount(self, mock_file, mock_stat, mock_isdir):
+        mock_file.side_effect = [
+            mock_open(read_data="u").return_value,
+            mock_open(read_data="p").return_value,
+            mock_open(read_data="e").return_value,
+        ]
+        config = SampleConfig()
+        read_from_mount_and_fallback_to_env_var("/etc/secrets/appfnd", "VAR", "module", "instance", config)
+        first_call_path = mock_file.call_args_list[0][0][0]
+        assert first_call_path.startswith("/custom/root")
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch('os.path.isdir', return_value=True)
+    @patch('os.stat')
+    @patch('builtins.open', new_callable=mock_open)
+    def test_default_base_mount_used_when_no_service_binding_root(self, mock_file, mock_stat, mock_isdir):
+        mock_file.side_effect = [
+            mock_open(read_data="u").return_value,
+            mock_open(read_data="p").return_value,
+            mock_open(read_data="e").return_value,
+        ]
+        config = SampleConfig()
+        read_from_mount_and_fallback_to_env_var("/etc/secrets/appfnd", "VAR", "module", "instance", config)
+        first_call_path = mock_file.call_args_list[0][0][0]
+        assert first_call_path.startswith("/etc/secrets/appfnd")

--- a/uv.lock
+++ b/uv.lock
@@ -2398,7 +2398,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Adds support for the [`SERVICE_BINDING_ROOT`](https://servicebinding.io/spec/core/1.1.0/) environment variable as a configurable base path for service binding discovery, aligning the Python Cloud SDK with the servicebinding.io spec and other SAP SDKs (Java).

- Introduces a public `resolve_base_mount(default)` helper in `resolver.py` that returns `SERVICE_BINDING_ROOT` if set, otherwise falls back to the provided default (`/etc/secrets/appfnd`)
- Wires `resolve_base_mount` into `read_from_mount_and_fallback_to_env_var()` so all callers (destination, objectstore, auditlog, dms) benefit automatically without any changes at call sites
- Exports `resolve_base_mount` from `sap_cloud_sdk.core.secret_resolver` so other modules can reuse the same logic
- Updates `aicore/__init__.py` to import and use `resolve_base_mount` instead of a hardcoded path
- Documents the `SERVICE_BINDING_ROOT` env var in the secret resolver user guide
- Adds two unit tests covering the override and fallback behaviour

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Set `SERVICE_BINDING_ROOT=/some/custom/path` in the environment
2. Call any service that uses the secret resolver (e.g. objectstore, destination)
3. Verify the resolver looks for secrets under `/some/custom/path/<module>/<instance>/` instead of `/etc/secrets/appfnd/`
4. Unset `SERVICE_BINDING_ROOT` and verify it falls back to `/etc/secrets/appfnd`
5. Run unit tests: `uv run pytest tests/core/unit/secret_resolver/ tests/aicore/ -m "not integration" -q`

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. `SERVICE_BINDING_ROOT` is opt-in — when not set, behaviour is identical to before.

## Additional Notes

The `resolve_base_mount` function is exported publicly so that modules with custom secret resolution logic (like `aicore`) can reuse the same `SERVICE_BINDING_ROOT` lookup without duplicating the env var read.
