### PR TITLE
fix(telemetry): constrain wrapt<2 so LangChain instrumentor loads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,14 @@ dependencies = [
     "grpcio>=1.60.0",
     "opentelemetry-api>=1.28.0",
     "opentelemetry-sdk>=1.28.0",
+    # Constrain wrapt to 1.x: opentelemetry-instrumentation-langchain (pulled
+    # via traceloop-sdk) calls wrap_function_wrapper(module=..., name=..., wrapper=...).
+    # wrapt 2.x removed the `module` keyword, causing the LangChain instrumentor
+    # initialization to fail at import time, which silently disables LangChain /
+    # LangGraph spans for any consumer using auto_instrument(). Remove this pin
+    # once a fixed opentelemetry-instrumentation-langchain release is published
+    # upstream (traceloop/openllmetry) and pinned by traceloop-sdk. See #91.
+    "wrapt<2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2418,6 +2418,7 @@ dependencies = [
     { name = "requests-oauthlib" },
     { name = "setuptools" },
     { name = "traceloop-sdk" },
+    { name = "wrapt" },
 ]
 
 [package.optional-dependencies]
@@ -2459,6 +2460,7 @@ requires-dist = [
     { name = "setuptools", specifier = "~=80.9.0" },
     { name = "starlette", marker = "extra == 'starlette'", specifier = ">=0.40.0" },
     { name = "traceloop-sdk", specifier = "~=0.54.0" },
+    { name = "wrapt", specifier = "<2" },
 ]
 provides-extras = ["starlette"]
 


### PR DESCRIPTION
Closes #91

## Summary

`opentelemetry-instrumentation-langchain` (pulled in via `traceloop-sdk~=0.54.0`) calls `wrap_function_wrapper(module=..., name=..., wrapper=...)`. `wrapt 2.x` removed the `module` keyword, so the LangChain instrumentor initialization fails with:

```
ERROR:root:Error initializing LangChain instrumentor: wrap_function_wrapper() got an unexpected keyword argument 'module'
```

`Traceloop.init` swallows the exception and the rest of the OTel pipeline (other instrumentors, exporters, baggage processor) keeps working — but **no LangChain / LangGraph spans are emitted** for any consumer using `auto_instrument()`. The breakage is silent, so it usually only surfaces as ‘why aren’t my LangGraph spans showing up?’.

This adds an interim constraint `wrapt<2` to `pyproject.toml` so the SDK pulls a `wrapt 1.x` (e.g. `1.17.x`) where `wrap_function_wrapper(module=...)` is still accepted. After this change, `auto_instrument()` cleanly initializes the LangChain instrumentor and downstream agents see chain / node / graph spans again.

The constraint should be removed once `opentelemetry-instrumentation-langchain` ships a release that switches to positional args (`wrap_function_wrapper(target, name, wrapper)`) and `traceloop-sdk` pins it. See #91 for the upstream tracking notes.

## Test plan

- [ ] `uv lock` resolves with `wrapt 1.17.x` (locally verified — only `wrapt` line is added to `uv.lock`).
- [ ] In a fresh venv with this SDK + `langchain` + `langgraph` installed, calling `auto_instrument()` no longer logs `Error initializing LangChain instrumentor`.
- [ ] LangChain / LangGraph spans are visible in the configured OTLP backend (verified locally against an MLflow OTLP receiver: chain / node spans appear after a single agent invocation).

## Notes

- No code path changes. Only dependency constraint + comment in `pyproject.toml` and the resulting line in `uv.lock`.
- I left the unrelated `version = "0.14.0" -> "0.14.1"` lockfile bump that `uv lock` proposed out of this PR to keep the diff focused.
- Happy to switch the constraint to a different shape if a maintainer prefers (e.g. `wrapt<2,>=1.17`, or scoped to an extra rather than the core dependency list).

Made with [Cursor](https://cursor.com)