### PR TITLE
refactor(secret-resolver)!: refactor to use constants for base path and env var prefix

### DIFF
--- a/src/sap_cloud_sdk/core/auditlog/config.py
+++ b/src/sap_cloud_sdk/core/auditlog/config.py
@@ -109,11 +109,7 @@ def _load_config_from_env() -> AuditLogConfig:
         binding_data: BindingData = BindingData("", "")
 
         read_from_mount_and_fallback_to_env_var(
-            base_volume_mount="/etc/secrets/appfnd",
-            base_var_name="CLOUD_SDK_CFG",
-            module="auditlog",
-            instance="default",
-            target=binding_data,
+            module="auditlog", instance="default", target=binding_data
         )
 
         binding_data.validate()

--- a/src/sap_cloud_sdk/core/secret_resolver/constants.py
+++ b/src/sap_cloud_sdk/core/secret_resolver/constants.py
@@ -3,3 +3,4 @@ Constants for secret resolver module.
 """
 
 BASE_MOUNT_PATH = "/etc/secrets/appfnd"
+CLOUD_SDK_ENV_PREFIX = "CLOUD_SDK_CFG"

--- a/src/sap_cloud_sdk/core/secret_resolver/resolver.py
+++ b/src/sap_cloud_sdk/core/secret_resolver/resolver.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import fields, is_dataclass
 from typing import Any, Dict, Tuple
-from .constants import BASE_MOUNT_PATH
+from .constants import BASE_MOUNT_PATH, CLOUD_SDK_ENV_PREFIX
 
 
 def resolve_base_mount(base_volume_mount: str = BASE_MOUNT_PATH) -> str:
@@ -125,11 +125,11 @@ def _load_from_env(base_var_name: str, module: str, instance: str, target: Any) 
 
 
 def read_from_mount_and_fallback_to_env_var(
-    base_volume_mount: str,
-    base_var_name: str,
     module: str,
     instance: str,
     target: Any,
+    base_volume_mount: str = BASE_MOUNT_PATH,
+    base_var_name: str = CLOUD_SDK_ENV_PREFIX,
 ) -> None:
     """
     Load secrets for a given module and instance into the provided dataclass instance `target`.

--- a/src/sap_cloud_sdk/destination/config.py
+++ b/src/sap_cloud_sdk/destination/config.py
@@ -132,8 +132,6 @@ def load_from_env_or_mount(instance: Optional[str] = None) -> DestinationConfig:
         # 1) Try mount at /etc/secrets/appfnd/destination/{instance}/...
         # 2) Fallback to env: CLOUD_SDK_CFG_DESTINATION_{INSTANCE}_{FIELD_KEY}
         read_from_mount_and_fallback_to_env_var(
-            base_volume_mount="/etc/secrets/appfnd",
-            base_var_name="CLOUD_SDK_CFG",
             module="destination",
             instance=inst,
             target=binding,

--- a/src/sap_cloud_sdk/dms/config.py
+++ b/src/sap_cloud_sdk/dms/config.py
@@ -121,8 +121,6 @@ def load_sdm_config_from_env_or_mount(instance: Optional[str] = None) -> DMSCred
         # 1) Try mount at /etc/secrets/appfnd/destination/{instance}/...
         # 2) Fallback to env: CLOUD_SDK_CFG_SDM_{INSTANCE}_{FIELD_KEY}
         read_from_mount_and_fallback_to_env_var(
-            base_volume_mount="/etc/secrets/appfnd",
-            base_var_name="CLOUD_SDK_CFG",
             module="sdm",
             instance=inst,
             target=binding,

--- a/src/sap_cloud_sdk/objectstore/__init__.py
+++ b/src/sap_cloud_sdk/objectstore/__init__.py
@@ -54,8 +54,6 @@ def create_client(
     # Cloud mode: use secret resolver to load configuration
     config = ObjectStoreBindingData()
     read_from_mount_and_fallback_to_env_var(
-        base_volume_mount="/etc/secrets/appfnd",
-        base_var_name="CLOUD_SDK_CFG",
         module="objectstore",
         instance=instance,
         target=config,

--- a/tests/core/unit/auditlog/unit/test_config.py
+++ b/tests/core/unit/auditlog/unit/test_config.py
@@ -216,8 +216,6 @@ class TestLoadConfigFromEnv:
         assert config.service_url == "https://service.example.com"
 
         mock_read.assert_called_once_with(
-            base_volume_mount="/etc/secrets/appfnd",
-            base_var_name="CLOUD_SDK_CFG",
             module="auditlog",
             instance="default",
             target=mock_read.call_args.kwargs["target"]

--- a/tests/core/unit/secret_resolver/unit/test_secret_resolver.py
+++ b/tests/core/unit/secret_resolver/unit/test_secret_resolver.py
@@ -25,21 +25,21 @@ class TestSecretResolver:
     def test_validate_inputs_empty_module(self):
         config = SampleConfig()
         with pytest.raises(ValueError, match="module name cannot be empty"):
-            read_from_mount_and_fallback_to_env_var("/path", "VAR", "", "instance", config)
+            read_from_mount_and_fallback_to_env_var("", "instance", config, base_volume_mount="/path", base_var_name="VAR")
 
     def test_validate_inputs_empty_instance(self):
         config = SampleConfig()
         with pytest.raises(ValueError, match="instance name cannot be empty"):
-            read_from_mount_and_fallback_to_env_var("/path", "VAR", "module", "", config)
+            read_from_mount_and_fallback_to_env_var("module", "", config, base_volume_mount="/path", base_var_name="VAR")
 
     def test_non_dataclass_target(self):
         with pytest.raises(RuntimeError, match="failed to read secrets.*target must be a dataclass instance"):
-            read_from_mount_and_fallback_to_env_var("/path", "VAR", "module", "instance", "not_dataclass")
+            read_from_mount_and_fallback_to_env_var("module", "instance", "not_dataclass", base_volume_mount="/path", base_var_name="VAR")
 
     def test_non_string_field_error(self):
         config = NonStringConfig()
         with pytest.raises(RuntimeError, match="failed to read secrets.*is not a string"):
-            read_from_mount_and_fallback_to_env_var("/path", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/path", base_var_name="VAR")
 
     @patch('os.path.isdir', return_value=True)
     @patch('os.stat')
@@ -52,7 +52,7 @@ class TestSecretResolver:
         ]
 
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/secrets", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/secrets", base_var_name="VAR")
 
         assert config.username == "test_user"
         assert config.password == "test_pass"
@@ -64,20 +64,20 @@ class TestSecretResolver:
     def test_load_from_mount_file_not_found(self, mock_file, mock_stat, mock_isdir):
         config = SampleConfig()
         with pytest.raises(RuntimeError, match="failed to read secrets.*failed to read secret file"):
-            read_from_mount_and_fallback_to_env_var("/secrets", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/secrets", base_var_name="VAR")
 
     @patch('os.stat', side_effect=FileNotFoundError("Path not found"))
     def test_validate_path_not_exists(self, mock_stat):
         config = SampleConfig()
         with pytest.raises(RuntimeError, match="mount failed"):
-            read_from_mount_and_fallback_to_env_var("/nonexistent", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/nonexistent", base_var_name="VAR")
 
     @patch('os.path.isdir', return_value=False)
     @patch('os.stat')
     def test_validate_path_not_directory(self, mock_stat, mock_isdir):
         config = SampleConfig()
         with pytest.raises(RuntimeError, match="mount failed"):
-            read_from_mount_and_fallback_to_env_var("/file", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/file", base_var_name="VAR")
 
     @patch.dict(os.environ, {
         "VAR_MODULE_INSTANCE_USER": "env_user",
@@ -88,7 +88,7 @@ class TestSecretResolver:
         config = SampleConfig()
         with patch('os.path.isdir', return_value=False), \
              patch('os.stat', side_effect=FileNotFoundError()):
-            read_from_mount_and_fallback_to_env_var("/nonexistent", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/nonexistent", base_var_name="VAR")
 
         assert config.username == "env_user"
         assert config.password == "env_pass"
@@ -100,7 +100,7 @@ class TestSecretResolver:
         with patch('os.path.isdir', return_value=False), \
              patch('os.stat', side_effect=FileNotFoundError()):
             with pytest.raises(RuntimeError, match="env var failed"):
-                read_from_mount_and_fallback_to_env_var("/nonexistent", "VAR", "module", "instance", config)
+                read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/nonexistent", base_var_name="VAR")
 
     @patch('os.path.isdir', return_value=True)
     @patch('os.stat')
@@ -113,7 +113,7 @@ class TestSecretResolver:
         ]
 
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/secrets", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/secrets", base_var_name="VAR")
 
         assert config.username == "mount_user"
 
@@ -123,7 +123,7 @@ class TestSecretResolver:
         with patch('os.path.isdir', return_value=False), \
              patch('os.stat', side_effect=FileNotFoundError()):
             with pytest.raises(RuntimeError, match="mount failed.*env var failed"):
-                read_from_mount_and_fallback_to_env_var("/nonexistent", "VAR", "module", "instance", config)
+                read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/nonexistent", base_var_name="VAR")
 
     @patch('os.path.isdir', return_value=True)
     @patch('os.stat')
@@ -136,7 +136,7 @@ class TestSecretResolver:
         ]
 
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/secrets", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/secrets", base_var_name="VAR")
 
         assert config.username == "user\nwith\nnewlines"
 
@@ -149,7 +149,7 @@ class TestSecretResolver:
         config = CaseConfig()
         with patch('os.path.isdir', return_value=False), \
              patch('os.stat', side_effect=FileNotFoundError()):
-            read_from_mount_and_fallback_to_env_var("/nonexistent", "VAR", "module", "instance", config)
+            read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/nonexistent", base_var_name="VAR")
 
         assert config.testfield == "test_value"
 
@@ -164,7 +164,7 @@ class TestSecretResolver:
         ]
 
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/secrets", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/secrets", base_var_name="VAR")
 
         assert config.username == "metadata_user"
 
@@ -179,7 +179,7 @@ class TestSecretResolver:
         with patch('os.path.isdir', return_value=False), \
              patch('os.stat', side_effect=FileNotFoundError()):
             read_from_mount_and_fallback_to_env_var(
-                "/nonexistent", "VAR", "module", "my-instance", config
+                "module", "my-instance", config, base_volume_mount="/nonexistent", base_var_name="VAR"
             )
 
         assert config.username == "env_user_hyphen"
@@ -197,7 +197,7 @@ class TestSecretResolver:
             mock_open(read_data="e").return_value,
         ]
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/etc/secrets/appfnd", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/etc/secrets/appfnd", base_var_name="VAR")
         first_call_path = mock_file.call_args_list[0][0][0]
         assert first_call_path.startswith("/custom/root")
 
@@ -212,6 +212,6 @@ class TestSecretResolver:
             mock_open(read_data="e").return_value,
         ]
         config = SampleConfig()
-        read_from_mount_and_fallback_to_env_var("/etc/secrets/appfnd", "VAR", "module", "instance", config)
+        read_from_mount_and_fallback_to_env_var("module", "instance", config, base_volume_mount="/etc/secrets/appfnd", base_var_name="VAR")
         first_call_path = mock_file.call_args_list[0][0][0]
         assert first_call_path.startswith("/etc/secrets/appfnd")

--- a/tests/destination/unit/test_config.py
+++ b/tests/destination/unit/test_config.py
@@ -126,8 +126,6 @@ class TestLoadFromEnvOrMount:
         # Verify resolver called with expected parameters
         assert mock_read.call_count == 1
         _, kwargs = mock_read.call_args
-        assert kwargs["base_volume_mount"] == "/etc/secrets/appfnd"
-        assert kwargs["base_var_name"] == "CLOUD_SDK_CFG"
         assert kwargs["module"] == "destination"
         assert kwargs["instance"] == "default"
         assert isinstance(kwargs["target"], BindingData)


### PR DESCRIPTION
## Description

Reorders `read_from_mount_and_fallback_to_env_var` parameters so `module`, `instance`, and `target` come first, and makes `base_volume_mount`/`base_var_name` optional kwargs with constant defaults.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring

## How to Test

1. Run the unit tests: `uv run pytest -m "not integration" -q`
2. Verify callers no longer need to pass `base_volume_mount` or `base_var_name`:
   ```python
   from sap_cloud_sdk.core.secret_resolver import read_from_mount_and_fallback_to_env_var
   read_from_mount_and_fallback_to_env_var(module="myservice", instance="default", target=cfg)
   ```
3. Verify overrides still work via keyword arguments:
   ```python
   read_from_mount_and_fallback_to_env_var(
       "myservice", "default", cfg,
       base_volume_mount="/custom/path",
       base_var_name="MY_PREFIX",
   )
   ```

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

- **`read_from_mount_and_fallback_to_env_var` parameter reorder**: The first two positional parameters changed from `(base_volume_mount, base_var_name, module, instance, target)` to `(module, instance, target, base_volume_mount=..., base_var_name=...)`. Any caller that used positional arguments must be updated.

  **Migration**: Update call sites to the new positional order, or switch to keyword arguments:
  ```python
  # Before
  read_from_mount_and_fallback_to_env_var("/etc/secrets/appfnd", "CLOUD_SDK_CFG", "mymod", "inst", cfg)

  # After (keyword args — most explicit)
  read_from_mount_and_fallback_to_env_var(module="mymod", instance="inst", target=cfg)

  # After (custom path via kwargs)
  read_from_mount_and_fallback_to_env_var("mymod", "inst", cfg, base_volume_mount="/custom", base_var_name="MY_PREFIX")
  ```

