### PR TITLE
chore(release): bump version to v0.18.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.18.0"
+version = "0.18.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2924,7 +2924,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.18.0"
+version = "0.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Summary

- Bumps version `0.18.0` → `0.18.1`
- Locks `uv.lock` to new version

Patch release for the PyJWT CVE fix landed in #107.