### PR TITLE
feat(agentgateway): make timeout configurable and increase default timeout value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.18.2"
+version = "0.19.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/__init__.py
+++ b/src/sap_cloud_sdk/agentgateway/__init__.py
@@ -53,6 +53,7 @@ Usage (Customer agent):
 """
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.agw_client import create_client, AgentGatewayClient
 from sap_cloud_sdk.agentgateway.exceptions import (
     AgentGatewaySDKError,
@@ -65,6 +66,8 @@ __all__ = [
     "create_client",
     # Client class
     "AgentGatewayClient",
+    # Configuration
+    "ClientConfig",
     # Data models
     "MCPTool",
     # Exceptions

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -35,9 +35,6 @@ _CREDENTIALS_PATH_ENV = "AGW_CREDENTIALS_PATH"
 # Default credential path for Kyma production deployments
 _CREDENTIALS_DEFAULT_PATH = "/etc/ums/credentials/credentials"
 
-# HTTP timeout for token requests and MCP server calls (seconds)
-_HTTP_TIMEOUT = 60.0
-
 # Resource URN for Agent Gateway token scope (hardcoded - production value)
 _AGW_RESOURCE_URN = "urn:sap:identity:application:provider:name:agent-gateway"
 
@@ -213,6 +210,7 @@ def _create_ssl_context(certificate: str, private_key: str) -> ssl.SSLContext:
 def _request_token_mtls(
     credentials: CustomerCredentials,
     grant_type: str,
+    timeout: float,
     app_tid: str | None = None,
     extra_data: dict | None = None,
 ) -> str:
@@ -255,7 +253,7 @@ def _request_token_mtls(
     try:
         with httpx.Client(
             verify=ssl_context,
-            timeout=_HTTP_TIMEOUT,
+            timeout=timeout,
         ) as client:
             response = client.post(
                 credentials.token_service_url,
@@ -293,6 +291,7 @@ def _request_token_mtls(
 
 def get_system_token_mtls(
     credentials: CustomerCredentials,
+    timeout: float,
     app_tid: str | None = None,
 ) -> str:
     """Get system-scoped token using mTLS client credentials flow.
@@ -301,6 +300,7 @@ def get_system_token_mtls(
 
     Args:
         credentials: Customer credentials.
+        timeout: HTTP timeout in seconds.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
     Returns:
@@ -310,6 +310,7 @@ def get_system_token_mtls(
     return _request_token_mtls(
         credentials,
         grant_type=_GRANT_TYPE_CLIENT_CREDENTIALS,
+        timeout=timeout,
         app_tid=app_tid,
         extra_data={"response_type": "token"},
     )
@@ -318,6 +319,7 @@ def get_system_token_mtls(
 def exchange_user_token(
     credentials: CustomerCredentials,
     user_token: str,
+    timeout: float,
     app_tid: str | None = None,
 ) -> str:
     """Exchange user token for AGW-scoped token using jwt-bearer grant.
@@ -328,6 +330,7 @@ def exchange_user_token(
     Args:
         credentials: Customer credentials.
         user_token: User's JWT token to exchange.
+        timeout: HTTP timeout in seconds.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
     Returns:
@@ -337,6 +340,7 @@ def exchange_user_token(
     return _request_token_mtls(
         credentials,
         grant_type=_GRANT_TYPE_JWT_BEARER,
+        timeout=timeout,
         app_tid=app_tid,
         extra_data={
             "assertion": user_token,
@@ -371,7 +375,7 @@ async def _list_server_tools(
     url: str,
     auth_token: str,
     dependency: IntegrationDependency,
-    timeout: float = _HTTP_TIMEOUT,
+    timeout: float,
 ) -> list[MCPTool]:
     """List tools from a single MCP server.
 
@@ -428,8 +432,8 @@ async def _list_server_tools(
 
 async def get_mcp_tools_customer(
     credentials: CustomerCredentials,
+    timeout: float,
     app_tid: str | None = None,
-    timeout: float = _HTTP_TIMEOUT,
 ) -> list[MCPTool]:
     """List all MCP tools from servers defined in credentials.
 
@@ -458,7 +462,7 @@ async def get_mcp_tools_customer(
     # Get system token for discovery
     loop = asyncio.get_running_loop()
     system_token = await loop.run_in_executor(
-        None, get_system_token_mtls, credentials, app_tid
+        None, get_system_token_mtls, credentials, timeout, app_tid
     )
 
     tools: list[MCPTool] = []
@@ -489,8 +493,8 @@ async def call_mcp_tool_customer(
     credentials: CustomerCredentials,
     tool: MCPTool,
     user_token: str | None,
+    timeout: float,
     app_tid: str | None = None,
-    timeout: float = _HTTP_TIMEOUT,
     **kwargs,
 ) -> str:
     """Invoke an MCP tool using customer flow.
@@ -516,7 +520,7 @@ async def call_mcp_tool_customer(
     if user_token:
         # Exchange user token for AGW-scoped token (with principal propagation)
         agw_token = await loop.run_in_executor(
-            None, exchange_user_token, credentials, user_token, app_tid
+            None, exchange_user_token, credentials, user_token, timeout, app_tid
         )
     else:
         # TODO: IBD workaround - use system token when user_token is not available.
@@ -527,7 +531,7 @@ async def call_mcp_tool_customer(
             "Principal propagation will NOT work."
         )
         agw_token = await loop.run_in_executor(
-            None, get_system_token_mtls, credentials, app_tid
+            None, get_system_token_mtls, credentials, timeout, app_tid
         )
 
     async with httpx.AsyncClient(

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -36,7 +36,7 @@ _CREDENTIALS_PATH_ENV = "AGW_CREDENTIALS_PATH"
 _CREDENTIALS_DEFAULT_PATH = "/etc/ums/credentials/credentials"
 
 # HTTP timeout for token requests and MCP server calls (seconds)
-_HTTP_TIMEOUT = 30.0
+_HTTP_TIMEOUT = 60.0
 
 # Resource URN for Agent Gateway token scope (hardcoded - production value)
 _AGW_RESOURCE_URN = "urn:sap:identity:application:provider:name:agent-gateway"
@@ -371,6 +371,7 @@ async def _list_server_tools(
     url: str,
     auth_token: str,
     dependency: IntegrationDependency,
+    timeout: float = _HTTP_TIMEOUT,
 ) -> list[MCPTool]:
     """List tools from a single MCP server.
 
@@ -390,7 +391,7 @@ async def _list_server_tools(
             "Authorization": f"Bearer {auth_token}",
             "x-correlation-id": str(uuid.uuid4()),
         },
-        timeout=_HTTP_TIMEOUT,
+        timeout=timeout,
     ) as http_client:
         async with streamable_http_client(url, http_client=http_client) as (
             read,
@@ -428,6 +429,7 @@ async def _list_server_tools(
 async def get_mcp_tools_customer(
     credentials: CustomerCredentials,
     app_tid: str | None = None,
+    timeout: float = _HTTP_TIMEOUT,
 ) -> list[MCPTool]:
     """List all MCP tools from servers defined in credentials.
 
@@ -471,7 +473,7 @@ async def get_mcp_tools_customer(
         )
 
         try:
-            server_tools = await _list_server_tools(url, system_token, dep)
+            server_tools = await _list_server_tools(url, system_token, dep, timeout)
             tools.extend(server_tools)
             logger.debug("Loaded %d tool(s) from %s", len(server_tools), dep.ord_id)
         except Exception:
@@ -488,6 +490,7 @@ async def call_mcp_tool_customer(
     tool: MCPTool,
     user_token: str | None,
     app_tid: str | None = None,
+    timeout: float = _HTTP_TIMEOUT,
     **kwargs,
 ) -> str:
     """Invoke an MCP tool using customer flow.
@@ -532,7 +535,7 @@ async def call_mcp_tool_customer(
             "Authorization": f"Bearer {agw_token}",
             "x-correlation-id": str(uuid.uuid4()),
         },
-        timeout=_HTTP_TIMEOUT,
+        timeout=timeout,
     ) as http_client:
         async with streamable_http_client(tool.url, http_client=http_client) as (
             read,

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -36,9 +36,6 @@ _IAS_LABEL_VALUE = "subscriber.ias"
 
 _DESTINATION_INSTANCE = "default"
 
-# HTTP timeout for MCP server requests (seconds)
-_HTTP_TIMEOUT = 60.0
-
 
 def _ias_dest_name() -> str:
     """Get IAS destination name based on landscape.
@@ -227,7 +224,7 @@ async def get_user_auth(
 
 
 async def list_server_tools(
-    dest_url: str, system_auth: str, fragment_name: str, timeout: float = _HTTP_TIMEOUT
+    dest_url: str, system_auth: str, fragment_name: str, timeout: float
 ) -> list[MCPTool]:
     """List tools from a single MCP server.
 
@@ -273,7 +270,7 @@ async def list_server_tools(
 
 async def get_mcp_tools_lob(
     tenant_subdomain: str,
-    timeout: float = _HTTP_TIMEOUT,
+    timeout: float,
 ) -> list[MCPTool]:
     """List all MCP tools using LoB flow (destination-based).
 
@@ -333,7 +330,7 @@ async def call_mcp_tool_lob(
     tool: MCPTool,
     user_token: str,
     tenant_subdomain: str,
-    timeout: float = _HTTP_TIMEOUT,
+    timeout: float,
     **kwargs,
 ) -> str:
     """Invoke an MCP tool using LoB flow (destination-based).

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -37,7 +37,7 @@ _IAS_LABEL_VALUE = "subscriber.ias"
 _DESTINATION_INSTANCE = "default"
 
 # HTTP timeout for MCP server requests (seconds)
-_HTTP_TIMEOUT = 30.0
+_HTTP_TIMEOUT = 60.0
 
 
 def _ias_dest_name() -> str:
@@ -227,7 +227,7 @@ async def get_user_auth(
 
 
 async def list_server_tools(
-    dest_url: str, system_auth: str, fragment_name: str
+    dest_url: str, system_auth: str, fragment_name: str, timeout: float = _HTTP_TIMEOUT
 ) -> list[MCPTool]:
     """List tools from a single MCP server.
 
@@ -241,7 +241,7 @@ async def list_server_tools(
     """
     async with httpx.AsyncClient(
         headers={"Authorization": system_auth, "x-correlation-id": str(uuid.uuid4())},
-        timeout=_HTTP_TIMEOUT,
+        timeout=timeout,
     ) as http_client:
         async with streamable_http_client(dest_url, http_client=http_client) as (
             read,
@@ -273,6 +273,7 @@ async def list_server_tools(
 
 async def get_mcp_tools_lob(
     tenant_subdomain: str,
+    timeout: float = _HTTP_TIMEOUT,
 ) -> list[MCPTool]:
     """List all MCP tools using LoB flow (destination-based).
 
@@ -309,7 +310,7 @@ async def get_mcp_tools_lob(
 
         try:
             system_auth = await get_system_auth(tenant_subdomain)
-            server_tools = await list_server_tools(mcp_url, system_auth, fragment_name)
+            server_tools = await list_server_tools(mcp_url, system_auth, fragment_name, timeout)
             tools.extend(server_tools)
             logger.debug(
                 "Loaded %d tool(s) from fragment '%s'",
@@ -330,6 +331,7 @@ async def call_mcp_tool_lob(
     tool: MCPTool,
     user_token: str,
     tenant_subdomain: str,
+    timeout: float = _HTTP_TIMEOUT,
     **kwargs,
 ) -> str:
     """Invoke an MCP tool using LoB flow (destination-based).
@@ -357,7 +359,7 @@ async def call_mcp_tool_lob(
 
     async with httpx.AsyncClient(
         headers={"Authorization": user_auth, "x-correlation-id": str(uuid.uuid4())},
-        timeout=_HTTP_TIMEOUT,
+        timeout=timeout,
     ) as http_client:
         async with streamable_http_client(tool.url, http_client=http_client) as (
             read,

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -310,7 +310,9 @@ async def get_mcp_tools_lob(
 
         try:
             system_auth = await get_system_auth(tenant_subdomain)
-            server_tools = await list_server_tools(mcp_url, system_auth, fragment_name, timeout)
+            server_tools = await list_server_tools(
+                mcp_url, system_auth, fragment_name, timeout
+            )
             tools.extend(server_tools)
             logger.debug(
                 "Loaded %d tool(s) from fragment '%s'",

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -158,7 +158,7 @@ class AgentGatewayClient:
                 )
                 credentials = load_customer_credentials(credentials_path)
                 return await get_mcp_tools_customer(
-                    credentials, app_tid, self._config.timeout
+                    credentials, self._config.timeout, app_tid
                 )
 
             # LoB flow - requires tenant_subdomain
@@ -250,8 +250,8 @@ class AgentGatewayClient:
                     credentials,
                     tool,
                     resolved_user_token,
-                    app_tid,
                     self._config.timeout,
+                    app_tid,
                     **kwargs,
                 )
 

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -11,6 +11,7 @@ import logging
 from typing import Callable
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway._customer import (
     detect_customer_agent_credentials,
     load_customer_credentials,
@@ -72,7 +73,7 @@ class AgentGatewayClient:
     def __init__(
         self,
         tenant_subdomain: str | Callable[[], str] | None = None,
-        timeout: float = 60.0,
+        config: ClientConfig | None = None,
     ):
         """Initialize the Agent Gateway client.
 
@@ -80,11 +81,10 @@ class AgentGatewayClient:
             tenant_subdomain: Tenant subdomain for multi-tenant lookup.
                 Can be a string or a callable returning a string.
                 Required for LoB agents, ignored for Customer agents.
-            timeout: HTTP timeout in seconds for token requests and MCP server calls.
-                Defaults to 60 seconds.
+            config: Client configuration. Uses defaults if not provided.
         """
         self._tenant_subdomain = tenant_subdomain
-        self._timeout = timeout
+        self._config = config or ClientConfig()
 
     @staticmethod
     def _resolve_value(
@@ -157,14 +157,16 @@ class AgentGatewayClient:
                     "Customer agent credentials detected at '%s'", credentials_path
                 )
                 credentials = load_customer_credentials(credentials_path)
-                return await get_mcp_tools_customer(credentials, app_tid, self._timeout)
+                return await get_mcp_tools_customer(
+                    credentials, app_tid, self._config.timeout
+                )
 
             # LoB flow - requires tenant_subdomain
             if app_tid:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await get_mcp_tools_lob(tenant, self._timeout)
+            return await get_mcp_tools_lob(tenant, self._config.timeout)
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is
@@ -249,7 +251,7 @@ class AgentGatewayClient:
                     tool,
                     resolved_user_token,
                     app_tid,
-                    self._timeout,
+                    self._config.timeout,
                     **kwargs,
                 )
 
@@ -264,7 +266,7 @@ class AgentGatewayClient:
 
             tenant = self._resolve_tenant_subdomain()
             return await call_mcp_tool_lob(
-                tool, resolved_user_token, tenant, self._timeout, **kwargs
+                tool, resolved_user_token, tenant, self._config.timeout, **kwargs
             )
 
         except AgentGatewaySDKError:
@@ -287,7 +289,7 @@ def _unwrap_exception_group(exc: BaseException) -> BaseException:
 
 def create_client(
     tenant_subdomain: str | Callable[[], str] | None = None,
-    timeout: float = 60.0,
+    config: ClientConfig | None = None,
 ) -> AgentGatewayClient:
     """Create an Agent Gateway client for discovering and invoking MCP tools.
 
@@ -298,8 +300,7 @@ def create_client(
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
             Can be a string or a callable returning a string.
             Required for LoB agents, ignored for Customer agents.
-        timeout: HTTP timeout in seconds for token requests and MCP server calls.
-            Defaults to 60 seconds.
+        config: Client configuration. Uses defaults if not provided.
 
     Returns:
         AgentGatewayClient instance.
@@ -342,4 +343,4 @@ def create_client(
         )
         ```
     """
-    return AgentGatewayClient(tenant_subdomain=tenant_subdomain, timeout=timeout)
+    return AgentGatewayClient(tenant_subdomain=tenant_subdomain, config=config)

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -72,6 +72,7 @@ class AgentGatewayClient:
     def __init__(
         self,
         tenant_subdomain: str | Callable[[], str] | None = None,
+        timeout: float = 60.0,
     ):
         """Initialize the Agent Gateway client.
 
@@ -79,8 +80,11 @@ class AgentGatewayClient:
             tenant_subdomain: Tenant subdomain for multi-tenant lookup.
                 Can be a string or a callable returning a string.
                 Required for LoB agents, ignored for Customer agents.
+            timeout: HTTP timeout in seconds for token requests and MCP server calls.
+                Defaults to 60 seconds.
         """
         self._tenant_subdomain = tenant_subdomain
+        self._timeout = timeout
 
     @staticmethod
     def _resolve_value(
@@ -153,14 +157,14 @@ class AgentGatewayClient:
                     "Customer agent credentials detected at '%s'", credentials_path
                 )
                 credentials = load_customer_credentials(credentials_path)
-                return await get_mcp_tools_customer(credentials, app_tid)
+                return await get_mcp_tools_customer(credentials, app_tid, self._timeout)
 
             # LoB flow - requires tenant_subdomain
             if app_tid:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await get_mcp_tools_lob(tenant)
+            return await get_mcp_tools_lob(tenant, self._timeout)
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is
@@ -240,7 +244,7 @@ class AgentGatewayClient:
 
                 credentials = load_customer_credentials(credentials_path)
                 return await call_mcp_tool_customer(
-                    credentials, tool, resolved_user_token, app_tid, **kwargs
+                    credentials, tool, resolved_user_token, app_tid, self._timeout, **kwargs
                 )
 
             # LoB flow - requires user_token and tenant_subdomain
@@ -253,7 +257,7 @@ class AgentGatewayClient:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await call_mcp_tool_lob(tool, resolved_user_token, tenant, **kwargs)
+            return await call_mcp_tool_lob(tool, resolved_user_token, tenant, self._timeout, **kwargs)
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is
@@ -267,6 +271,7 @@ class AgentGatewayClient:
 
 def create_client(
     tenant_subdomain: str | Callable[[], str] | None = None,
+    timeout: float = 60.0,
 ) -> AgentGatewayClient:
     """Create an Agent Gateway client for discovering and invoking MCP tools.
 
@@ -277,6 +282,8 @@ def create_client(
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
             Can be a string or a callable returning a string.
             Required for LoB agents, ignored for Customer agents.
+        timeout: HTTP timeout in seconds for token requests and MCP server calls.
+            Defaults to 60 seconds.
 
     Returns:
         AgentGatewayClient instance.
@@ -319,4 +326,4 @@ def create_client(
         )
         ```
     """
-    return AgentGatewayClient(tenant_subdomain=tenant_subdomain)
+    return AgentGatewayClient(tenant_subdomain=tenant_subdomain, timeout=timeout)

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -278,7 +278,7 @@ class AgentGatewayClient:
             ) from e
 
 
-def _unwrap_exception_group(exc: Exception) -> Exception:
+def _unwrap_exception_group(exc: BaseException) -> BaseException:
     """Unwrap nested ExceptionGroups to present meaningful error messages."""
     while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
         exc = exc.exceptions[0]

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -171,7 +171,8 @@ class AgentGatewayClient:
             raise
         except Exception as e:
             logger.exception("Unexpected error during tool discovery")
-            raise AgentGatewaySDKError(f"Tool discovery failed: {e}") from e
+            cause = _unwrap_exception_group(e)
+            raise AgentGatewaySDKError(f"Tool discovery failed: {cause}") from e
 
     @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_CALL_MCP_TOOL)
     async def call_mcp_tool(
@@ -264,9 +265,17 @@ class AgentGatewayClient:
             raise
         except Exception as e:
             logger.exception("Unexpected error during tool invocation")
+            cause = _unwrap_exception_group(e)
             raise AgentGatewaySDKError(
-                f"Tool invocation failed for '{tool.name}': {e}"
+                f"Tool invocation failed for '{tool.name}': {cause}"
             ) from e
+
+
+def _unwrap_exception_group(exc: Exception) -> Exception:
+    """Unwrap nested ExceptionGroups to present meaningful error messages."""
+    while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
+        exc = exc.exceptions[0]
+    return exc
 
 
 def create_client(

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -245,7 +245,12 @@ class AgentGatewayClient:
 
                 credentials = load_customer_credentials(credentials_path)
                 return await call_mcp_tool_customer(
-                    credentials, tool, resolved_user_token, app_tid, self._timeout, **kwargs
+                    credentials,
+                    tool,
+                    resolved_user_token,
+                    app_tid,
+                    self._timeout,
+                    **kwargs,
                 )
 
             # LoB flow - requires user_token and tenant_subdomain
@@ -258,7 +263,9 @@ class AgentGatewayClient:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await call_mcp_tool_lob(tool, resolved_user_token, tenant, self._timeout, **kwargs)
+            return await call_mcp_tool_lob(
+                tool, resolved_user_token, tenant, self._timeout, **kwargs
+            )
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is

--- a/src/sap_cloud_sdk/agentgateway/config.py
+++ b/src/sap_cloud_sdk/agentgateway/config.py
@@ -2,6 +2,8 @@
 
 from dataclasses import dataclass
 
+DEFAULT_TIMEOUT_SECONDS = 60.0
+
 
 @dataclass
 class ClientConfig:
@@ -12,4 +14,4 @@ class ClientConfig:
             Defaults to 60 seconds.
     """
 
-    timeout: float = 60.0
+    timeout: float = DEFAULT_TIMEOUT_SECONDS

--- a/src/sap_cloud_sdk/agentgateway/config.py
+++ b/src/sap_cloud_sdk/agentgateway/config.py
@@ -1,0 +1,15 @@
+"""Configuration for Agent Gateway client."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ClientConfig:
+    """Configuration options for the Agent Gateway client.
+
+    Attributes:
+        timeout: HTTP timeout in seconds for token requests and MCP server calls.
+            Defaults to 60 seconds.
+    """
+
+    timeout: float = 60.0

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -165,7 +165,7 @@ class TestListMcpTools:
 
             await agw_client.list_mcp_tools()
 
-            mock_lob.assert_called_once_with("my-tenant")
+            mock_lob.assert_called_once_with("my-tenant", 60.0)
 
     @pytest.mark.asyncio
     async def test_calls_lob_flow(self):
@@ -185,7 +185,7 @@ class TestListMcpTools:
 
             await agw_client.list_mcp_tools()
 
-            mock_lob.assert_called_once_with("my-tenant")
+            mock_lob.assert_called_once_with("my-tenant", 60.0)
 
     @pytest.mark.asyncio
     async def test_returns_tools_from_lob_flow(self):
@@ -306,7 +306,7 @@ class TestCallMcpTool:
 
             assert result == "result"
             mock_lob.assert_called_once_with(
-                mock_tool, "my-jwt", "my-tenant", param1="value1"
+                mock_tool, "my-jwt", "my-tenant", 60.0, param1="value1"
             )
 
     @pytest.mark.asyncio
@@ -332,7 +332,7 @@ class TestCallMcpTool:
             )
 
             assert result == "result"
-            mock_lob.assert_called_once_with(mock_tool, "my-jwt", "my-tenant")
+            mock_lob.assert_called_once_with(mock_tool, "my-jwt", "my-tenant", 60.0)
 
     @pytest.mark.asyncio
     async def test_customer_credentials_calls_customer_flow(self, mock_tool):
@@ -386,7 +386,7 @@ class TestCallMcpTool:
 
             assert result == "tool result"
             mock_lob.assert_called_once_with(
-                mock_tool, "jwt-token", "my-tenant", order_id="12345"
+                mock_tool, "jwt-token", "my-tenant", 60.0, order_id="12345"
             )
 
     @pytest.mark.asyncio

--- a/tests/agentgateway/unit/test_config.py
+++ b/tests/agentgateway/unit/test_config.py
@@ -1,0 +1,28 @@
+"""Unit tests for ClientConfig."""
+
+from sap_cloud_sdk.agentgateway import ClientConfig, create_client
+
+
+class TestClientConfig:
+    """Tests for ClientConfig dataclass."""
+
+    def test_default_values(self):
+        """ClientConfig has sensible defaults."""
+        config = ClientConfig()
+        assert config.timeout == 60.0
+
+    def test_custom_timeout(self):
+        """ClientConfig accepts custom timeout."""
+        config = ClientConfig(timeout=120.0)
+        assert config.timeout == 120.0
+
+    def test_create_client_with_config(self):
+        """create_client accepts a ClientConfig."""
+        config = ClientConfig(timeout=90.0)
+        client = create_client(config=config)
+        assert client._config.timeout == 90.0
+
+    def test_create_client_without_config_uses_defaults(self):
+        """create_client uses default config when none provided."""
+        client = create_client()
+        assert client._config.timeout == 60.0

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -305,7 +305,7 @@ class TestGetSystemTokenMtls:
             mock_client.post.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = get_system_token_mtls(credentials)
+            result = get_system_token_mtls(credentials, timeout=60.0)
 
             assert result == "system-token-123"
             mock_client.post.assert_called_once()
@@ -332,7 +332,7 @@ class TestGetSystemTokenMtls:
             mock_client_class.return_value = mock_client
 
             with pytest.raises(AgentGatewaySDKError, match="Token request failed"):
-                get_system_token_mtls(credentials)
+                get_system_token_mtls(credentials, timeout=60.0)
 
 
 # ============================================================
@@ -374,7 +374,7 @@ class TestExchangeUserToken:
             mock_client.post.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = exchange_user_token(credentials, "user-jwt-token")
+            result = exchange_user_token(credentials, "user-jwt-token", timeout=60.0)
 
             assert result == "exchanged-token-123"
             call_args = mock_client.post.call_args
@@ -402,7 +402,9 @@ class TestExchangeUserToken:
             mock_client.post.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = exchange_user_token(credentials, "user-jwt", app_tid="test-tid")
+            result = exchange_user_token(
+                credentials, "user-jwt", timeout=60.0, app_tid="test-tid"
+            )
 
             assert result == "token-with-tid"
             call_args = mock_client.post.call_args
@@ -449,7 +451,7 @@ class TestGetMcpToolsCustomer:
         with pytest.raises(
             AgentGatewaySDKError, match="integrationDependencies is empty"
         ):
-            await get_mcp_tools_customer(credentials)
+            await get_mcp_tools_customer(credentials, timeout=60.0)
 
     @pytest.mark.asyncio
     async def test_discovers_tools_from_credentials(self, credentials):
@@ -475,7 +477,7 @@ class TestGetMcpToolsCustomer:
                 return_value=mock_tools,
             ) as mock_list,
         ):
-            result = await get_mcp_tools_customer(credentials)
+            result = await get_mcp_tools_customer(credentials, timeout=60.0)
 
             assert len(result) == 1
             assert result[0].name == "list_cost_centers"
@@ -523,7 +525,7 @@ class TestGetMcpToolsCustomer:
                 side_effect=mock_list_tools,
             ),
         ):
-            result = await get_mcp_tools_customer(credentials)
+            result = await get_mcp_tools_customer(credentials, timeout=60.0)
 
             # Should still return tools from server2
             assert len(result) == 1
@@ -613,11 +615,11 @@ class TestCallMcpToolCustomer:
             mock_session_class.return_value = mock_session_ctx
 
             result = await call_mcp_tool_customer(
-                credentials, mock_tool, "user-jwt", order_id="12345"
+                credentials, mock_tool, "user-jwt", 60.0, order_id="12345"
             )
 
             assert result == "Order created successfully"
-            mock_exchange.assert_called_once_with(credentials, "user-jwt", None)
+            mock_exchange.assert_called_once_with(credentials, "user-jwt", 60.0, None)
 
     @pytest.mark.asyncio
     async def test_uses_system_token_when_user_token_not_provided(
@@ -669,10 +671,10 @@ class TestCallMcpToolCustomer:
 
             # Call without user_token (None)
             result = await call_mcp_tool_customer(
-                credentials, mock_tool, None, order_id="12345"
+                credentials, mock_tool, None, 60.0, order_id="12345"
             )
 
             assert result == "Result with system token"
             # Should use system token, not exchange
-            mock_system_token.assert_called_once_with(credentials, None)
+            mock_system_token.assert_called_once_with(credentials, 60.0, None)
             mock_exchange.assert_not_called()

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -323,7 +323,7 @@ class TestGetMcpToolsLob:
         with patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list:
             mock_list.return_value = []
 
-            result = await get_mcp_tools_lob("tenant-sub")
+            result = await get_mcp_tools_lob("tenant-sub", 60.0)
 
             assert result == []
 
@@ -337,7 +337,7 @@ class TestGetMcpToolsLob:
         with patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list:
             mock_list.return_value = [fragment]
 
-            result = await get_mcp_tools_lob("tenant-sub")
+            result = await get_mcp_tools_lob("tenant-sub", 60.0)
 
             assert result == []
 
@@ -372,7 +372,7 @@ class TestGetMcpToolsLob:
             mock_auth.return_value = "Bearer token"
             mock_tools.return_value = [mock_tool]
 
-            await get_mcp_tools_lob("tenant-sub")
+            await get_mcp_tools_lob("tenant-sub", 60.0)
 
             # Verify get_system_auth called with just tenant_subdomain
             mock_auth.assert_called_once_with("tenant-sub")
@@ -418,7 +418,7 @@ class TestGetMcpToolsLob:
             mock_auth.side_effect = [Exception("Auth failed"), "Bearer token"]
             mock_tools.return_value = [mock_tool]
 
-            result = await get_mcp_tools_lob("tenant-sub")
+            result = await get_mcp_tools_lob("tenant-sub", 60.0)
 
             # Should still get tools from second fragment
             assert len(result) == 1
@@ -477,7 +477,7 @@ class TestCallMcpToolLob:
             mock_session.return_value.__aenter__.return_value = mock_session_instance
 
             result = await call_mcp_tool_lob(
-                tool, "user-jwt", "tenant-sub", param1="value1"
+                tool, "user-jwt", "tenant-sub", 60.0, param1="value1"
             )
 
             assert result == "Tool result"
@@ -527,6 +527,6 @@ class TestCallMcpToolLob:
             mock_session_instance.call_tool = AsyncMock(return_value=mock_result)
             mock_session.return_value.__aenter__.return_value = mock_session_instance
 
-            result = await call_mcp_tool_lob(tool, "user-jwt", "tenant-sub")
+            result = await call_mcp_tool_lob(tool, "user-jwt", "tenant-sub", 60.0)
 
             assert result == ""

--- a/uv.lock
+++ b/uv.lock
@@ -2924,7 +2924,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.18.2"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
## Description

Increases the timeout value to 60s as a more reasonable default. 

The PR makes timeouts configurable for edge cases.

Also, added changes to unwrap `ExceptionGroup` from async task groups to surface meaningful error messages                                              
(e.g., `"MCP Builder destination request failed"` instead of `"unhandled errors in a TaskGroup"`) 

## Type of Change

Please check the relevant option:

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update


## Checklist

Before submitting your PR, please review and check the following:

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [ ] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [ ] I have added type hints for all public APIs
- [ ] My code does not contain sensitive information (credentials, tokens, etc.)
- [ ] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages


