### PR TITLE
chore: add permissions section to workflow YAML files

### DIFF
--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check-version-bump:
     name: Enforce version bump when src/ is modified

--- a/.github/workflows/commit-validation.yaml
+++ b/.github/workflows/commit-validation.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   commit-validation:
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}

--- a/.github/workflows/proto-verify.yaml
+++ b/.github/workflows/proto-verify.yaml
@@ -15,6 +15,9 @@ on:
       - 'src/sap_cloud_sdk/core/auditlog_ng/proto/**'
       - 'Makefile'
 
+permissions:
+  contents: read
+
 jobs:
   verify-proto:
     name: Verify generated proto code is up-to-date

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -6,6 +6,9 @@ on:
       - main
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     name: Publish to Artifactory

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   check-reuse-compliance:
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '0 */3 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ["self-hosted"]


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Add explicit `permissions:` blocks to all GitHub Actions workflows that were missing them, following the [principle of least privilege](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for `GITHUB_TOKEN`.

Each workflow was audited for write-access requirements:

- `check-version-bump.yaml`, `commit-validation.yaml`, `proto-verify.yaml`, `release-internal.yml`, `reuse.yaml` — read-only operations only; set to `contents: read`
- `sync.yaml` — performs `git push` to the internal mirror repository using `GITHUB_TOKEN` as a fallback; set to `contents: write`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Dependency update

## How to Test

1. Merge this PR
2. Trigger any of the affected workflows (e.g. open a pull request against `main` to run `check-version-bump`, `commit-validation`, `proto-verify`, `release-internal`, `reuse`)
3. Verify all workflows complete successfully — no permission-denied errors
4. After merge, go to Repository → Settings → Actions → General → Workflow permissions and switch to **"Read repository contents and packages permissions"**
5. Re-trigger the workflows and confirm they still pass

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [ ] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

This is a CI-only change with no impact on the published package or its public API. The version bump to `0.19.1` reflects the infrastructure maintenance.

After this PR is merged, the final step (switching the repo default to read-only) must be done manually in GitHub repository settings by an administrator.
