### PR TITLE
feat: propagate W3C baggage headers into OTel context

### DIFF
--- a/src/sap_cloud_sdk/core/telemetry/middleware/starlette_a2a.py
+++ b/src/sap_cloud_sdk/core/telemetry/middleware/starlette_a2a.py
@@ -3,6 +3,7 @@
 import logging
 from contextvars import ContextVar
 from typing import Any, Dict
+from opentelemetry import context as otel_context, propagate
 
 from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_SAP_TRIGGER_TYPE,
@@ -32,9 +33,12 @@ class _IASMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Any) -> Response:
         token = self._attrs_var.set(_extract_ias_attrs(request))
+        ctx = propagate.extract(request.headers)
+        ctx_token = otel_context.attach(ctx)
         try:
             return await call_next(request)
         finally:
+            otel_context.detach(ctx_token)
             self._attrs_var.reset(token)
 
 


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

When using auto_instrument(middlewares=[StarletteIASTelemetryMiddleware(...)]), W3C baggage headers from incoming HTTP requests were not visible on spans, as baggage is not extracted from the request headers into the OTel context. This PR fixes it.

## Related Issue

Closes #87  

(Link to the GitHub issue this PR addresses)

## Type of Change

Please check the relevant option:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

Describe how reviewers can test your changes:

1. Step 1
2. Step 2
3. Expected result

## Checklist

Before submitting your PR, please review and check the following:

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [ ] All tests pass locally
- [ ] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [ ] I have added type hints for all public APIs
- [ ] My code does not contain sensitive information (credentials, tokens, etc.)
- [ ] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

If this PR introduces breaking changes, please describe:

- What breaks
- Migration path for users
- Alternative approaches considered

## Additional Notes

Add any additional context, screenshots, or information that would help reviewers.
