### PR TITLE
fix(extensibility): use ConsumptionLevel for UMS destination lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.19.2"
+version = "0.19.3"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.19.1"
+version = "0.19.2"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/extensibility/_ums_transport.py
+++ b/src/sap_cloud_sdk/extensibility/_ums_transport.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import httpx
 
-from sap_cloud_sdk.destination import Level
+from sap_cloud_sdk.destination import ConsumptionLevel
 from sap_cloud_sdk.destination import create_client as create_destination_client
 from sap_cloud_sdk.extensibility._models import (
     DEFAULT_EXTENSION_CAPABILITY_ID,
@@ -540,7 +540,8 @@ class UmsTransport:
         # 1. Resolve destination -----------------------------------------
         try:
             dest = self._dest_client.get_destination(
-                self._destination_name, level=Level.SUB_ACCOUNT
+                self._destination_name,
+                level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
             )
         except Exception as exc:
             raise TransportError(

--- a/uv.lock
+++ b/uv.lock
@@ -2924,7 +2924,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.19.2"
+version = "0.19.3"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
The UMS transport passes `Level.SUB_ACCOUNT` to `get_destination()`, which appends `@SUB_ACCOUNT` to the URL path. The Destination Service V2 API rejects this with HTTP 400 because it expects lowercase level hints.

`get_destination()` accepts `ConsumptionLevel`, not `Level`:

| Enum | Value | URL suffix | Result |
|------|-------|-----------|--------|
| `Level.SUB_ACCOUNT` | `"SUB_ACCOUNT"` | `@SUB_ACCOUNT` | HTTP 400 |
| `ConsumptionLevel.PROVIDER_SUBACCOUNT` | `"provider_subaccount"` | `@provider_subaccount` | OK |
| `ConsumptionLevel.SUBACCOUNT` | `"subaccount"` | `@subaccount` | OK |

This uses `PROVIDER_SUBACCOUNT` since UMS destinations are provisioned in the provider subaccount.