### PR TITLE
chore: release v0.19.3 with extensibility fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.19.2"
+version = "0.19.3"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/extensions.py
+++ b/src/sap_cloud_sdk/core/telemetry/extensions.py
@@ -252,7 +252,7 @@ def resolve_source_info(
     fields when the key is not found in the mapping.
 
     Args:
-        key: Lookup key in the source mapping (e.g. prefixed tool name or
+        key: Lookup key in the source mapping (e.g. tool name or
             hook ID).
         source_mapping: Mapping of keys to source info objects or dicts.
             May be ``None``.
@@ -417,10 +417,8 @@ async def call_extension_tool(
     mcp_client: Any,
     tool_name: str,
     args: dict[str, Any],
-    extension_name: str,
     capability: str = "default",
     source_mapping: dict[str, Any] | None = None,
-    tool_prefix: str = "",
 ) -> Any:
     """Call an MCP tool with telemetry instrumentation.
 
@@ -432,23 +430,25 @@ async def call_extension_tool(
     Args:
         mcp_client: The MCP client session connected to the tool's server.
             Must have an async ``call_tool(name, args)`` method.
-        tool_name: The raw MCP tool name (before any prefixing).
+        tool_name: The raw MCP tool name (e.g. ``"create_ticket"``), used
+            as the lookup key in *source_mapping* and passed directly to
+            ``mcp_client.call_tool()``.
         args: Dictionary of arguments to pass to the tool.
-        extension_name: Human-readable name of the extension.  Used as
-            fallback when *source_mapping* does not contain the tool.
         capability: Extension capability ID (default: ``"default"``).
-        source_mapping: Optional mapping of prefixed tool names to source
-            info objects (from ``ext_impl.source.tools``).
-        tool_prefix: The tool prefix (e.g. ``"sap_mcp_servicenow_v1_"``).
-            Used to reconstruct the lookup key for *source_mapping*.
+        source_mapping: Optional mapping of tool names to
+            :class:`~sap_cloud_sdk.extensibility.ExtensionSourceInfo`
+            objects (from ``ext_impl.source.tools``).  Keys must match the
+            *tool_name* values passed to this function.
+            See :class:`~sap_cloud_sdk.extensibility.ExtensionSourceMapping`.
 
     Returns:
         The tool's response from the MCP server.
-    """
-    lookup_key = tool_prefix + tool_name if tool_prefix else tool_name
 
+    See Also:
+        :func:`call_extension_hook` for hook-based extensions.
+    """
     resolved_name, resolved_id, resolved_version, resolved_url, resolved_solution_id = (
-        resolve_source_info(lookup_key, source_mapping, extension_name)
+        resolve_source_info(tool_name, source_mapping, "unknown")
     )
 
     attrs = build_extension_span_attributes(

--- a/src/sap_cloud_sdk/extensibility/_models.py
+++ b/src/sap_cloud_sdk/extensibility/_models.py
@@ -489,15 +489,15 @@ class ExtensionSourceMapping:
     Returned by the extensibility backend when multiple extensions are merged
     into a single capability implementation response.
 
-    Tool keys are prefixed tool names
-    (e.g., ``"sap_mcp_servicenow_v1_create_ticket"``).
+    Tool keys are raw tool names
+    (e.g., ``"create_ticket"``).
     Hook keys are hook IDs (UUIDs) (e.g.,
     ``"3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e"``).
     Values are :class:`ExtensionSourceInfo` objects containing the extension's
     name, version, and unique identifier.
 
     Attributes:
-        tools: Mapping of prefixed tool name to extension source info.
+        tools: Mapping of tool name to extension source info.
         hooks: Mapping of hook ID to extension source info.
     """
 
@@ -512,7 +512,7 @@ class ExtensionSourceMapping:
 
             {
                 "tools": {
-                    "sap_mcp_taxvalidator_validate_validate_tax": {
+                    "validate_tax": {
                         "extensionName": "ap-invoice-extension",
                         "extensionVersion": "1",
                         "extensionId": "a1b2c3d4-..."
@@ -679,7 +679,7 @@ class ExtensionCapabilityImplementation:
                 ],
                 "source": {
                     "tools": {
-                        "sap_mcp_servicenow_v1_create_ticket": {
+                        "create_ticket": {
                             "extensionName": "servicenow-ext",
                             "extensionVersion": "1",
                             "extensionId": "abc-123"
@@ -740,8 +740,8 @@ class ExtensionCapabilityImplementation:
         """Look up the extension name that contributed a specific tool.
 
         Args:
-            tool_name: The prefixed tool name (e.g.,
-                ``"sap_mcp_servicenow_v1_create_ticket"``).
+            tool_name: The tool name (e.g.,
+                ``"create_ticket"``).
 
         Returns:
             Extension name, or ``None`` if source mapping is not available
@@ -774,8 +774,8 @@ class ExtensionCapabilityImplementation:
         ``None`` when source mapping is not available or the tool is not found.
 
         Args:
-            tool_name: The prefixed tool name (e.g.,
-                ``"sap_mcp_servicenow_v1_create_ticket"``).
+            tool_name: The tool name (e.g.,
+                ``"create_ticket"``).
 
         Returns:
             :class:`ExtensionSourceInfo` for the tool, or ``None``.

--- a/src/sap_cloud_sdk/extensibility/_ums_transport.py
+++ b/src/sap_cloud_sdk/extensibility/_ums_transport.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import httpx
 
-from sap_cloud_sdk.destination import Level
+from sap_cloud_sdk.destination import ConsumptionLevel
 from sap_cloud_sdk.destination import create_client as create_destination_client
 from sap_cloud_sdk.extensibility._models import (
     DEFAULT_EXTENSION_CAPABILITY_ID,
@@ -540,7 +540,8 @@ class UmsTransport:
         # 1. Resolve destination -----------------------------------------
         try:
             dest = self._dest_client.get_destination(
-                self._destination_name, level=Level.SUB_ACCOUNT
+                self._destination_name,
+                level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
             )
         except Exception as exc:
             raise TransportError(

--- a/tests/core/unit/telemetry/test_extensions.py
+++ b/tests/core/unit/telemetry/test_extensions.py
@@ -902,7 +902,6 @@ class TestCallExtensionTool:
                 mcp_client=mock_client,
                 tool_name="create_ticket",
                 args={"title": "Bug"},
-                extension_name="ServiceNow",
             )
             assert result == "result-123"
             mock_client.call_tool.assert_awaited_once_with(
@@ -921,20 +920,32 @@ class TestCallExtensionTool:
                 extension_id: str
                 extension_version: str
 
-            mapping = {"prefix_tool1": FakeSourceInfo("Mapped Ext", "uuid-m", "7")}
+            mapping = {"create_ticket": FakeSourceInfo("Mapped Ext", "uuid-m", "7")}
             mock_client = AsyncMock()
             mock_client.call_tool.return_value = "ok"
 
             reset_tool_call_metrics()
-            result = await call_extension_tool(
-                mcp_client=mock_client,
-                tool_name="tool1",
-                args={},
-                extension_name="Fallback",
-                source_mapping=mapping,
-                tool_prefix="prefix_",
-            )
-            assert result == "ok"
+            with patch(
+                "sap_cloud_sdk.core.telemetry.extensions._tracer"
+            ) as mock_tracer:
+                mock_tracer.start_as_current_span = MagicMock(
+                    return_value=MagicMock(
+                        __enter__=MagicMock(), __exit__=MagicMock(return_value=False)
+                    )
+                )
+                result = await call_extension_tool(
+                    mcp_client=mock_client,
+                    tool_name="create_ticket",
+                    args={},
+                    source_mapping=mapping,
+                )
+                assert result == "ok"
+                call_args = mock_tracer.start_as_current_span.call_args
+                attrs = call_args[1]["attributes"]
+                assert attrs[ATTR_EXTENSION_NAME] == "Mapped Ext"
+                assert attrs[ATTR_EXTENSION_ID] == "uuid-m"
+                assert attrs[ATTR_EXTENSION_VERSION] == "7"
+                assert attrs[ATTR_EXTENSION_ITEM_NAME] == "create_ticket"
 
         asyncio.run(_run())
 
@@ -949,7 +960,6 @@ class TestCallExtensionTool:
                     mcp_client=mock_client,
                     tool_name="t",
                     args={},
-                    extension_name="E",
                 )
             count, _ = get_tool_call_metrics()
             assert count == 1  # Duration still recorded

--- a/tests/extensibility/unit/test_models.py
+++ b/tests/extensibility/unit/test_models.py
@@ -740,12 +740,12 @@ class TestExtensionSourceMapping:
         """Parse a complete source mapping from backend JSON (new format)."""
         data = {
             "tools": {
-                "sap_mcp_servicenow_v1_create_ticket": {
+                "create_ticket": {
                     "extensionName": "servicenow-ext",
                     "extensionVersion": "2",
                     "extensionId": "uuid-sn",
                 },
-                "sap_mcp_jira_v1_create_issue": {
+                "create_issue": {
                     "extensionName": "jira-ext",
                     "extensionVersion": "1",
                     "extensionId": "uuid-jira",
@@ -765,21 +765,10 @@ class TestExtensionSourceMapping:
             },
         }
         mapping = ExtensionSourceMapping.from_dict(data)
-        assert (
-            mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_name
-            == "servicenow-ext"
-        )
-        assert (
-            mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_version
-            == "2"
-        )
-        assert (
-            mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_id
-            == "uuid-sn"
-        )
-        assert (
-            mapping.tools["sap_mcp_jira_v1_create_issue"].extension_name == "jira-ext"
-        )
+        assert mapping.tools["create_ticket"].extension_name == "servicenow-ext"
+        assert mapping.tools["create_ticket"].extension_version == "2"
+        assert mapping.tools["create_ticket"].extension_id == "uuid-sn"
+        assert mapping.tools["create_issue"].extension_name == "jira-ext"
         assert (
             mapping.hooks["3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e"].extension_name
             == "workflow-ext"
@@ -793,21 +782,16 @@ class TestExtensionSourceMapping:
         """Parse old format where values are plain strings."""
         data = {
             "tools": {
-                "sap_mcp_servicenow_v1_create_ticket": "servicenow-ext",
+                "create_ticket": "servicenow-ext",
             },
             "hooks": {
                 "3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e": "workflow-ext",
             },
         }
         mapping = ExtensionSourceMapping.from_dict(data)
-        assert (
-            mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_name
-            == "servicenow-ext"
-        )
-        assert (
-            mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_version == ""
-        )
-        assert mapping.tools["sap_mcp_servicenow_v1_create_ticket"].extension_id == ""
+        assert mapping.tools["create_ticket"].extension_name == "servicenow-ext"
+        assert mapping.tools["create_ticket"].extension_version == ""
+        assert mapping.tools["create_ticket"].extension_id == ""
         assert (
             mapping.hooks["3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e"].extension_name
             == "workflow-ext"
@@ -823,7 +807,7 @@ class TestExtensionSourceMapping:
         """Parse with only tools key present."""
         data = {
             "tools": {
-                "prefix_tool": {
+                "my_tool": {
                     "extensionName": "my-ext",
                     "extensionVersion": "1",
                     "extensionId": "id-1",
@@ -831,7 +815,7 @@ class TestExtensionSourceMapping:
             }
         }
         mapping = ExtensionSourceMapping.from_dict(data)
-        assert mapping.tools["prefix_tool"].extension_name == "my-ext"
+        assert mapping.tools["my_tool"].extension_name == "my-ext"
         assert mapping.hooks == {}
 
     def test_from_dict_only_hooks(self):
@@ -902,7 +886,7 @@ class TestExtensionCapabilityImplementationSource:
             ],
             "source": {
                 "tools": {
-                    "sap_mcp_servicenow_v1_create_ticket": {
+                    "create_ticket": {
                         "extensionName": "servicenow-ext",
                         "extensionVersion": "2",
                         "extensionId": "uuid-sn",
@@ -919,18 +903,9 @@ class TestExtensionCapabilityImplementationSource:
         }
         impl = ExtensionCapabilityImplementation.from_dict(data)
         assert impl.source is not None
-        assert (
-            impl.source.tools["sap_mcp_servicenow_v1_create_ticket"].extension_name
-            == "servicenow-ext"
-        )
-        assert (
-            impl.source.tools["sap_mcp_servicenow_v1_create_ticket"].extension_version
-            == "2"
-        )
-        assert (
-            impl.source.tools["sap_mcp_servicenow_v1_create_ticket"].extension_id
-            == "uuid-sn"
-        )
+        assert impl.source.tools["create_ticket"].extension_name == "servicenow-ext"
+        assert impl.source.tools["create_ticket"].extension_version == "2"
+        assert impl.source.tools["create_ticket"].extension_id == "uuid-sn"
         assert (
             impl.source.hooks["3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e"].extension_name
             == "workflow-ext"
@@ -942,20 +917,14 @@ class TestExtensionCapabilityImplementationSource:
             "capabilityId": "default",
             "mcpServers": [],
             "source": {
-                "tools": {"sap_mcp_servicenow_v1_create_ticket": "servicenow-ext"},
+                "tools": {"create_ticket": "servicenow-ext"},
                 "hooks": {"3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e": "workflow-ext"},
             },
         }
         impl = ExtensionCapabilityImplementation.from_dict(data)
         assert impl.source is not None
-        assert (
-            impl.source.tools["sap_mcp_servicenow_v1_create_ticket"].extension_name
-            == "servicenow-ext"
-        )
-        assert (
-            impl.source.tools["sap_mcp_servicenow_v1_create_ticket"].extension_version
-            == ""
-        )
+        assert impl.source.tools["create_ticket"].extension_name == "servicenow-ext"
+        assert impl.source.tools["create_ticket"].extension_version == ""
         assert (
             impl.source.hooks["3f5c8c8a-7b4d-4f9c-a4c0-7d5cb1a39f7e"].extension_name
             == "workflow-ext"

--- a/uv.lock
+++ b/uv.lock
@@ -2924,7 +2924,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.19.2"
+version = "0.19.3"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Single release PR for **v0.19.3** combining two extensibility-related changes:

- **#128** — fix(extensibility): use `ConsumptionLevel.PROVIDER_SUBACCOUNT` for UMS destination lookup (fixes HTTP 400 from `@SUB_ACCOUNT` path)
- **#115** — refactor(telemetry): remove prefixed tool name convention from extension tool calls

Includes version bump in `pyproject.toml` and `uv.lock` (`0.19.2` → `0.19.3`).

Supersedes merging #115 and #128 separately (avoids duplicate version bumps).

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Dependency update

## How to Test

1. `uv run pytest -m "not integration" -q`
2. `uv build`
3. Verify `pyproject.toml` and `uv.lock` both show `sap-cloud-sdk` version `0.19.3`

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

After merge, close or supersede:
- https://github.com/SAP/cloud-sdk-python/pull/128
- https://github.com/SAP/cloud-sdk-python/pull/115