### PR TITLE
feat: add configurable token cache for customer and lob flows

### DIFF
--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -320,9 +320,9 @@ def get_system_token_mtls(
     Returns:
         System-scoped access token.
     """
-    cached = cache.get_system_token(app_tid)
+    cached = cache.get_system_token(credentials.client_id)
     if cached:
-        logger.debug("Using cached system token (app_tid=%s)", app_tid)
+        logger.debug("Using cached system token (client_id=%s)", credentials.client_id)
         return cached
 
     logger.info("Acquiring system token via mTLS client credentials")
@@ -334,7 +334,7 @@ def get_system_token_mtls(
         app_tid=app_tid,
         extra_data={"response_type": "token"},
     )
-    cache.set_system_token(token, expires_at, app_tid)
+    cache.set_system_token(token, expires_at, credentials.client_id)
     return token
 
 
@@ -363,9 +363,9 @@ def exchange_user_token(
     Returns:
         AGW-scoped access token with user identity.
     """
-    cached = cache.get_user_token(user_token, app_tid)
+    cached = cache.get_user_token(user_token, credentials.client_id)
     if cached:
-        logger.debug("Using cached user token (app_tid=%s)", app_tid)
+        logger.debug("Using cached user token (client_id=%s)", credentials.client_id)
         return cached
 
     logger.info("Exchanging user token for AGW-scoped token via jwt-bearer grant")
@@ -380,7 +380,7 @@ def exchange_user_token(
             "token_format": "jwt",
         },
     )
-    cache.set_user_token(user_token, token, expires_at, app_tid)
+    cache.set_user_token(user_token, token, expires_at, credentials.client_id)
     return token
 
 
@@ -520,7 +520,7 @@ async def get_mcp_tools_customer(
             dep.global_tenant_id,
         )
 
-        while True:
+        for attempt in (1, 2):
             if not system_token:
                 # won't catch exceptions here - if token acquisition fails,
                 # we want the discovery to fail immediately
@@ -532,12 +532,12 @@ async def get_mcp_tools_customer(
                 logger.debug("Loaded %d tool(s) from %s", len(server_tools), dep.ord_id)
             except Exception as exc:
                 unwrapped = _unwrap_exception_group(exc)
-                if _is_unauthorized(unwrapped):
+                if _is_unauthorized(unwrapped) and attempt == 1:
                     logger.info(
                         "401 from %s — invalidating cached system token and retrying",
                         dep.ord_id,
                     )
-                    cache.invalidate_system_token(app_tid)
+                    cache.invalidate_system_token(credentials.client_id)
                     system_token = None  # Force refetch on next loop iteration
                     continue
                 logger.exception("Failed to load tools from %s — skipping", dep.ord_id)
@@ -609,9 +609,9 @@ async def call_mcp_tool_customer(
 
     def _invalidate_token() -> None:
         if user_token:
-            cache.invalidate_user_token(user_token, app_tid)
+            cache.invalidate_user_token(user_token, credentials.client_id)
         else:
-            cache.invalidate_system_token(app_tid)
+            cache.invalidate_system_token(credentials.client_id)
 
     last_exc: Exception | None = None
     for attempt in (1, 2):

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -499,11 +499,15 @@ async def get_mcp_tools_customer(
 
     logger.info("Discovering tools from %d MCP server(s)", len(dependencies))
 
-    # Get system token for discovery
-    loop = asyncio.get_running_loop()
-    system_token = await loop.run_in_executor(
-        None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
-    )
+    system_token = None
+    # Define a helper closure to refetch the system token on demand, since it may need to be
+    # refreshed during the discovery loop if any server returns a 401
+    async def refetch_system_token() -> str:
+        loop = asyncio.get_running_loop()
+        new_token = await loop.run_in_executor(
+            None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
+        )
+        return new_token
 
     tools: list[MCPTool] = []
 
@@ -516,47 +520,28 @@ async def get_mcp_tools_customer(
             dep.global_tenant_id,
         )
 
-        try:
-            server_tools = await _list_server_tools(url, system_token, dep, timeout)
-            tools.extend(server_tools)
-            logger.debug("Loaded %d tool(s) from %s", len(server_tools), dep.ord_id)
-        except Exception as exc:
-            unwrapped = _unwrap_exception_group(exc)
-            if _is_unauthorized(unwrapped):
-                logger.info(
-                    "401 from %s — invalidating cached system token and retrying",
-                    dep.ord_id,
-                )
-                cache.invalidate_system_token(app_tid)
-                try:
-                    fresh_token = await loop.run_in_executor(
-                        None,
-                        get_system_token_mtls,
-                        credentials,
-                        timeout,
-                        config,
-                        cache,
-                        app_tid,
-                    )
-                    server_tools = await _list_server_tools(
-                        url, fresh_token, dep, timeout
-                    )
-                    tools.extend(server_tools)
-                    # Replace stale token for remaining iterations
-                    system_token = fresh_token
-                    logger.debug(
-                        "Loaded %d tool(s) from %s after retry",
-                        len(server_tools),
+        while True:
+            if not system_token:
+                # won't catch exceptions here - if token acquisition fails,
+                # we want the discovery to fail immediately
+                system_token = await refetch_system_token()
+
+            try:
+                server_tools = await _list_server_tools(url, system_token, dep, timeout)
+                tools.extend(server_tools)
+                logger.debug("Loaded %d tool(s) from %s", len(server_tools), dep.ord_id)
+            except Exception as exc:
+                unwrapped = _unwrap_exception_group(exc)
+                if _is_unauthorized(unwrapped):
+                    logger.info(
+                        "401 from %s — invalidating cached system token and retrying",
                         dep.ord_id,
                     )
+                    cache.invalidate_system_token(app_tid)
+                    system_token = None  # Force refetch on next loop iteration
                     continue
-                except Exception:
-                    logger.exception(
-                        "Failed to load tools from %s after retry — skipping",
-                        dep.ord_id,
-                    )
-                    continue
-            logger.exception("Failed to load tools from %s — skipping", dep.ord_id)
+                logger.exception("Failed to load tools from %s — skipping", dep.ord_id)
+            break  # Success, move to next server
 
     logger.info(
         "Loaded %d MCP tool(s) from %d server(s)", len(tools), len(dependencies)

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -25,7 +25,7 @@ from sap_cloud_sdk.agentgateway._models import (
     IntegrationDependency,
     MCPTool,
 )
-from sap_cloud_sdk.agentgateway._token_cache import _TokenCache, compute_expires_at
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
 from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 
@@ -213,7 +213,7 @@ def _request_token_mtls(
     credentials: CustomerCredentials,
     grant_type: str,
     timeout: float,
-    config: ClientConfig,
+    cache: _TokenCache,
     app_tid: str | None = None,
     extra_data: dict | None = None,
 ) -> tuple[str, float]:
@@ -223,7 +223,7 @@ def _request_token_mtls(
         credentials: Customer credentials with certificate and private key.
         grant_type: OAuth2 grant type.
         timeout: HTTP timeout in seconds.
-        config: Client configuration (used to compute cache expiry).
+        cache: Token cache to calculate expiry (for buffer and fallback TTL).
         app_tid: BTP Application Tenant ID of subscriber (optional).
         extra_data: Additional form data for the token request.
 
@@ -289,7 +289,7 @@ def _request_token_mtls(
                 f"Token response missing 'access_token'. Keys: {list(token_data.keys())}"
             )
 
-        expires_at = compute_expires_at(token_data, config)
+        expires_at = cache.compute_expires_at(token_data)
 
         logger.debug("Token acquired successfully (length: %d)", len(access_token))
         return access_token, expires_at
@@ -301,7 +301,6 @@ def _request_token_mtls(
 def get_system_token_mtls(
     credentials: CustomerCredentials,
     timeout: float,
-    config: ClientConfig,
     cache: _TokenCache,
     app_tid: str | None = None,
 ) -> str:
@@ -313,7 +312,6 @@ def get_system_token_mtls(
     Args:
         credentials: Customer credentials.
         timeout: HTTP timeout in seconds.
-        config: Client configuration.
         cache: Token cache to consult and update.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
@@ -330,7 +328,7 @@ def get_system_token_mtls(
         credentials,
         grant_type=_GRANT_TYPE_CLIENT_CREDENTIALS,
         timeout=timeout,
-        config=config,
+        cache=cache,
         app_tid=app_tid,
         extra_data={"response_type": "token"},
     )
@@ -342,7 +340,6 @@ def exchange_user_token(
     credentials: CustomerCredentials,
     user_token: str,
     timeout: float,
-    config: ClientConfig,
     cache: _TokenCache,
     app_tid: str | None = None,
 ) -> str:
@@ -356,7 +353,6 @@ def exchange_user_token(
         credentials: Customer credentials.
         user_token: User's JWT token to exchange.
         timeout: HTTP timeout in seconds.
-        config: Client configuration.
         cache: Token cache to consult and update.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
@@ -373,7 +369,7 @@ def exchange_user_token(
         credentials,
         grant_type=_GRANT_TYPE_JWT_BEARER,
         timeout=timeout,
-        config=config,
+        cache=cache,
         app_tid=app_tid,
         extra_data={
             "assertion": user_token,
@@ -505,7 +501,7 @@ async def get_mcp_tools_customer(
     async def refetch_system_token() -> str:
         loop = asyncio.get_running_loop()
         new_token = await loop.run_in_executor(
-            None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
+            None, get_system_token_mtls, credentials, timeout, cache, app_tid
         )
         return new_token
 
@@ -592,7 +588,6 @@ async def call_mcp_tool_customer(
                 credentials,
                 user_token,
                 timeout,
-                config,
                 cache,
                 app_tid,
             )
@@ -604,7 +599,7 @@ async def call_mcp_tool_customer(
             "Principal propagation will NOT work."
         )
         return await loop.run_in_executor(
-            None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
+            None, get_system_token_mtls, credentials, timeout, cache, app_tid
         )
 
     def _invalidate_token() -> None:

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -496,6 +496,7 @@ async def get_mcp_tools_customer(
     logger.info("Discovering tools from %d MCP server(s)", len(dependencies))
 
     system_token = None
+
     # Define a helper closure to refetch the system token on demand, since it may need to be
     # refreshed during the discovery loop if any server returns a 401
     async def refetch_system_token() -> str:

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -25,6 +25,8 @@ from sap_cloud_sdk.agentgateway._models import (
     IntegrationDependency,
     MCPTool,
 )
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache, compute_expires_at
+from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 
 logger = logging.getLogger(__name__)
@@ -211,19 +213,24 @@ def _request_token_mtls(
     credentials: CustomerCredentials,
     grant_type: str,
     timeout: float,
+    config: ClientConfig,
     app_tid: str | None = None,
     extra_data: dict | None = None,
-) -> str:
+) -> tuple[str, float]:
     """Make mTLS token request to IAS.
 
     Args:
         credentials: Customer credentials with certificate and private key.
         grant_type: OAuth2 grant type.
+        timeout: HTTP timeout in seconds.
+        config: Client configuration (used to compute cache expiry).
         app_tid: BTP Application Tenant ID of subscriber (optional).
         extra_data: Additional form data for the token request.
 
     Returns:
-        Access token string.
+        Tuple of (access_token, expires_at) where expires_at is a
+        time.monotonic() value indicating when the cached token should
+        be refreshed (already includes the configured buffer).
 
     Raises:
         AgentGatewaySDKError: If token request fails.
@@ -282,8 +289,10 @@ def _request_token_mtls(
                 f"Token response missing 'access_token'. Keys: {list(token_data.keys())}"
             )
 
+        expires_at = compute_expires_at(token_data, config)
+
         logger.debug("Token acquired successfully (length: %d)", len(access_token))
-        return access_token
+        return access_token, expires_at
 
     except httpx.RequestError as e:
         raise AgentGatewaySDKError(f"Token request failed: {e}")
@@ -292,61 +301,87 @@ def _request_token_mtls(
 def get_system_token_mtls(
     credentials: CustomerCredentials,
     timeout: float,
+    config: ClientConfig,
+    cache: _TokenCache,
     app_tid: str | None = None,
 ) -> str:
     """Get system-scoped token using mTLS client credentials flow.
 
-    Used for tool discovery where user identity is not needed.
+    Used for tool discovery where user identity is not needed. Returns
+    a cached token if still valid; otherwise acquires a fresh one.
 
     Args:
         credentials: Customer credentials.
         timeout: HTTP timeout in seconds.
+        config: Client configuration.
+        cache: Token cache to consult and update.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
     Returns:
         System-scoped access token.
     """
+    cached = cache.get_system_token(app_tid)
+    if cached:
+        logger.debug("Using cached system token (app_tid=%s)", app_tid)
+        return cached
+
     logger.info("Acquiring system token via mTLS client credentials")
-    return _request_token_mtls(
+    token, expires_at = _request_token_mtls(
         credentials,
         grant_type=_GRANT_TYPE_CLIENT_CREDENTIALS,
         timeout=timeout,
+        config=config,
         app_tid=app_tid,
         extra_data={"response_type": "token"},
     )
+    cache.set_system_token(token, expires_at, app_tid)
+    return token
 
 
 def exchange_user_token(
     credentials: CustomerCredentials,
     user_token: str,
     timeout: float,
+    config: ClientConfig,
+    cache: _TokenCache,
     app_tid: str | None = None,
 ) -> str:
     """Exchange user token for AGW-scoped token using jwt-bearer grant.
 
     Used for tool invocation where user identity must be preserved
-    for principal propagation.
+    for principal propagation. Returns a cached exchanged token if
+    still valid; otherwise acquires a fresh one.
 
     Args:
         credentials: Customer credentials.
         user_token: User's JWT token to exchange.
         timeout: HTTP timeout in seconds.
+        config: Client configuration.
+        cache: Token cache to consult and update.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
     Returns:
         AGW-scoped access token with user identity.
     """
+    cached = cache.get_user_token(user_token, app_tid)
+    if cached:
+        logger.debug("Using cached user token (app_tid=%s)", app_tid)
+        return cached
+
     logger.info("Exchanging user token for AGW-scoped token via jwt-bearer grant")
-    return _request_token_mtls(
+    token, expires_at = _request_token_mtls(
         credentials,
         grant_type=_GRANT_TYPE_JWT_BEARER,
         timeout=timeout,
+        config=config,
         app_tid=app_tid,
         extra_data={
             "assertion": user_token,
             "token_format": "jwt",
         },
     )
+    cache.set_user_token(user_token, token, expires_at, app_tid)
+    return token
 
 
 def _build_mcp_url(gateway_url: str, ord_id: str, gt_id: str) -> str:
@@ -433,6 +468,8 @@ async def _list_server_tools(
 async def get_mcp_tools_customer(
     credentials: CustomerCredentials,
     timeout: float,
+    config: ClientConfig,
+    cache: _TokenCache,
     app_tid: str | None = None,
 ) -> list[MCPTool]:
     """List all MCP tools from servers defined in credentials.
@@ -442,6 +479,9 @@ async def get_mcp_tools_customer(
 
     Args:
         credentials: Customer credentials with integrationDependencies.
+        timeout: HTTP timeout in seconds.
+        config: Client configuration.
+        cache: Token cache shared across calls.
         app_tid: BTP Application Tenant ID of subscriber (optional).
 
     Returns:
@@ -462,7 +502,7 @@ async def get_mcp_tools_customer(
     # Get system token for discovery
     loop = asyncio.get_running_loop()
     system_token = await loop.run_in_executor(
-        None, get_system_token_mtls, credentials, timeout, app_tid
+        None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
     )
 
     tools: list[MCPTool] = []
@@ -480,7 +520,42 @@ async def get_mcp_tools_customer(
             server_tools = await _list_server_tools(url, system_token, dep, timeout)
             tools.extend(server_tools)
             logger.debug("Loaded %d tool(s) from %s", len(server_tools), dep.ord_id)
-        except Exception:
+        except Exception as exc:
+            unwrapped = _unwrap_exception_group(exc)
+            if _is_unauthorized(unwrapped):
+                logger.info(
+                    "401 from %s — invalidating cached system token and retrying",
+                    dep.ord_id,
+                )
+                cache.invalidate_system_token(app_tid)
+                try:
+                    fresh_token = await loop.run_in_executor(
+                        None,
+                        get_system_token_mtls,
+                        credentials,
+                        timeout,
+                        config,
+                        cache,
+                        app_tid,
+                    )
+                    server_tools = await _list_server_tools(
+                        url, fresh_token, dep, timeout
+                    )
+                    tools.extend(server_tools)
+                    # Replace stale token for remaining iterations
+                    system_token = fresh_token
+                    logger.debug(
+                        "Loaded %d tool(s) from %s after retry",
+                        len(server_tools),
+                        dep.ord_id,
+                    )
+                    continue
+                except Exception:
+                    logger.exception(
+                        "Failed to load tools from %s after retry — skipping",
+                        dep.ord_id,
+                    )
+                    continue
             logger.exception("Failed to load tools from %s — skipping", dep.ord_id)
 
     logger.info(
@@ -494,6 +569,8 @@ async def call_mcp_tool_customer(
     tool: MCPTool,
     user_token: str | None,
     timeout: float,
+    config: ClientConfig,
+    cache: _TokenCache,
     app_tid: str | None = None,
     **kwargs,
 ) -> str:
@@ -502,11 +579,16 @@ async def call_mcp_tool_customer(
     If user_token is provided, exchanges it for an AGW-scoped token to preserve
     user identity for principal propagation. Otherwise, falls back to system token.
 
+    On a 401 from the MCP server, drops the cached token and retries once.
+
     Args:
         credentials: Customer credentials.
         tool: MCPTool to invoke.
         user_token: User's JWT token for principal propagation (optional).
             If None, system token is used instead (no principal propagation).
+        timeout: HTTP timeout in seconds.
+        config: Client configuration.
+        cache: Token cache shared across calls.
         app_tid: BTP Application Tenant ID of subscriber (optional).
         **kwargs: Tool input parameters.
 
@@ -517,12 +599,18 @@ async def call_mcp_tool_customer(
 
     loop = asyncio.get_running_loop()
 
-    if user_token:
-        # Exchange user token for AGW-scoped token (with principal propagation)
-        agw_token = await loop.run_in_executor(
-            None, exchange_user_token, credentials, user_token, timeout, app_tid
-        )
-    else:
+    async def _acquire_token() -> str:
+        if user_token:
+            return await loop.run_in_executor(
+                None,
+                exchange_user_token,
+                credentials,
+                user_token,
+                timeout,
+                config,
+                cache,
+                app_tid,
+            )
         # TODO: IBD workaround - use system token when user_token is not available.
         # This bypasses principal propagation. Remove this fallback once IBD
         # supports proper user token flow.
@@ -530,13 +618,55 @@ async def call_mcp_tool_customer(
             "No user_token provided - using system token for tool invocation. "
             "Principal propagation will NOT work."
         )
-        agw_token = await loop.run_in_executor(
-            None, get_system_token_mtls, credentials, timeout, app_tid
+        return await loop.run_in_executor(
+            None, get_system_token_mtls, credentials, timeout, config, cache, app_tid
         )
 
+    def _invalidate_token() -> None:
+        if user_token:
+            cache.invalidate_user_token(user_token, app_tid)
+        else:
+            cache.invalidate_system_token(app_tid)
+
+    last_exc: Exception | None = None
+    for attempt in (1, 2):
+        agw_token = await _acquire_token()
+        try:
+            return await _invoke_tool(tool, agw_token, timeout, **kwargs)
+        except Exception as exc:
+            unwrapped = _unwrap_exception_group(exc)
+            if _is_unauthorized(unwrapped) and attempt == 1:
+                logger.info(
+                    "401 from MCP server for tool '%s' — invalidating cached token and retrying",
+                    tool.name,
+                )
+                _invalidate_token()
+                last_exc = exc
+                continue
+            raise
+
+    # Defensive — should not be reachable; second attempt either returns or raises.
+    raise AgentGatewaySDKError(
+        f"Tool invocation for '{tool.name}' failed after 401 retry: {last_exc}"
+    )
+
+
+async def _invoke_tool(
+    tool: MCPTool,
+    auth_token: str,
+    timeout: float,
+    **kwargs,
+) -> str:
+    """Open an MCP session to `tool.url` and invoke `tool.name` with `kwargs`.
+
+    Returns the first content block's text, or empty string when content is
+    empty. Raises whatever the MCP transport / session raises (notably
+    `httpx.HTTPStatusError` on 401, which the caller uses to drive cache
+    invalidation and retry).
+    """
     async with httpx.AsyncClient(
         headers={
-            "Authorization": f"Bearer {agw_token}",
+            "Authorization": f"Bearer {auth_token}",
             "x-correlation-id": str(uuid.uuid4()),
         },
         timeout=timeout,
@@ -556,3 +686,17 @@ async def call_mcp_tool_customer(
 
                 first = result.content[0]
                 return str(getattr(first, "text", ""))
+
+
+def _unwrap_exception_group(exc: BaseException) -> BaseException:
+    """Unwrap nested ExceptionGroups to find the underlying cause."""
+    while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
+        exc = exc.exceptions[0]
+    return exc
+
+
+def _is_unauthorized(exc: BaseException) -> bool:
+    """Detect a 401 response from the MCP server (httpx-based)."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response is not None and exc.response.status_code == 401
+    return False

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -23,7 +23,8 @@ from sap_cloud_sdk.destination import (
 )
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
-from sap_cloud_sdk.agentgateway.exceptions import MCPServerNotFoundError
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
+from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -145,14 +146,17 @@ def get_ias_fragment_name(tenant_subdomain: str) -> str:
 
 async def get_system_auth(
     tenant_subdomain: str,
+    cache: _TokenCache,
 ) -> str:
     """Get system-scoped auth (Phase 1 - client credentials).
 
-    Looks up the IAS fragment (subscriber.ias label) and uses it to acquire
-    a client-credentials token via BTP Destination Service.
+    Checks the token cache first. On a miss, looks up the IAS fragment
+    (subscriber.ias label) and acquires a client-credentials token via
+    BTP Destination Service, then caches the result.
 
     Args:
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+        cache: Token cache shared across calls.
 
     Returns:
         Authorization header value (e.g., "Bearer xxx").
@@ -160,6 +164,11 @@ async def get_system_auth(
     Raises:
         MCPServerNotFoundError: If no IAS fragment or auth token is found.
     """
+    cached = cache.get_system_token(tenant_subdomain)
+    if cached:
+        logger.debug("System token cache hit for tenant '%s'", tenant_subdomain)
+        return cached
+
     loop = asyncio.get_running_loop()
 
     def _fetch_system_auth_sync():
@@ -179,20 +188,31 @@ async def get_system_auth(
 
         return _fetch_auth_token(dest_name, tenant_subdomain, options)
 
-    return await loop.run_in_executor(None, _fetch_system_auth_sync)
+    auth = await loop.run_in_executor(None, _fetch_system_auth_sync)
+    expires_at = cache.compute_expires_at_from_bearer(auth)
+    cache.set_system_token(auth, expires_at, tenant_subdomain)
+    return auth
 
 
 async def get_user_auth(
     mcp_fragment_name: str,
     user_token: str,
     tenant_subdomain: str,
+    cache: _TokenCache,
 ) -> str:
     """Get user-scoped auth (Phase 2 - token exchange).
+
+    Checks the token cache first. On a miss, exchanges the user token via
+    BTP Destination Service, then caches the result.
+
+    Cache key is scoped to (user_token, mcp_fragment_name, tenant_subdomain)
+    since different fragments may yield differently-scoped tokens.
 
     Args:
         mcp_fragment_name: MCP fragment name for token exchange.
         user_token: User's JWT for principal propagation.
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+        cache: Token cache shared across calls.
 
     Returns:
         Authorization header value with user identity embedded.
@@ -200,6 +220,16 @@ async def get_user_auth(
     Raises:
         MCPServerNotFoundError: If no auth token is returned.
     """
+    scope_key = f"{mcp_fragment_name}|{tenant_subdomain}"
+    cached = cache.get_user_token(user_token, scope_key)
+    if cached:
+        logger.debug(
+            "User token cache hit for tenant '%s', fragment '%s'",
+            tenant_subdomain,
+            mcp_fragment_name,
+        )
+        return cached
+
     loop = asyncio.get_running_loop()
 
     def _fetch_user_auth_sync():
@@ -220,7 +250,10 @@ async def get_user_auth(
 
         return _fetch_auth_token(dest_name, tenant_subdomain, options)
 
-    return await loop.run_in_executor(None, _fetch_user_auth_sync)
+    auth = await loop.run_in_executor(None, _fetch_user_auth_sync)
+    expires_at = cache.compute_expires_at_from_bearer(auth)
+    cache.set_user_token(user_token, auth, expires_at, scope_key)
+    return auth
 
 
 async def list_server_tools(
@@ -271,13 +304,18 @@ async def list_server_tools(
 async def get_mcp_tools_lob(
     tenant_subdomain: str,
     timeout: float,
+    cache: _TokenCache,
 ) -> list[MCPTool]:
     """List all MCP tools using LoB flow (destination-based).
 
     Uses Phase 1 auth (client-scoped) via BTP Destination Service.
+    On a 401 from an MCP server, invalidates the cached system token and
+    retries once before skipping the fragment.
 
     Args:
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+        timeout: HTTP timeout in seconds.
+        cache: Token cache shared across calls.
 
     Returns:
         List of MCPTool objects from all MCP servers.
@@ -295,6 +333,11 @@ async def get_mcp_tools_lob(
         )
         return tools
 
+    system_auth = None
+
+    async def _refetch_system_auth() -> str:
+        return await get_system_auth(tenant_subdomain, cache)
+
     for fragment in fragments:
         fragment_name = fragment.name
         mcp_url = fragment.properties.get("URL") or fragment.properties.get("url")
@@ -305,22 +348,36 @@ async def get_mcp_tools_lob(
             )
             continue
 
-        try:
-            system_auth = await get_system_auth(tenant_subdomain)
-            server_tools = await list_server_tools(
-                mcp_url, system_auth, fragment_name, timeout
-            )
-            tools.extend(server_tools)
-            logger.debug(
-                "Loaded %d tool(s) from fragment '%s'",
-                len(server_tools),
-                fragment_name,
-            )
-        except Exception:
-            logger.exception(
-                "Failed to load tools from fragment '%s' — skipping",
-                fragment_name,
-            )
+        for attempt in (1, 2):
+            if not system_auth:
+                # Auth failure here is immediately fatal — same token is needed for
+                # all fragments, so there is no point continuing.
+                system_auth = await _refetch_system_auth()
+
+            try:
+                server_tools = await list_server_tools(
+                    mcp_url, system_auth, fragment_name, timeout
+                )
+                tools.extend(server_tools)
+                logger.debug(
+                    "Loaded %d tool(s) from fragment '%s'",
+                    len(server_tools),
+                    fragment_name,
+                )
+            except Exception as exc:
+                unwrapped = _unwrap_exception_group(exc)
+                if _is_unauthorized(unwrapped) and attempt == 1:
+                    logger.info(
+                        "401 from '%s' — invalidating cached system token and retrying",
+                        fragment_name,
+                    )
+                    cache.invalidate_system_token(tenant_subdomain)
+                    system_auth = None
+                    continue
+                logger.exception(
+                    "Failed to load tools from fragment '%s' — skipping", fragment_name
+                )
+            break
 
     logger.info("Loaded %d MCP tool(s) from %d fragment(s)", len(tools), len(fragments))
     return tools
@@ -331,17 +388,21 @@ async def call_mcp_tool_lob(
     user_token: str,
     tenant_subdomain: str,
     timeout: float,
+    cache: _TokenCache,
     **kwargs,
 ) -> str:
     """Invoke an MCP tool using LoB flow (destination-based).
 
     Uses Phase 2 auth (user-scoped) via token exchange.
     Principal propagation ensures LoB systems see user identity.
+    On a 401, invalidates the cached user token and retries once.
 
     Args:
         tool: MCPTool object (from list_mcp_tools).
         user_token: User's JWT for principal propagation.
         tenant_subdomain: Tenant subdomain for token exchange.
+        timeout: HTTP timeout in seconds.
+        cache: Token cache shared across calls.
         **kwargs: Tool input parameters.
 
     Returns:
@@ -349,27 +410,68 @@ async def call_mcp_tool_lob(
 
     Raises:
         MCPServerNotFoundError: If destination/auth fails.
+        AgentGatewaySDKError: If tool invocation fails after 401 retry.
     """
     if not tool.fragment_name:
         raise MCPServerNotFoundError(
             f"Tool '{tool.name}' missing fragment_name for LoB invocation"
         )
-    user_auth = await get_user_auth(tool.fragment_name, user_token, tenant_subdomain)
 
-    async with httpx.AsyncClient(
-        headers={"Authorization": user_auth, "x-correlation-id": str(uuid.uuid4())},
-        timeout=timeout,
-    ) as http_client:
-        async with streamable_http_client(tool.url, http_client=http_client) as (
-            read,
-            write,
-            _,
-        ):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(tool.name, kwargs)
-                if not result.content:
-                    logger.warning("Tool '%s' returned empty content", tool.name)
-                    return ""
-                first = result.content[0]
-                return str(getattr(first, "text", ""))
+    scope_key = f"{tool.fragment_name}|{tenant_subdomain}"
+    last_exc: Exception | None = None
+
+    for attempt in (1, 2):
+        user_auth = await get_user_auth(
+            tool.fragment_name, user_token, tenant_subdomain, cache
+        )
+        try:
+            async with httpx.AsyncClient(
+                headers={
+                    "Authorization": user_auth,
+                    "x-correlation-id": str(uuid.uuid4()),
+                },
+                timeout=timeout,
+            ) as http_client:
+                async with streamable_http_client(
+                    tool.url, http_client=http_client
+                ) as (read, write, _):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        result = await session.call_tool(tool.name, kwargs)
+                        if not result.content:
+                            logger.warning(
+                                "Tool '%s' returned empty content", tool.name
+                            )
+                            return ""
+                        first = result.content[0]
+                        return str(getattr(first, "text", ""))
+        except Exception as exc:
+            unwrapped = _unwrap_exception_group(exc)
+            if _is_unauthorized(unwrapped) and attempt == 1:
+                logger.info(
+                    "401 from MCP server for tool '%s' — invalidating cached token and retrying",
+                    tool.name,
+                )
+                cache.invalidate_user_token(user_token, scope_key)
+                last_exc = exc
+                continue
+            raise
+
+    # Defensive — should not be reachable; second attempt either returns or raises.
+    raise AgentGatewaySDKError(
+        f"Tool invocation for '{tool.name}' failed after 401 retry: {last_exc}"
+    )
+
+
+def _unwrap_exception_group(exc: BaseException) -> BaseException:
+    """Unwrap nested ExceptionGroups to find the underlying cause."""
+    while isinstance(exc, BaseExceptionGroup) and exc.exceptions:
+        exc = exc.exceptions[0]
+    return exc
+
+
+def _is_unauthorized(exc: BaseException) -> bool:
+    """Detect a 401 response from the MCP server (httpx-based)."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response is not None and exc.response.status_code == 401
+    return False

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -24,7 +24,10 @@ from sap_cloud_sdk.destination import (
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
 from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
-from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
+from sap_cloud_sdk.agentgateway.exceptions import (
+    AgentGatewaySDKError,
+    MCPServerNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -57,7 +57,6 @@ def _parse_jwt_exp(jwt: str) -> int | None:
         if len(parts) < 2:
             return None
         payload_b64 = parts[1]
-        # Pad base64
         payload_b64 += "=" * (-len(payload_b64) % 4)
         claims = json.loads(base64.urlsafe_b64decode(payload_b64))
         exp = claims.get("exp")

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -117,15 +117,12 @@ class _TokenCache:
             del self._system_tokens[key]
         return None
 
-    def set_system_token(self, token: str, expires_at: float,
-                         client_id: str) -> None:
+    def set_system_token(self, token: str, expires_at: float, client_id: str) -> None:
         """Cache a system token under `client_id`; evict LRU once size exceeds limit."""
         key = client_id
-        self._system_tokens[key] = _CachedToken(token=token,
-                                                expires_at=expires_at)
+        self._system_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
         self._system_tokens.move_to_end(key)
-        while len(self._system_tokens
-                  ) > self._config.max_system_token_cache_size:
+        while len(self._system_tokens) > self._config.max_system_token_cache_size:
             evicted, _ = self._system_tokens.popitem(last=False)
             logger.debug("System token cache full — evicted '%s'", evicted)
 
@@ -157,8 +154,7 @@ class _TokenCache:
     ) -> None:
         """Cache an exchanged user token; evict LRU once size exceeds limit."""
         key = self._hash_key(user_jwt, client_id)
-        self._user_tokens[key] = _CachedToken(token=token,
-                                              expires_at=expires_at)
+        self._user_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
         self._user_tokens.move_to_end(key)
         while len(self._user_tokens) > self._config.max_user_token_cache_size:
             evicted, _ = self._user_tokens.popitem(last=False)
@@ -185,7 +181,11 @@ class _TokenCache:
         now_mono = time.monotonic()
         buffer = self._config.token_expiry_buffer_seconds
 
-        jwt = auth_header[7:] if auth_header.lower().startswith("bearer ") else auth_header
+        jwt = (
+            auth_header[7:]
+            if auth_header.lower().startswith("bearer ")
+            else auth_header
+        )
         exp = _parse_jwt_exp(jwt)
         if exp is not None:
             remaining = exp - time.time()

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -1,0 +1,189 @@
+"""Token cache for Agent Gateway customer flow.
+
+Caches IAS tokens (system + user-exchanged) per client to avoid redundant
+mTLS token requests during agentic loops. LoB flow uses BTP Destination
+Service which has its own caching, so this module only serves the customer
+flow.
+
+Keying:
+- System tokens are keyed by `app_tid` (or "_default" when unset).
+- User tokens are keyed by `sha256(user_jwt + "|" + (app_tid or ""))[:16]`.
+
+The `app_tid` component is required because `_request_token_mtls` includes
+it in the form payload, producing a tenant-scoped token. Mixing tokens
+across tenants would break principal propagation.
+
+Thread safety:
+Token fetches run in the default `ThreadPoolExecutor` via
+`loop.run_in_executor`. CPython GIL makes individual dict / OrderedDict
+operations atomic, but compound check-then-set is not. Two concurrent
+coroutines for the same key may both miss and both fetch; the race
+produces redundant token requests, not corruption.
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+from sap_cloud_sdk.agentgateway.config import ClientConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _CachedToken:
+    """A cached token with monotonic expiry."""
+
+    token: str
+    expires_at: float  # time.monotonic() value
+
+    def is_valid(self) -> bool:
+        """Return True if the token has not yet reached its monotonic expiry."""
+        return time.monotonic() < self.expires_at
+
+
+def _parse_jwt_exp(jwt: str) -> int | None:
+    """Extract `exp` claim (seconds since epoch) from a JWT without verification.
+
+    Returns None if the JWT is malformed or has no `exp` claim. The result
+    is used only as a hint for cache TTL — never for security decisions.
+    """
+    try:
+        parts = jwt.split(".")
+        if len(parts) < 2:
+            return None
+        payload_b64 = parts[1]
+        # Pad base64
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+        exp = claims.get("exp")
+        return int(exp) if exp is not None else None
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+
+
+def compute_expires_at(token_data: dict, config: ClientConfig) -> float:
+    """Resolve the cache expiry timestamp (monotonic) for a token response.
+
+    Resolution order:
+      1. `expires_in` from the response, minus the buffer.
+      2. `exp` claim from `id_token` (translated from wall clock to monotonic),
+         minus the buffer.
+      3. Config-provided fallback TTL.
+    """
+    now_mono = time.monotonic()
+    buffer = config.token_expiry_buffer_seconds
+
+    expires_in = token_data.get("expires_in")
+    if expires_in is not None:
+        try:
+            return now_mono + int(expires_in) - buffer
+        except (ValueError, TypeError):
+            pass
+
+    id_token = token_data.get("id_token")
+    if id_token:
+        exp = _parse_jwt_exp(id_token)
+        if exp is not None:
+            remaining = exp - time.time()
+            if remaining > buffer:
+                return now_mono + remaining - buffer
+
+    return now_mono + config.fallback_token_ttl_seconds
+
+
+class _TokenCache:
+    """Per-client token cache with TTL and LRU eviction.
+
+    Both system and user tokens use OrderedDict for LRU ordering. Keys
+    include `app_tid` so tenant-scoped tokens never leak across tenants.
+    """
+
+    _SYSTEM_DEFAULT_KEY = "_default"
+
+    def __init__(self, config: ClientConfig):
+        """Initialize empty caches bounded by sizes from `config`."""
+        self._config = config
+        self._system_tokens: OrderedDict[str, _CachedToken] = OrderedDict()
+        self._user_tokens: OrderedDict[str, _CachedToken] = OrderedDict()
+
+    # --- System Token ---
+
+    def get_system_token(self, app_tid: str | None) -> str | None:
+        """Return a valid cached system token for `app_tid`, or None on miss/expiry."""
+        key = app_tid or self._SYSTEM_DEFAULT_KEY
+        cached = self._system_tokens.get(key)
+        if cached and cached.is_valid():
+            self._system_tokens.move_to_end(key)
+            return cached.token
+        if cached:
+            del self._system_tokens[key]
+        return None
+
+    def set_system_token(
+        self, token: str, expires_at: float, app_tid: str | None
+    ) -> None:
+        """Cache a system token under `app_tid`; evict LRU once size exceeds limit."""
+        key = app_tid or self._SYSTEM_DEFAULT_KEY
+        self._system_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
+        self._system_tokens.move_to_end(key)
+        while len(self._system_tokens) > self._config.max_system_token_cache_size:
+            evicted, _ = self._system_tokens.popitem(last=False)
+            logger.debug("System token cache full — evicted '%s'", evicted)
+
+    def invalidate_system_token(self, app_tid: str | None) -> None:
+        """Drop the cached system token for `app_tid` (no-op if absent)."""
+        key = app_tid or self._SYSTEM_DEFAULT_KEY
+        if self._system_tokens.pop(key, None):
+            logger.debug("Invalidated system token (app_tid=%s)", app_tid)
+
+    # --- User Tokens ---
+
+    def get_user_token(self, user_jwt: str, app_tid: str | None) -> str | None:
+        """Return a valid cached exchanged token for `(user_jwt, app_tid)`, or None."""
+        key = self._hash_key(user_jwt, app_tid)
+        cached = self._user_tokens.get(key)
+        if cached and cached.is_valid():
+            self._user_tokens.move_to_end(key)
+            return cached.token
+        if cached:
+            del self._user_tokens[key]
+        return None
+
+    def set_user_token(
+        self,
+        user_jwt: str,
+        token: str,
+        expires_at: float,
+        app_tid: str | None,
+    ) -> None:
+        """Cache an exchanged user token; evict LRU once size exceeds limit."""
+        key = self._hash_key(user_jwt, app_tid)
+        self._user_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
+        self._user_tokens.move_to_end(key)
+        while len(self._user_tokens) > self._config.max_user_token_cache_size:
+            evicted, _ = self._user_tokens.popitem(last=False)
+            logger.debug("User token cache full — evicted '%s'", evicted)
+
+    def invalidate_user_token(self, user_jwt: str, app_tid: str | None) -> None:
+        """Drop the cached user token for `(user_jwt, app_tid)` (no-op if absent)."""
+        key = self._hash_key(user_jwt, app_tid)
+        if self._user_tokens.pop(key, None):
+            logger.debug("Invalidated user token (app_tid=%s)", app_tid)
+
+    # --- Maintenance ---
+
+    def clear(self) -> None:
+        """Drop all cached tokens. Forces a fresh fetch on next access."""
+        self._system_tokens.clear()
+        self._user_tokens.clear()
+
+    @staticmethod
+    def _hash_key(user_jwt: str, app_tid: str | None) -> str:
+        """Derive a short, stable cache key from `(user_jwt, app_tid)` via sha256."""
+        material = f"{user_jwt}|{app_tid or ''}"
+        return hashlib.sha256(material.encode()).hexdigest()[:16]

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -6,12 +6,8 @@ Service which has its own caching, so this module only serves the customer
 flow.
 
 Keying:
-- System tokens are keyed by `app_tid` (or "_default" when unset).
-- User tokens are keyed by `sha256(user_jwt + "|" + (app_tid or ""))[:16]`.
-
-The `app_tid` component is required because `_request_token_mtls` includes
-it in the form payload, producing a tenant-scoped token. Mixing tokens
-across tenants would break principal propagation.
+- System tokens are keyed by `client_id` (or "_default" when unset).
+- User tokens are keyed by `sha256(user_jwt + "|" + (client_id or ""))[:16]`.
 
 Thread safety:
 Token fetches run in the default `ThreadPoolExecutor` via
@@ -98,8 +94,7 @@ def compute_expires_at(token_data: dict, config: ClientConfig) -> float:
 class _TokenCache:
     """Per-client token cache with TTL and LRU eviction.
 
-    Both system and user tokens use OrderedDict for LRU ordering. Keys
-    include `app_tid` so tenant-scoped tokens never leak across tenants.
+    Both system and user tokens use OrderedDict for LRU ordering.
     """
 
     _SYSTEM_DEFAULT_KEY = "_default"
@@ -112,9 +107,9 @@ class _TokenCache:
 
     # --- System Token ---
 
-    def get_system_token(self, app_tid: str | None) -> str | None:
-        """Return a valid cached system token for `app_tid`, or None on miss/expiry."""
-        key = app_tid or self._SYSTEM_DEFAULT_KEY
+    def get_system_token(self, client_id: str) -> str | None:
+        """Return a valid cached system token for `client_id`, or None on miss/expiry."""
+        key = client_id
         cached = self._system_tokens.get(key)
         if cached and cached.is_valid():
             self._system_tokens.move_to_end(key)
@@ -123,28 +118,29 @@ class _TokenCache:
             del self._system_tokens[key]
         return None
 
-    def set_system_token(
-        self, token: str, expires_at: float, app_tid: str | None
-    ) -> None:
-        """Cache a system token under `app_tid`; evict LRU once size exceeds limit."""
-        key = app_tid or self._SYSTEM_DEFAULT_KEY
-        self._system_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
+    def set_system_token(self, token: str, expires_at: float,
+                         client_id: str) -> None:
+        """Cache a system token under `client_id`; evict LRU once size exceeds limit."""
+        key = client_id
+        self._system_tokens[key] = _CachedToken(token=token,
+                                                expires_at=expires_at)
         self._system_tokens.move_to_end(key)
-        while len(self._system_tokens) > self._config.max_system_token_cache_size:
+        while len(self._system_tokens
+                  ) > self._config.max_system_token_cache_size:
             evicted, _ = self._system_tokens.popitem(last=False)
             logger.debug("System token cache full — evicted '%s'", evicted)
 
-    def invalidate_system_token(self, app_tid: str | None) -> None:
-        """Drop the cached system token for `app_tid` (no-op if absent)."""
-        key = app_tid or self._SYSTEM_DEFAULT_KEY
+    def invalidate_system_token(self, client_id: str) -> None:
+        """Drop the cached system token for `client_id` (no-op if absent)."""
+        key = client_id
         if self._system_tokens.pop(key, None):
-            logger.debug("Invalidated system token (app_tid=%s)", app_tid)
+            logger.debug("Invalidated system token (client_id=%s)", client_id)
 
     # --- User Tokens ---
 
-    def get_user_token(self, user_jwt: str, app_tid: str | None) -> str | None:
-        """Return a valid cached exchanged token for `(user_jwt, app_tid)`, or None."""
-        key = self._hash_key(user_jwt, app_tid)
+    def get_user_token(self, user_jwt: str, client_id: str) -> str | None:
+        """Return a valid cached exchanged token for `(user_jwt, client_id)`, or None."""
+        key = self._hash_key(user_jwt, client_id)
         cached = self._user_tokens.get(key)
         if cached and cached.is_valid():
             self._user_tokens.move_to_end(key)
@@ -158,21 +154,22 @@ class _TokenCache:
         user_jwt: str,
         token: str,
         expires_at: float,
-        app_tid: str | None,
+        client_id: str,
     ) -> None:
         """Cache an exchanged user token; evict LRU once size exceeds limit."""
-        key = self._hash_key(user_jwt, app_tid)
-        self._user_tokens[key] = _CachedToken(token=token, expires_at=expires_at)
+        key = self._hash_key(user_jwt, client_id)
+        self._user_tokens[key] = _CachedToken(token=token,
+                                              expires_at=expires_at)
         self._user_tokens.move_to_end(key)
         while len(self._user_tokens) > self._config.max_user_token_cache_size:
             evicted, _ = self._user_tokens.popitem(last=False)
             logger.debug("User token cache full — evicted '%s'", evicted)
 
-    def invalidate_user_token(self, user_jwt: str, app_tid: str | None) -> None:
-        """Drop the cached user token for `(user_jwt, app_tid)` (no-op if absent)."""
-        key = self._hash_key(user_jwt, app_tid)
+    def invalidate_user_token(self, user_jwt: str, client_id: str) -> None:
+        """Drop the cached user token for `(user_jwt, client_id)` (no-op if absent)."""
+        key = self._hash_key(user_jwt, client_id)
         if self._user_tokens.pop(key, None):
-            logger.debug("Invalidated user token (app_tid=%s)", app_tid)
+            logger.debug("Invalidated user token (client_id=%s)", client_id)
 
     # --- Maintenance ---
 
@@ -182,7 +179,7 @@ class _TokenCache:
         self._user_tokens.clear()
 
     @staticmethod
-    def _hash_key(user_jwt: str, app_tid: str | None) -> str:
-        """Derive a short, stable cache key from `(user_jwt, app_tid)` via sha256."""
-        material = f"{user_jwt}|{app_tid or ''}"
+    def _hash_key(user_jwt: str, client_id: str) -> str:
+        """Derive a short, stable cache key from `(user_jwt, client_id)` via sha256."""
+        material = f"{user_jwt}|{client_id}"
         return hashlib.sha256(material.encode()).hexdigest()[:16]

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -61,36 +61,6 @@ def _parse_jwt_exp(jwt: str) -> int | None:
         return None
 
 
-def compute_expires_at(token_data: dict, config: ClientConfig) -> float:
-    """Resolve the cache expiry timestamp (monotonic) for a token response.
-
-    Resolution order:
-      1. `expires_in` from the response, minus the buffer.
-      2. `exp` claim from `id_token` (translated from wall clock to monotonic),
-         minus the buffer.
-      3. Config-provided fallback TTL.
-    """
-    now_mono = time.monotonic()
-    buffer = config.token_expiry_buffer_seconds
-
-    expires_in = token_data.get("expires_in")
-    if expires_in is not None:
-        try:
-            return now_mono + int(expires_in) - buffer
-        except (ValueError, TypeError):
-            pass
-
-    id_token = token_data.get("id_token")
-    if id_token:
-        exp = _parse_jwt_exp(id_token)
-        if exp is not None:
-            remaining = exp - time.time()
-            if remaining > buffer:
-                return now_mono + remaining - buffer
-
-    return now_mono + config.fallback_token_ttl_seconds
-
-
 class _TokenCache:
     """Per-client token cache with TTL and LRU eviction.
 
@@ -170,6 +140,37 @@ class _TokenCache:
         key = self._hash_key(user_jwt, client_id)
         if self._user_tokens.pop(key, None):
             logger.debug("Invalidated user token (client_id=%s)", client_id)
+
+    # --- Utility ---
+
+    def compute_expires_at(self, token_data: dict) -> float:
+        """Resolve the cache expiry timestamp (monotonic) for a token response.
+
+        Resolution order:
+        1. `expires_in` from the response, minus the buffer.
+        2. `exp` claim from `id_token` (translated from wall clock to monotonic),
+            minus the buffer.
+        3. Config-provided fallback TTL.
+        """
+        now_mono = time.monotonic()
+        buffer = self._config.token_expiry_buffer_seconds
+
+        expires_in = token_data.get("expires_in")
+        if expires_in is not None:
+            try:
+                return now_mono + int(expires_in) - buffer
+            except (ValueError, TypeError):
+                pass
+
+        id_token = token_data.get("id_token")
+        if id_token:
+            exp = _parse_jwt_exp(id_token)
+            if exp is not None:
+                remaining = exp - time.time()
+                if remaining > buffer:
+                    return now_mono + remaining - buffer
+
+        return now_mono + self._config.fallback_token_ttl_seconds
 
     # --- Maintenance ---
 

--- a/src/sap_cloud_sdk/agentgateway/_token_cache.py
+++ b/src/sap_cloud_sdk/agentgateway/_token_cache.py
@@ -1,9 +1,8 @@
-"""Token cache for Agent Gateway customer flow.
+"""Token cache for Agent Gateway flows.
 
 Caches IAS tokens (system + user-exchanged) per client to avoid redundant
-mTLS token requests during agentic loops. LoB flow uses BTP Destination
-Service which has its own caching, so this module only serves the customer
-flow.
+token requests during agentic loops. Used by both customer flow (mTLS) and
+LoB flow (BTP Destination Service).
 
 Keying:
 - System tokens are keyed by `client_id` (or "_default" when unset).
@@ -59,6 +58,36 @@ def _parse_jwt_exp(jwt: str) -> int | None:
         return int(exp) if exp is not None else None
     except (ValueError, KeyError, TypeError, json.JSONDecodeError):
         return None
+
+
+def compute_expires_at(token_data: dict, config: ClientConfig) -> float:
+    """Resolve the cache expiry timestamp (monotonic) for a token response.
+
+    Resolution order:
+    1. `expires_in` from the response, minus the buffer.
+    2. `exp` claim from `id_token` (translated from wall clock to monotonic),
+        minus the buffer.
+    3. Config-provided fallback TTL.
+    """
+    now_mono = time.monotonic()
+    buffer = config.token_expiry_buffer_seconds
+
+    expires_in = token_data.get("expires_in")
+    if expires_in is not None:
+        try:
+            return now_mono + int(expires_in) - buffer
+        except (ValueError, TypeError):
+            pass
+
+    id_token = token_data.get("id_token")
+    if id_token:
+        exp = _parse_jwt_exp(id_token)
+        if exp is not None:
+            remaining = exp - time.time()
+            if remaining > buffer:
+                return now_mono + remaining - buffer
+
+    return now_mono + config.fallback_token_ttl_seconds
 
 
 class _TokenCache:
@@ -144,31 +173,24 @@ class _TokenCache:
     # --- Utility ---
 
     def compute_expires_at(self, token_data: dict) -> float:
-        """Resolve the cache expiry timestamp (monotonic) for a token response.
+        """Resolve the cache expiry timestamp (monotonic) for a token response."""
+        return compute_expires_at(token_data, self._config)
 
-        Resolution order:
-        1. `expires_in` from the response, minus the buffer.
-        2. `exp` claim from `id_token` (translated from wall clock to monotonic),
-            minus the buffer.
-        3. Config-provided fallback TTL.
+    def compute_expires_at_from_bearer(self, auth_header: str) -> float:
+        """Resolve the cache expiry timestamp for a bearer auth header string.
+
+        Strips the 'Bearer ' prefix and parses the `exp` claim from the JWT.
+        Falls back to the config-provided fallback TTL if parsing fails.
         """
         now_mono = time.monotonic()
         buffer = self._config.token_expiry_buffer_seconds
 
-        expires_in = token_data.get("expires_in")
-        if expires_in is not None:
-            try:
-                return now_mono + int(expires_in) - buffer
-            except (ValueError, TypeError):
-                pass
-
-        id_token = token_data.get("id_token")
-        if id_token:
-            exp = _parse_jwt_exp(id_token)
-            if exp is not None:
-                remaining = exp - time.time()
-                if remaining > buffer:
-                    return now_mono + remaining - buffer
+        jwt = auth_header[7:] if auth_header.lower().startswith("bearer ") else auth_header
+        exp = _parse_jwt_exp(jwt)
+        if exp is not None:
+            remaining = exp - time.time()
+            if remaining > buffer:
+                return now_mono + remaining - buffer
 
         return now_mono + self._config.fallback_token_ttl_seconds
 

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -88,6 +88,7 @@ class AgentGatewayClient:
         self._config = config or ClientConfig()
         self._token_cache = _TokenCache(self._config)
 
+    @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_CLEAR_TOKEN_CACHE)
     def clear_token_cache(self) -> None:
         """Drop all cached tokens. Forces a fresh token fetch on the next call.
 

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -172,7 +172,9 @@ class AgentGatewayClient:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await get_mcp_tools_lob(tenant, self._config.timeout, self._token_cache)
+            return await get_mcp_tools_lob(
+                tenant, self._config.timeout, self._token_cache
+            )
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is
@@ -274,7 +276,12 @@ class AgentGatewayClient:
 
             tenant = self._resolve_tenant_subdomain()
             return await call_mcp_tool_lob(
-                tool, resolved_user_token, tenant, self._config.timeout, self._token_cache, **kwargs
+                tool,
+                resolved_user_token,
+                tenant,
+                self._config.timeout,
+                self._token_cache,
+                **kwargs,
             )
 
         except AgentGatewaySDKError:

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -11,6 +11,7 @@ import logging
 from typing import Callable
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
 from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway._customer import (
     detect_customer_agent_credentials,
@@ -85,6 +86,16 @@ class AgentGatewayClient:
         """
         self._tenant_subdomain = tenant_subdomain
         self._config = config or ClientConfig()
+        self._token_cache = _TokenCache(self._config)
+
+    def clear_token_cache(self) -> None:
+        """Drop all cached tokens. Forces a fresh token fetch on the next call.
+
+        Useful when external state (revoked credentials, tenant change) makes
+        cached tokens unsafe to reuse, or for testing. No-op for LoB flow,
+        which delegates caching to BTP Destination Service.
+        """
+        self._token_cache.clear()
 
     @staticmethod
     def _resolve_value(
@@ -158,7 +169,11 @@ class AgentGatewayClient:
                 )
                 credentials = load_customer_credentials(credentials_path)
                 return await get_mcp_tools_customer(
-                    credentials, self._config.timeout, app_tid
+                    credentials,
+                    self._config.timeout,
+                    self._config,
+                    self._token_cache,
+                    app_tid,
                 )
 
             # LoB flow - requires tenant_subdomain
@@ -251,6 +266,8 @@ class AgentGatewayClient:
                     tool,
                     resolved_user_token,
                     self._config.timeout,
+                    self._config,
+                    self._token_cache,
                     app_tid,
                     **kwargs,
                 )

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -172,7 +172,7 @@ class AgentGatewayClient:
                 logger.warning("app_tid parameter ignored for LoB agent flow")
 
             tenant = self._resolve_tenant_subdomain()
-            return await get_mcp_tools_lob(tenant, self._config.timeout)
+            return await get_mcp_tools_lob(tenant, self._config.timeout, self._token_cache)
 
         except AgentGatewaySDKError:
             # Re-raise SDK errors as-is
@@ -274,7 +274,7 @@ class AgentGatewayClient:
 
             tenant = self._resolve_tenant_subdomain()
             return await call_mcp_tool_lob(
-                tool, resolved_user_token, tenant, self._config.timeout, **kwargs
+                tool, resolved_user_token, tenant, self._config.timeout, self._token_cache, **kwargs
             )
 
         except AgentGatewaySDKError:

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -88,16 +88,6 @@ class AgentGatewayClient:
         self._config = config or ClientConfig()
         self._token_cache = _TokenCache(self._config)
 
-    @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_CLEAR_TOKEN_CACHE)
-    def clear_token_cache(self) -> None:
-        """Drop all cached tokens. Forces a fresh token fetch on the next call.
-
-        Useful when external state (revoked credentials, tenant change) makes
-        cached tokens unsafe to reuse, or for testing. No-op for LoB flow,
-        which delegates caching to BTP Destination Service.
-        """
-        self._token_cache.clear()
-
     @staticmethod
     def _resolve_value(
         value: str | Callable[[], str] | None,

--- a/src/sap_cloud_sdk/agentgateway/config.py
+++ b/src/sap_cloud_sdk/agentgateway/config.py
@@ -3,6 +3,10 @@
 from dataclasses import dataclass
 
 DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_TOKEN_EXPIRY_BUFFER_SECONDS = 60
+DEFAULT_MAX_USER_TOKEN_CACHE_SIZE = 10
+DEFAULT_MAX_SYSTEM_TOKEN_CACHE_SIZE = 10
+DEFAULT_FALLBACK_TOKEN_TTL_SECONDS = 300
 
 
 @dataclass
@@ -12,6 +16,20 @@ class ClientConfig:
     Attributes:
         timeout: HTTP timeout in seconds for token requests and MCP server calls.
             Defaults to 60 seconds.
+        token_expiry_buffer_seconds: Refresh tokens this many seconds before
+            their reported expiry. Defaults to 60 seconds.
+        max_user_token_cache_size: Maximum number of user tokens cached
+            per client. LRU eviction once exceeded. Defaults to 10.
+        max_system_token_cache_size: Maximum number of system tokens cached
+            per client (one per app_tid). LRU eviction once exceeded.
+            Defaults to 10.
+        fallback_token_ttl_seconds: TTL applied when neither `expires_in`
+            nor a parseable `id_token` exp claim is available in the token
+            response. Defaults to 300 seconds.
     """
 
     timeout: float = DEFAULT_TIMEOUT_SECONDS
+    token_expiry_buffer_seconds: int = DEFAULT_TOKEN_EXPIRY_BUFFER_SECONDS
+    max_user_token_cache_size: int = DEFAULT_MAX_USER_TOKEN_CACHE_SIZE
+    max_system_token_cache_size: int = DEFAULT_MAX_SYSTEM_TOKEN_CACHE_SIZE
+    fallback_token_ttl_seconds: int = DEFAULT_FALLBACK_TOKEN_TTL_SECONDS

--- a/src/sap_cloud_sdk/core/telemetry/operation.py
+++ b/src/sap_cloud_sdk/core/telemetry/operation.py
@@ -114,7 +114,6 @@ class Operation(str, Enum):
     # Agent Gateway Operations
     AGENTGATEWAY_LIST_MCP_TOOLS = "list_mcp_tools"
     AGENTGATEWAY_CALL_MCP_TOOL = "call_mcp_tool"
-    AGENTGATEWAY_CLEAR_TOKEN_CACHE = "clear_token_cache"
 
     # Agent Memory Operations
     AGENT_MEMORY_ADD_MEMORY = "add_memory"

--- a/src/sap_cloud_sdk/core/telemetry/operation.py
+++ b/src/sap_cloud_sdk/core/telemetry/operation.py
@@ -114,6 +114,7 @@ class Operation(str, Enum):
     # Agent Gateway Operations
     AGENTGATEWAY_LIST_MCP_TOOLS = "list_mcp_tools"
     AGENTGATEWAY_CALL_MCP_TOOL = "call_mcp_tool"
+    AGENTGATEWAY_CLEAR_TOKEN_CACHE = "clear_token_cache"
 
     # Agent Memory Operations
     AGENT_MEMORY_ADD_MEMORY = "add_memory"

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -1,7 +1,9 @@
 """Unit tests for Agent Gateway client."""
 
-from unittest.mock import patch, AsyncMock
+import time
+from unittest.mock import patch, AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from sap_cloud_sdk.agentgateway import (
@@ -9,6 +11,10 @@ from sap_cloud_sdk.agentgateway import (
     AgentGatewayClient,
     MCPTool,
     AgentGatewaySDKError,
+)
+from sap_cloud_sdk.agentgateway._models import (
+    CustomerCredentials,
+    IntegrationDependency,
 )
 
 
@@ -411,3 +417,273 @@ class TestCallMcpTool:
             )
 
             assert result == "Success: Order created"
+
+
+# ============================================================
+# Test: Token cache behavior through the public API
+# ============================================================
+
+
+def _customer_credentials() -> CustomerCredentials:
+    """Build a minimal CustomerCredentials fixture for cache-behavior tests."""
+    return CustomerCredentials(
+        token_service_url="https://ias.example.com/oauth2/token",
+        client_id="test-client",
+        certificate="cert",
+        private_key="key",
+        gateway_url="https://agw.example.com",
+        integration_dependencies=[
+            IntegrationDependency(
+                ord_id="sap.test:apiResource:demo:v1",
+                global_tenant_id="250695",
+            ),
+        ],
+    )
+
+
+def _build_streaming_mocks(
+    initialize_side_effect=None,
+    call_tool_side_effect=None,
+    list_tools_side_effect=None,
+):
+    """Build the chain of mocks needed to drive customer flow MCP calls."""
+    http_client = AsyncMock()
+    http_client.__aenter__ = AsyncMock(return_value=http_client)
+    http_client.__aexit__ = AsyncMock(return_value=None)
+
+    stream_ctx = AsyncMock()
+    stream_ctx.__aenter__ = AsyncMock(return_value=(AsyncMock(), AsyncMock(), None))
+    stream_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    session = AsyncMock()
+    if initialize_side_effect is not None:
+        session.initialize = AsyncMock(side_effect=initialize_side_effect)
+    else:
+        init_result = MagicMock()
+        init_result.serverInfo.name = "demo-server"
+        session.initialize = AsyncMock(return_value=init_result)
+
+    if list_tools_side_effect is not None:
+        session.list_tools = AsyncMock(side_effect=list_tools_side_effect)
+    else:
+        list_result = MagicMock()
+        list_result.tools = []
+        session.list_tools = AsyncMock(return_value=list_result)
+
+    if call_tool_side_effect is not None:
+        session.call_tool = AsyncMock(side_effect=call_tool_side_effect)
+    else:
+        call_result = MagicMock()
+        content = MagicMock()
+        content.text = "ok"
+        call_result.content = [content]
+        session.call_tool = AsyncMock(return_value=call_result)
+
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session)
+    session_ctx.__aexit__ = AsyncMock(return_value=None)
+
+    return http_client, stream_ctx, session_ctx
+
+
+def _make_401() -> httpx.HTTPStatusError:
+    """Construct an httpx 401 HTTPStatusError for simulating MCP auth failures."""
+    request = httpx.Request("POST", "https://example.com")
+    response = httpx.Response(401, request=request)
+    return httpx.HTTPStatusError("Unauthorized", request=request, response=response)
+
+
+def _patch_customer_flow(token_request_side_effect):
+    """Patch detection/loading + IAS request + MCP transport for customer flow.
+
+    Returns the http/stream/session mocks plus the IAS request mock so callers
+    can assert on call counts.
+    """
+    http_client, stream_ctx, session_ctx = _build_streaming_mocks()
+
+    request_mock = MagicMock(side_effect=token_request_side_effect)
+
+    patches = [
+        patch(
+            "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+            return_value="/path/to/credentials",
+        ),
+        patch(
+            "sap_cloud_sdk.agentgateway.agw_client.load_customer_credentials",
+            return_value=_customer_credentials(),
+        ),
+        patch(
+            "sap_cloud_sdk.agentgateway._customer._request_token_mtls",
+            request_mock,
+        ),
+        patch("httpx.AsyncClient", return_value=http_client),
+        patch(
+            "sap_cloud_sdk.agentgateway._customer.streamable_http_client",
+            return_value=stream_ctx,
+        ),
+        patch(
+            "sap_cloud_sdk.agentgateway._customer.ClientSession",
+            return_value=session_ctx,
+        ),
+    ]
+    return patches, request_mock, session_ctx
+
+
+class TestTokenCacheBehavior:
+    """Cache behavior verified through AgentGatewayClient public API."""
+
+    @pytest.mark.asyncio
+    async def test_list_mcp_tools_twice_hits_ias_once(self, mock_tool):
+        """Two list_mcp_tools calls share one cached system token."""
+        patches, request_mock, _ = _patch_customer_flow(
+            token_request_side_effect=lambda *a, **kw: (
+                "system-token",
+                time.monotonic() + 600,
+            )
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            agw_client = create_client()
+
+            await agw_client.list_mcp_tools()
+            await agw_client.list_mcp_tools()
+
+            assert request_mock.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_call_mcp_tool_twice_same_user_token_hits_ias_once(self, mock_tool):
+        """Two call_mcp_tool calls with same user_token reuse exchanged token."""
+        patches, request_mock, _ = _patch_customer_flow(
+            token_request_side_effect=lambda *a, **kw: (
+                "exchanged-token",
+                time.monotonic() + 600,
+            )
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            agw_client = create_client()
+
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt-A")
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt-A")
+
+            assert request_mock.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_different_user_tokens_isolated(self, mock_tool):
+        """Different user_tokens trigger separate exchanges."""
+        patches, request_mock, _ = _patch_customer_flow(
+            token_request_side_effect=[
+                ("tok-A", time.monotonic() + 600),
+                ("tok-B", time.monotonic() + 600),
+            ]
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            agw_client = create_client()
+
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt-A")
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt-B")
+
+            assert request_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_app_tid_isolation(self, mock_tool):
+        """Same user_token across different app_tid values stays isolated."""
+        patches, request_mock, _ = _patch_customer_flow(
+            token_request_side_effect=[
+                ("tok-tenant-a", time.monotonic() + 600),
+                ("tok-tenant-b", time.monotonic() + 600),
+            ]
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            agw_client = create_client()
+
+            await agw_client.call_mcp_tool(
+                tool=mock_tool, user_token="user-jwt", app_tid="tenant-a"
+            )
+            await agw_client.call_mcp_tool(
+                tool=mock_tool, user_token="user-jwt", app_tid="tenant-b"
+            )
+
+            assert request_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_clear_token_cache_forces_refetch(self, mock_tool):
+        """clear_token_cache drops cached tokens, next call refetches."""
+        patches, request_mock, _ = _patch_customer_flow(
+            token_request_side_effect=lambda *a, **kw: (
+                "any-token",
+                time.monotonic() + 600,
+            )
+        )
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            agw_client = create_client()
+
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt")
+            agw_client.clear_token_cache()
+            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt")
+
+            assert request_mock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_401_invalidates_cache_and_retries(self, mock_tool):
+        """A 401 from the MCP server drops the cached token and retries once."""
+        http_client, stream_ctx, _ = _build_streaming_mocks()
+
+        # First call_tool raises 401, second returns success
+        success = MagicMock()
+        content = MagicMock()
+        content.text = "ok-after-retry"
+        success.content = [content]
+
+        session = AsyncMock()
+        init_result = MagicMock()
+        init_result.serverInfo.name = "demo-server"
+        session.initialize = AsyncMock(return_value=init_result)
+        session.call_tool = AsyncMock(side_effect=[_make_401(), success])
+        session_ctx = AsyncMock()
+        session_ctx.__aenter__ = AsyncMock(return_value=session)
+        session_ctx.__aexit__ = AsyncMock(return_value=None)
+
+        request_mock = MagicMock(
+            side_effect=[
+                ("stale-token", time.monotonic() + 600),
+                ("fresh-token", time.monotonic() + 600),
+            ]
+        )
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+                return_value="/path/to/credentials",
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.load_customer_credentials",
+                return_value=_customer_credentials(),
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._customer._request_token_mtls",
+                request_mock,
+            ),
+            patch("httpx.AsyncClient", return_value=http_client),
+            patch(
+                "sap_cloud_sdk.agentgateway._customer.streamable_http_client",
+                return_value=stream_ctx,
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._customer.ClientSession",
+                return_value=session_ctx,
+            ),
+        ):
+            agw_client = create_client()
+
+            result = await agw_client.call_mcp_tool(
+                tool=mock_tool, user_token="user-jwt"
+            )
+
+            assert result == "ok-after-retry"
+            # Stale exchange + fresh exchange after invalidation
+            assert request_mock.call_count == 2
+

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -1,7 +1,7 @@
 """Unit tests for Agent Gateway client."""
 
 import time
-from unittest.mock import patch, AsyncMock, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock, ANY
 
 import httpx
 import pytest
@@ -171,7 +171,7 @@ class TestListMcpTools:
 
             await agw_client.list_mcp_tools()
 
-            mock_lob.assert_called_once_with("my-tenant", 60.0)
+            mock_lob.assert_called_once_with("my-tenant", 60.0, ANY)
 
     @pytest.mark.asyncio
     async def test_calls_lob_flow(self):
@@ -191,7 +191,7 @@ class TestListMcpTools:
 
             await agw_client.list_mcp_tools()
 
-            mock_lob.assert_called_once_with("my-tenant", 60.0)
+            mock_lob.assert_called_once_with("my-tenant", 60.0, ANY)
 
     @pytest.mark.asyncio
     async def test_returns_tools_from_lob_flow(self):
@@ -312,7 +312,7 @@ class TestCallMcpTool:
 
             assert result == "result"
             mock_lob.assert_called_once_with(
-                mock_tool, "my-jwt", "my-tenant", 60.0, param1="value1"
+                mock_tool, "my-jwt", "my-tenant", 60.0, ANY, param1="value1"
             )
 
     @pytest.mark.asyncio
@@ -338,7 +338,7 @@ class TestCallMcpTool:
             )
 
             assert result == "result"
-            mock_lob.assert_called_once_with(mock_tool, "my-jwt", "my-tenant", 60.0)
+            mock_lob.assert_called_once_with(mock_tool, "my-jwt", "my-tenant", 60.0, ANY)
 
     @pytest.mark.asyncio
     async def test_customer_credentials_calls_customer_flow(self, mock_tool):
@@ -392,7 +392,7 @@ class TestCallMcpTool:
 
             assert result == "tool result"
             mock_lob.assert_called_once_with(
-                mock_tool, "jwt-token", "my-tenant", 60.0, order_id="12345"
+                mock_tool, "jwt-token", "my-tenant", 60.0, ANY, order_id="12345"
             )
 
     @pytest.mark.asyncio

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -609,25 +609,6 @@ class TestTokenCacheBehavior:
             assert request_mock.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_clear_token_cache_forces_refetch(self, mock_tool):
-        """clear_token_cache drops cached tokens, next call refetches."""
-        patches, request_mock, _ = _patch_customer_flow(
-            token_request_side_effect=lambda *a, **kw: (
-                "any-token",
-                time.monotonic() + 600,
-            )
-        )
-
-        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
-            agw_client = create_client()
-
-            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt")
-            agw_client.clear_token_cache()
-            await agw_client.call_mcp_tool(tool=mock_tool, user_token="user-jwt")
-
-            assert request_mock.call_count == 2
-
-    @pytest.mark.asyncio
     async def test_401_invalidates_cache_and_retries(self, mock_tool):
         """A 401 from the MCP server drops the cached token and retries once."""
         http_client, stream_ctx, _ = _build_streaming_mocks()

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -587,12 +587,11 @@ class TestTokenCacheBehavior:
             assert request_mock.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_app_tid_isolation(self, mock_tool):
-        """Same user_token across different app_tid values stays isolated."""
+    async def test_same_user_token_different_app_tid_shares_cache(self, mock_tool):
+        """Same user_token + same client_id shares cache regardless of app_tid."""
         patches, request_mock, _ = _patch_customer_flow(
             token_request_side_effect=[
                 ("tok-tenant-a", time.monotonic() + 600),
-                ("tok-tenant-b", time.monotonic() + 600),
             ]
         )
 
@@ -606,7 +605,7 @@ class TestTokenCacheBehavior:
                 tool=mock_tool, user_token="user-jwt", app_tid="tenant-b"
             )
 
-            assert request_mock.call_count == 2
+            assert request_mock.call_count == 1
 
     @pytest.mark.asyncio
     async def test_401_invalidates_cache_and_retries(self, mock_tool):

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -16,6 +16,8 @@ from sap_cloud_sdk.agentgateway._customer import (
     _CREDENTIALS_PATH_ENV,
     _CREDENTIALS_DEFAULT_PATH,
 )
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
+from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway._models import (
     CustomerCredentials,
     IntegrationDependency,
@@ -305,7 +307,9 @@ class TestGetSystemTokenMtls:
             mock_client.post.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = get_system_token_mtls(credentials, timeout=60.0)
+            result = get_system_token_mtls(
+                credentials, timeout=60.0, config=ClientConfig(), cache=_TokenCache(ClientConfig())
+            )
 
             assert result == "system-token-123"
             mock_client.post.assert_called_once()
@@ -332,7 +336,12 @@ class TestGetSystemTokenMtls:
             mock_client_class.return_value = mock_client
 
             with pytest.raises(AgentGatewaySDKError, match="Token request failed"):
-                get_system_token_mtls(credentials, timeout=60.0)
+                get_system_token_mtls(
+                    credentials,
+                    timeout=60.0,
+                    config=ClientConfig(),
+                    cache=_TokenCache(ClientConfig()),
+                )
 
 
 # ============================================================
@@ -374,7 +383,13 @@ class TestExchangeUserToken:
             mock_client.post.return_value = mock_response
             mock_client_class.return_value = mock_client
 
-            result = exchange_user_token(credentials, "user-jwt-token", timeout=60.0)
+            result = exchange_user_token(
+                credentials,
+                "user-jwt-token",
+                timeout=60.0,
+                config=ClientConfig(),
+                cache=_TokenCache(ClientConfig()),
+            )
 
             assert result == "exchanged-token-123"
             call_args = mock_client.post.call_args
@@ -403,7 +418,12 @@ class TestExchangeUserToken:
             mock_client_class.return_value = mock_client
 
             result = exchange_user_token(
-                credentials, "user-jwt", timeout=60.0, app_tid="test-tid"
+                credentials,
+                "user-jwt",
+                timeout=60.0,
+                config=ClientConfig(),
+                cache=_TokenCache(ClientConfig()),
+                app_tid="test-tid",
             )
 
             assert result == "token-with-tid"
@@ -451,7 +471,12 @@ class TestGetMcpToolsCustomer:
         with pytest.raises(
             AgentGatewaySDKError, match="integrationDependencies is empty"
         ):
-            await get_mcp_tools_customer(credentials, timeout=60.0)
+            await get_mcp_tools_customer(
+                credentials,
+                timeout=60.0,
+                config=ClientConfig(),
+                cache=_TokenCache(ClientConfig()),
+            )
 
     @pytest.mark.asyncio
     async def test_discovers_tools_from_credentials(self, credentials):
@@ -477,7 +502,12 @@ class TestGetMcpToolsCustomer:
                 return_value=mock_tools,
             ) as mock_list,
         ):
-            result = await get_mcp_tools_customer(credentials, timeout=60.0)
+            result = await get_mcp_tools_customer(
+                credentials,
+                timeout=60.0,
+                config=ClientConfig(),
+                cache=_TokenCache(ClientConfig()),
+            )
 
             assert len(result) == 1
             assert result[0].name == "list_cost_centers"
@@ -525,7 +555,12 @@ class TestGetMcpToolsCustomer:
                 side_effect=mock_list_tools,
             ),
         ):
-            result = await get_mcp_tools_customer(credentials, timeout=60.0)
+            result = await get_mcp_tools_customer(
+                credentials,
+                timeout=60.0,
+                config=ClientConfig(),
+                cache=_TokenCache(ClientConfig()),
+            )
 
             # Should still return tools from server2
             assert len(result) == 1
@@ -615,11 +650,21 @@ class TestCallMcpToolCustomer:
             mock_session_class.return_value = mock_session_ctx
 
             result = await call_mcp_tool_customer(
-                credentials, mock_tool, "user-jwt", 60.0, order_id="12345"
+                credentials,
+                mock_tool,
+                "user-jwt",
+                60.0,
+                ClientConfig(),
+                _TokenCache(ClientConfig()),
+                order_id="12345",
             )
 
             assert result == "Order created successfully"
-            mock_exchange.assert_called_once_with(credentials, "user-jwt", 60.0, None)
+            mock_exchange.assert_called_once()
+            args, _ = mock_exchange.call_args
+            assert args[0] is credentials
+            assert args[1] == "user-jwt"
+            assert args[2] == 60.0
 
     @pytest.mark.asyncio
     async def test_uses_system_token_when_user_token_not_provided(
@@ -671,10 +716,20 @@ class TestCallMcpToolCustomer:
 
             # Call without user_token (None)
             result = await call_mcp_tool_customer(
-                credentials, mock_tool, None, 60.0, order_id="12345"
+                credentials,
+                mock_tool,
+                None,
+                60.0,
+                ClientConfig(),
+                _TokenCache(ClientConfig()),
+                order_id="12345",
             )
 
             assert result == "Result with system token"
             # Should use system token, not exchange
-            mock_system_token.assert_called_once_with(credentials, 60.0, None)
+            mock_system_token.assert_called_once()
+            args, _ = mock_system_token.call_args
+            assert args[0] is credentials
+            assert args[1] == 60.0
             mock_exchange.assert_not_called()
+

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -308,7 +308,7 @@ class TestGetSystemTokenMtls:
             mock_client_class.return_value = mock_client
 
             result = get_system_token_mtls(
-                credentials, timeout=60.0, config=ClientConfig(), cache=_TokenCache(ClientConfig())
+                credentials, timeout=60.0, cache=_TokenCache(ClientConfig())
             )
 
             assert result == "system-token-123"
@@ -339,7 +339,6 @@ class TestGetSystemTokenMtls:
                 get_system_token_mtls(
                     credentials,
                     timeout=60.0,
-                    config=ClientConfig(),
                     cache=_TokenCache(ClientConfig()),
                 )
 
@@ -387,7 +386,6 @@ class TestExchangeUserToken:
                 credentials,
                 "user-jwt-token",
                 timeout=60.0,
-                config=ClientConfig(),
                 cache=_TokenCache(ClientConfig()),
             )
 
@@ -421,7 +419,6 @@ class TestExchangeUserToken:
                 credentials,
                 "user-jwt",
                 timeout=60.0,
-                config=ClientConfig(),
                 cache=_TokenCache(ClientConfig()),
                 app_tid="test-tid",
             )

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -1,8 +1,10 @@
 """Unit tests for LoB agent flow."""
 
 import os
+import time
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import httpx
 import pytest
 
 from sap_cloud_sdk.agentgateway._lob import (
@@ -18,9 +20,15 @@ from sap_cloud_sdk.agentgateway._lob import (
     _MCP_LABEL_VALUE,
     _IAS_LABEL_VALUE,
 )
+from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
 from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.exceptions import MCPServerNotFoundError
 from sap_cloud_sdk.destination import ConsumptionLevel
+
+
+def _make_cache() -> _TokenCache:
+    return _TokenCache(ClientConfig())
 
 
 # ============================================================
@@ -250,8 +258,10 @@ class TestGetSystemAuth:
     """Tests for get_system_auth async function."""
 
     @pytest.mark.asyncio
-    async def test_fetches_system_auth(self):
-        """Fetch system auth using IAS fragment looked up by label."""
+    async def test_fetches_system_auth_on_cache_miss(self):
+        """Fetch system auth from Destination Service on cache miss."""
+        cache = _make_cache()
+
         with patch.dict(os.environ, {"APPFND_CONHOS_LANDSCAPE": "eu10"}):
             with (
                 patch(
@@ -264,7 +274,7 @@ class TestGetSystemAuth:
                 mock_ias.return_value = "sap-managed-runtime-agw-subscriber-ias-abc"
                 mock_fetch.return_value = "Bearer system-token"
 
-                result = await get_system_auth("tenant-sub")
+                result = await get_system_auth("tenant-sub", cache)
 
                 assert result == "Bearer system-token"
                 mock_ias.assert_called_once_with("tenant-sub")
@@ -278,6 +288,42 @@ class TestGetSystemAuth:
                 )
                 assert call_args[0][2].fragment_level == ConsumptionLevel.INSTANCE
 
+    @pytest.mark.asyncio
+    async def test_returns_cached_token_without_fetching(self):
+        """Return cached token without calling Destination Service."""
+        cache = _make_cache()
+        cache.set_system_token("Bearer cached-token", time.monotonic() + 600, "tenant-sub")
+
+        with (
+            patch("sap_cloud_sdk.agentgateway._lob.get_ias_fragment_name") as mock_ias,
+            patch("sap_cloud_sdk.agentgateway._lob._fetch_auth_token") as mock_fetch,
+        ):
+            result = await get_system_auth("tenant-sub", cache)
+
+            assert result == "Bearer cached-token"
+            mock_ias.assert_not_called()
+            mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caches_fetched_token(self):
+        """Store fetched token in cache so subsequent calls hit cache."""
+        cache = _make_cache()
+
+        with patch.dict(os.environ, {"APPFND_CONHOS_LANDSCAPE": "eu10"}):
+            with (
+                patch("sap_cloud_sdk.agentgateway._lob.get_ias_fragment_name") as mock_ias,
+                patch("sap_cloud_sdk.agentgateway._lob._fetch_auth_token") as mock_fetch,
+            ):
+                mock_ias.return_value = "ias-frag"
+                mock_fetch.return_value = "Bearer fresh-token"
+
+                await get_system_auth("tenant-sub", cache)
+                # Second call should hit cache
+                result = await get_system_auth("tenant-sub", cache)
+
+                assert result == "Bearer fresh-token"
+                mock_fetch.assert_called_once()  # only one Destination Service call
+
 
 # ============================================================
 # Test: get_user_auth
@@ -288,15 +334,17 @@ class TestGetUserAuth:
     """Tests for get_user_auth async function."""
 
     @pytest.mark.asyncio
-    async def test_fetches_user_auth_with_token_exchange(self):
-        """Fetch user auth with token exchange."""
+    async def test_fetches_user_auth_on_cache_miss(self):
+        """Fetch user auth with token exchange on cache miss."""
+        cache = _make_cache()
+
         with patch.dict(os.environ, {"APPFND_CONHOS_LANDSCAPE": "eu10"}):
             with patch(
                 "sap_cloud_sdk.agentgateway._lob._fetch_auth_token"
             ) as mock_fetch:
                 mock_fetch.return_value = "Bearer user-token"
 
-                result = await get_user_auth("mcp-fragment", "user-jwt", "tenant-sub")
+                result = await get_user_auth("mcp-fragment", "user-jwt", "tenant-sub", cache)
 
                 assert result == "Bearer user-token"
                 mock_fetch.assert_called_once()
@@ -307,6 +355,54 @@ class TestGetUserAuth:
                 assert options.user_token == "user-jwt"
                 assert options.fragment_name == "mcp-fragment"
                 assert options.fragment_level == ConsumptionLevel.INSTANCE
+
+    @pytest.mark.asyncio
+    async def test_returns_cached_user_token_without_fetching(self):
+        """Return cached user token without calling Destination Service."""
+        cache = _make_cache()
+        scope_key = "mcp-fragment|tenant-sub"
+        cache.set_user_token("user-jwt", "Bearer cached-user-token", time.monotonic() + 600, scope_key)
+
+        with patch("sap_cloud_sdk.agentgateway._lob._fetch_auth_token") as mock_fetch:
+            result = await get_user_auth("mcp-fragment", "user-jwt", "tenant-sub", cache)
+
+            assert result == "Bearer cached-user-token"
+            mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_caches_fetched_user_token(self):
+        """Store fetched user token in cache so subsequent calls hit cache."""
+        cache = _make_cache()
+
+        with patch.dict(os.environ, {"APPFND_CONHOS_LANDSCAPE": "eu10"}):
+            with patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_auth_token"
+            ) as mock_fetch:
+                mock_fetch.return_value = "Bearer fresh-user-token"
+
+                await get_user_auth("mcp-fragment", "user-jwt", "tenant-sub", cache)
+                result = await get_user_auth("mcp-fragment", "user-jwt", "tenant-sub", cache)
+
+                assert result == "Bearer fresh-user-token"
+                mock_fetch.assert_called_once()  # only one Destination Service call
+
+    @pytest.mark.asyncio
+    async def test_user_tokens_isolated_by_fragment(self):
+        """Different fragments produce separate cache entries."""
+        cache = _make_cache()
+
+        with patch.dict(os.environ, {"APPFND_CONHOS_LANDSCAPE": "eu10"}):
+            with patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_auth_token"
+            ) as mock_fetch:
+                mock_fetch.side_effect = ["Bearer token-frag-a", "Bearer token-frag-b"]
+
+                result_a = await get_user_auth("frag-a", "user-jwt", "tenant-sub", cache)
+                result_b = await get_user_auth("frag-b", "user-jwt", "tenant-sub", cache)
+
+                assert result_a == "Bearer token-frag-a"
+                assert result_b == "Bearer token-frag-b"
+                assert mock_fetch.call_count == 2
 
 
 # ============================================================
@@ -320,16 +416,19 @@ class TestGetMcpToolsLob:
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_fragments(self):
         """Return empty list when no fragments found."""
+        cache = _make_cache()
+
         with patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list:
             mock_list.return_value = []
 
-            result = await get_mcp_tools_lob("tenant-sub", 60.0)
+            result = await get_mcp_tools_lob("tenant-sub", 60.0, cache)
 
             assert result == []
 
     @pytest.mark.asyncio
     async def test_skips_fragments_without_url(self):
         """Skip fragments that don't have URL property."""
+        cache = _make_cache()
         fragment = MagicMock()
         fragment.name = "mcp-server-a"
         fragment.properties = {}  # No URL
@@ -337,13 +436,14 @@ class TestGetMcpToolsLob:
         with patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list:
             mock_list.return_value = [fragment]
 
-            result = await get_mcp_tools_lob("tenant-sub", 60.0)
+            result = await get_mcp_tools_lob("tenant-sub", 60.0, cache)
 
             assert result == []
 
     @pytest.mark.asyncio
     async def test_uses_fragment_name_directly(self):
         """Use fragment name as-is (no -technical stripping)."""
+        cache = _make_cache()
         fragment = MagicMock()
         fragment.name = "mcp-server-a"
         fragment.properties = {"URL": "https://example.com/mcp"}
@@ -372,18 +472,49 @@ class TestGetMcpToolsLob:
             mock_auth.return_value = "Bearer token"
             mock_tools.return_value = [mock_tool]
 
-            await get_mcp_tools_lob("tenant-sub", 60.0)
+            await get_mcp_tools_lob("tenant-sub", 60.0, cache)
 
-            # Verify get_system_auth called with just tenant_subdomain
-            mock_auth.assert_called_once_with("tenant-sub")
-            # Verify list_server_tools called with the unchanged fragment name
+            mock_auth.assert_called_once_with("tenant-sub", cache)
             mock_tools.assert_called_once()
             call_args = mock_tools.call_args[0]
             assert call_args[2] == "mcp-server-a"
 
     @pytest.mark.asyncio
-    async def test_handles_exception_for_single_fragment(self):
-        """Continue processing other fragments when one fails."""
+    async def test_reuses_system_auth_across_fragments(self):
+        """Fetch system auth once and reuse for all fragments."""
+        cache = _make_cache()
+        fragment1 = MagicMock()
+        fragment1.name = "frag-1"
+        fragment1.properties = {"URL": "https://example1.com/mcp"}
+
+        fragment2 = MagicMock()
+        fragment2.name = "frag-2"
+        fragment2.properties = {"URL": "https://example2.com/mcp"}
+
+        with (
+            patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.get_system_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_server_tools",
+                new_callable=AsyncMock,
+            ) as mock_tools,
+        ):
+            mock_list.return_value = [fragment1, fragment2]
+            mock_auth.return_value = "Bearer token"
+            mock_tools.return_value = []
+
+            await get_mcp_tools_lob("tenant-sub", 60.0, cache)
+
+            # get_system_auth called once — result reused for second fragment
+            mock_auth.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_non_401_exception_for_single_fragment(self):
+        """Continue processing other fragments when list_server_tools fails (non-401)."""
+        cache = _make_cache()
         fragment1 = MagicMock()
         fragment1.name = "mcp-server1"
         fragment1.properties = {"URL": "https://example1.com/mcp"}
@@ -413,16 +544,101 @@ class TestGetMcpToolsLob:
             ) as mock_tools,
         ):
             mock_list.return_value = [fragment1, fragment2]
+            mock_auth.return_value = "Bearer token"
+            mock_tools.side_effect = [Exception("Connection refused"), [mock_tool]]
 
-            # First fragment fails, second succeeds
-            mock_auth.side_effect = [Exception("Auth failed"), "Bearer token"]
-            mock_tools.return_value = [mock_tool]
+            result = await get_mcp_tools_lob("tenant-sub", 60.0, cache)
 
-            result = await get_mcp_tools_lob("tenant-sub", 60.0)
-
-            # Should still get tools from second fragment
             assert len(result) == 1
             assert result[0].name == "tool2"
+
+    @pytest.mark.asyncio
+    async def test_retries_on_401_and_succeeds(self):
+        """On 401 from list_server_tools: invalidate system token, retry, succeed."""
+        cache = _make_cache()
+        fragment = MagicMock()
+        fragment.name = "mcp-server"
+        fragment.properties = {"URL": "https://example.com/mcp"}
+
+        mock_tool = MCPTool(
+            name="tool",
+            server_name="server",
+            description="Test",
+            input_schema={},
+            url="https://example.com/mcp",
+            fragment_name="mcp-server",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        unauthorized = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+
+        with (
+            patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.get_system_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_server_tools",
+                new_callable=AsyncMock,
+            ) as mock_tools,
+        ):
+            mock_list.return_value = [fragment]
+            mock_auth.side_effect = ["Bearer stale-token", "Bearer fresh-token"]
+            mock_tools.side_effect = [unauthorized, [mock_tool]]
+
+            result = await get_mcp_tools_lob("tenant-sub", 60.0, cache)
+
+            assert len(result) == 1
+            assert mock_auth.call_count == 2
+            assert mock_tools.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_fragment_after_two_401s(self):
+        """On 401 on both attempts: skip fragment, continue with others."""
+        cache = _make_cache()
+        fragment1 = MagicMock()
+        fragment1.name = "bad-server"
+        fragment1.properties = {"URL": "https://bad.example.com/mcp"}
+
+        fragment2 = MagicMock()
+        fragment2.name = "good-server"
+        fragment2.properties = {"URL": "https://good.example.com/mcp"}
+
+        mock_tool = MCPTool(
+            name="good-tool",
+            server_name="good-server",
+            description="Test",
+            input_schema={},
+            url="https://good.example.com/mcp",
+            fragment_name="good-server",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        unauthorized = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+
+        with (
+            patch("sap_cloud_sdk.agentgateway._lob.list_mcp_fragments") as mock_list,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.get_system_auth",
+                new_callable=AsyncMock,
+            ) as mock_auth,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_server_tools",
+                new_callable=AsyncMock,
+            ) as mock_tools,
+        ):
+            mock_list.return_value = [fragment1, fragment2]
+            mock_auth.return_value = "Bearer token"
+            # fragment1: 401 on both attempts; fragment2: success
+            mock_tools.side_effect = [unauthorized, unauthorized, [mock_tool]]
+
+            result = await get_mcp_tools_lob("tenant-sub", 60.0, cache)
+
+            assert len(result) == 1
+            assert result[0].name == "good-tool"
 
 
 # ============================================================
@@ -436,6 +652,7 @@ class TestCallMcpToolLob:
     @pytest.mark.asyncio
     async def test_calls_tool_with_user_auth(self):
         """Call tool using user authentication."""
+        cache = _make_cache()
         tool = MCPTool(
             name="test-tool",
             server_name="test-server",
@@ -461,7 +678,6 @@ class TestCallMcpToolLob:
         ):
             mock_auth.return_value = "Bearer user-token"
 
-            # Setup async context managers
             mock_http_instance = AsyncMock()
             mock_http.return_value.__aenter__.return_value = mock_http_instance
 
@@ -477,11 +693,13 @@ class TestCallMcpToolLob:
             mock_session.return_value.__aenter__.return_value = mock_session_instance
 
             result = await call_mcp_tool_lob(
-                tool, "user-jwt", "tenant-sub", 60.0, param1="value1"
+                tool, "user-jwt", "tenant-sub", 60.0, cache, param1="value1"
             )
 
             assert result == "Tool result"
-            mock_auth.assert_called_once_with("test-fragment", "user-jwt", "tenant-sub")
+            mock_auth.assert_called_once_with(
+                "test-fragment", "user-jwt", "tenant-sub", cache
+            )
             mock_session_instance.call_tool.assert_called_once_with(
                 "test-tool", {"param1": "value1"}
             )
@@ -489,6 +707,7 @@ class TestCallMcpToolLob:
     @pytest.mark.asyncio
     async def test_returns_empty_string_when_no_content(self):
         """Return empty string when tool returns no content."""
+        cache = _make_cache()
         tool = MCPTool(
             name="test-tool",
             server_name="test-server",
@@ -527,6 +746,135 @@ class TestCallMcpToolLob:
             mock_session_instance.call_tool = AsyncMock(return_value=mock_result)
             mock_session.return_value.__aenter__.return_value = mock_session_instance
 
-            result = await call_mcp_tool_lob(tool, "user-jwt", "tenant-sub", 60.0)
+            result = await call_mcp_tool_lob(tool, "user-jwt", "tenant-sub", 60.0, cache)
 
             assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_401_and_succeeds(self):
+        """On 401 from MCP server: invalidate cached user token, retry, succeed."""
+        cache = _make_cache()
+        tool = MCPTool(
+            name="test-tool",
+            server_name="test-server",
+            description="Test tool",
+            input_schema={},
+            url="https://example.com/mcp",
+            fragment_name="test-fragment",
+        )
+
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock()]
+        mock_result.content[0].text = "Success after retry"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        unauthorized = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.get_user_auth", new_callable=AsyncMock
+            ) as mock_auth,
+            patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.streamable_http_client"
+            ) as mock_stream,
+            patch("sap_cloud_sdk.agentgateway._lob.ClientSession") as mock_session,
+        ):
+            mock_auth.side_effect = ["Bearer stale-token", "Bearer fresh-token"]
+
+            mock_http_instance = AsyncMock()
+            mock_http.return_value.__aenter__ = AsyncMock(return_value=mock_http_instance)
+            mock_http.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_stream.return_value.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), None)
+            )
+            mock_stream.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_session_instance = AsyncMock()
+            mock_session_instance.initialize = AsyncMock()
+            mock_session_instance.call_tool = AsyncMock(
+                side_effect=[unauthorized, mock_result]
+            )
+            mock_session.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session_instance
+            )
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await call_mcp_tool_lob(
+                tool, "user-jwt", "tenant-sub", 60.0, cache
+            )
+
+            assert result == "Success after retry"
+            assert mock_auth.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_invalidates_user_token_on_401(self):
+        """On 401: invalidate the user token in cache before retry."""
+        cache = _make_cache()
+        scope_key = "test-fragment|tenant-sub"
+        cache.set_user_token(
+            "user-jwt", "Bearer stale-token", time.monotonic() + 600, scope_key
+        )
+
+        tool = MCPTool(
+            name="test-tool",
+            server_name="test-server",
+            description="Test tool",
+            input_schema={},
+            url="https://example.com/mcp",
+            fragment_name="test-fragment",
+        )
+
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock()]
+        mock_result.content[0].text = "ok"
+
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        unauthorized = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+
+        call_count = 0
+
+        async def _fake_get_user_auth(fragment, user_tok, tenant, c):
+            nonlocal call_count
+            call_count += 1
+            # After invalidation the cache entry is gone; simulate fresh fetch
+            return "Bearer fresh-token"
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.get_user_auth",
+                side_effect=_fake_get_user_auth,
+            ),
+            patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http,
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.streamable_http_client"
+            ) as mock_stream,
+            patch("sap_cloud_sdk.agentgateway._lob.ClientSession") as mock_session,
+        ):
+            mock_http_instance = AsyncMock()
+            mock_http.return_value.__aenter__ = AsyncMock(return_value=mock_http_instance)
+            mock_http.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_stream.return_value.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), None)
+            )
+            mock_stream.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_session_instance = AsyncMock()
+            mock_session_instance.initialize = AsyncMock()
+            mock_session_instance.call_tool = AsyncMock(
+                side_effect=[unauthorized, mock_result]
+            )
+            mock_session.return_value.__aenter__ = AsyncMock(
+                return_value=mock_session_instance
+            )
+            mock_session.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            await call_mcp_tool_lob(tool, "user-jwt", "tenant-sub", 60.0, cache)
+
+            # Cache entry was invalidated before retry
+            assert cache.get_user_token("user-jwt", scope_key) is None
+            assert call_count == 2

--- a/tests/agentgateway/unit/test_token_cache.py
+++ b/tests/agentgateway/unit/test_token_cache.py
@@ -1,0 +1,114 @@
+"""Unit tests for token cache helpers with non-trivial logic.
+
+Cache class behavior is tested through AgentGatewayClient (test_agw_client.py)
+to keep coverage focused on observable functionality. Only `_parse_jwt_exp`
+and `compute_expires_at` are exercised here directly because they contain
+parsing/branching logic that is hard to drive through the public API.
+"""
+
+import base64
+import json
+import time
+
+from sap_cloud_sdk.agentgateway._token_cache import (
+    _parse_jwt_exp,
+    compute_expires_at,
+)
+from sap_cloud_sdk.agentgateway.config import ClientConfig
+
+
+def _make_jwt(claims: dict) -> str:
+    """Build a non-signed JWT for testing (header.payload.signature)."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.signature"
+
+
+class TestParseJwtExp:
+    """Tests for the unverified JWT `exp` claim parser."""
+
+    def test_extracts_exp(self):
+        """Extract `exp` claim from a well-formed JWT payload."""
+        jwt = _make_jwt({"exp": 1700000000, "iat": 1699996400})
+        assert _parse_jwt_exp(jwt) == 1700000000
+
+    def test_returns_none_when_exp_missing(self):
+        """Return None when payload has no `exp` claim."""
+        jwt = _make_jwt({"iat": 1699996400})
+        assert _parse_jwt_exp(jwt) is None
+
+    def test_returns_none_for_malformed_jwt(self):
+        """Return None for strings that are not three-part JWTs."""
+        assert _parse_jwt_exp("not-a-jwt") is None
+        assert _parse_jwt_exp("") is None
+        assert _parse_jwt_exp("only.two") is None
+
+    def test_returns_none_for_garbage_payload(self):
+        """Return None when the payload segment is not valid base64/JSON."""
+        assert _parse_jwt_exp("aaa.@@not-base64@@.bbb") is None
+
+
+class TestComputeExpiresAt:
+    """Tests for cache expiry resolution from token responses."""
+
+    def test_uses_expires_in_when_present(self):
+        """Prefer `expires_in` from the response and subtract the buffer."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"expires_in": 3600}, cfg)
+        assert before + 3540 - 1 <= result <= before + 3540 + 1
+
+    def test_expires_in_equal_to_buffer_expires_immediately(self):
+        """Token whose `expires_in` equals the buffer is treated as already expiring now."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"expires_in": 60}, cfg)
+        after = time.monotonic()
+        assert before - 1 <= result <= after + 1
+
+    def test_expires_in_below_buffer_is_already_stale(self):
+        """Token whose `expires_in` is below the buffer resolves to a past timestamp."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"expires_in": 30}, cfg)
+        assert before - 31 <= result <= before - 29
+
+    def test_falls_back_to_id_token_exp(self):
+        """Fall back to the `exp` claim of `id_token` when `expires_in` is absent."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        future_exp = int(time.time()) + 600
+        jwt = _make_jwt({"exp": future_exp})
+        before = time.monotonic()
+        result = compute_expires_at({"id_token": jwt}, cfg)
+        assert before + 540 - 5 <= result <= before + 540 + 5
+
+    def test_uses_fallback_when_no_expiry_info(self):
+        """Use config fallback TTL when neither `expires_in` nor `id_token` is present."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"access_token": "opaque"}, cfg)
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_uses_fallback_when_id_token_malformed(self):
+        """Use fallback TTL when the `id_token` cannot be parsed."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"id_token": "garbage"}, cfg)
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_uses_fallback_when_id_token_exp_within_buffer(self):
+        """Skip the `id_token` path when remaining lifetime is below the buffer."""
+        # If remaining time is below the buffer, the id_token path is skipped.
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        soon_exp = int(time.time()) + 30
+        jwt = _make_jwt({"exp": soon_exp})
+        before = time.monotonic()
+        result = compute_expires_at({"id_token": jwt}, cfg)
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_handles_invalid_expires_in_value(self):
+        """Use fallback TTL when `expires_in` is not coercible to int."""
+        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        before = time.monotonic()
+        result = compute_expires_at({"expires_in": "not-a-number"}, cfg)
+        assert before + 300 - 1 <= result <= before + 300 + 1

--- a/tests/agentgateway/unit/test_token_cache.py
+++ b/tests/agentgateway/unit/test_token_cache.py
@@ -20,8 +20,11 @@ from sap_cloud_sdk.agentgateway.config import ClientConfig
 
 def _make_jwt(claims: dict) -> str:
     """Build a non-signed JWT for testing (header.payload.signature)."""
-    header = base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode()).rstrip(b"=")
-    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).rstrip(b"=")
+    header = base64.urlsafe_b64encode(json.dumps({
+        "alg": "none"
+    }).encode()).rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps(claims).encode()).rstrip(b"=")
     return f"{header.decode()}.{payload.decode()}.signature"
 
 
@@ -54,14 +57,16 @@ class TestComputeExpiresAt:
 
     def test_uses_expires_in_when_present(self):
         """Prefer `expires_in` from the response and subtract the buffer."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"expires_in": 3600}, cfg)
         assert before + 3540 - 1 <= result <= before + 3540 + 1
 
     def test_expires_in_equal_to_buffer_expires_immediately(self):
         """Token whose `expires_in` equals the buffer is treated as already expiring now."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"expires_in": 60}, cfg)
         after = time.monotonic()
@@ -69,14 +74,16 @@ class TestComputeExpiresAt:
 
     def test_expires_in_below_buffer_is_already_stale(self):
         """Token whose `expires_in` is below the buffer resolves to a past timestamp."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"expires_in": 30}, cfg)
         assert before - 31 <= result <= before - 29
 
     def test_falls_back_to_id_token_exp(self):
         """Fall back to the `exp` claim of `id_token` when `expires_in` is absent."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         future_exp = int(time.time()) + 600
         jwt = _make_jwt({"exp": future_exp})
         before = time.monotonic()
@@ -85,14 +92,16 @@ class TestComputeExpiresAt:
 
     def test_uses_fallback_when_no_expiry_info(self):
         """Use config fallback TTL when neither `expires_in` nor `id_token` is present."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"access_token": "opaque"}, cfg)
         assert before + 300 - 1 <= result <= before + 300 + 1
 
     def test_uses_fallback_when_id_token_malformed(self):
         """Use fallback TTL when the `id_token` cannot be parsed."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"id_token": "garbage"}, cfg)
         assert before + 300 - 1 <= result <= before + 300 + 1
@@ -100,7 +109,8 @@ class TestComputeExpiresAt:
     def test_uses_fallback_when_id_token_exp_within_buffer(self):
         """Skip the `id_token` path when remaining lifetime is below the buffer."""
         # If remaining time is below the buffer, the id_token path is skipped.
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         soon_exp = int(time.time()) + 30
         jwt = _make_jwt({"exp": soon_exp})
         before = time.monotonic()
@@ -109,13 +119,66 @@ class TestComputeExpiresAt:
 
     def test_handles_invalid_expires_in_value(self):
         """Use fallback TTL when `expires_in` is not coercible to int."""
-        cfg = ClientConfig(token_expiry_buffer_seconds=60, fallback_token_ttl_seconds=300)
+        cfg = ClientConfig(token_expiry_buffer_seconds=60,
+                           fallback_token_ttl_seconds=300)
         before = time.monotonic()
         result = compute_expires_at({"expires_in": "not-a-number"}, cfg)
         assert before + 300 - 1 <= result <= before + 300 + 1
 
 
-class TestTokenCacheClientIdIsolation:
+class TestComputeExpiresAtFromBearer:
+    """Tests for cache expiry resolution from a bearer auth header string."""
+
+    def test_uses_exp_from_bearer_jwt(self):
+        """Parse exp claim from Bearer JWT and apply buffer."""
+        cache = _TokenCache(
+            ClientConfig(token_expiry_buffer_seconds=60,
+                         fallback_token_ttl_seconds=300))
+        future_exp = int(time.time()) + 600
+        jwt = _make_jwt({"exp": future_exp})
+        before = time.monotonic()
+        result = cache.compute_expires_at_from_bearer(f"Bearer {jwt}")
+        assert before + 540 - 5 <= result <= before + 540 + 5
+
+    def test_falls_back_when_no_exp_in_jwt(self):
+        """Use fallback TTL when JWT has no exp claim."""
+        cache = _TokenCache(
+            ClientConfig(token_expiry_buffer_seconds=60,
+                         fallback_token_ttl_seconds=300))
+        jwt = _make_jwt({"sub": "user"})
+        before = time.monotonic()
+        result = cache.compute_expires_at_from_bearer(f"Bearer {jwt}")
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_falls_back_when_header_not_bearer(self):
+        """Use fallback TTL for non-Bearer auth headers."""
+        cache = _TokenCache(
+            ClientConfig(token_expiry_buffer_seconds=60,
+                         fallback_token_ttl_seconds=300))
+        before = time.monotonic()
+        result = cache.compute_expires_at_from_bearer("Basic dXNlcjpwYXNz")
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_falls_back_when_bearer_token_malformed(self):
+        """Use fallback TTL when bearer token is not a valid JWT."""
+        cache = _TokenCache(
+            ClientConfig(token_expiry_buffer_seconds=60,
+                         fallback_token_ttl_seconds=300))
+        before = time.monotonic()
+        result = cache.compute_expires_at_from_bearer("Bearer not-a-jwt")
+        assert before + 300 - 1 <= result <= before + 300 + 1
+
+    def test_strips_bearer_prefix_case_insensitively(self):
+        """Strip 'bearer ' prefix regardless of case."""
+        cache = _TokenCache(
+            ClientConfig(token_expiry_buffer_seconds=60,
+                         fallback_token_ttl_seconds=300))
+        future_exp = int(time.time()) + 600
+        jwt = _make_jwt({"exp": future_exp})
+        result_lower = cache.compute_expires_at_from_bearer(f"bearer {jwt}")
+        result_upper = cache.compute_expires_at_from_bearer(f"Bearer {jwt}")
+        assert abs(result_lower - result_upper) < 1
+
     """Tokens are isolated by client_id — same user JWT, different credentials, no sharing."""
 
     def test_system_tokens_isolated_by_client_id(self):

--- a/tests/agentgateway/unit/test_token_cache.py
+++ b/tests/agentgateway/unit/test_token_cache.py
@@ -11,6 +11,7 @@ import json
 import time
 
 from sap_cloud_sdk.agentgateway._token_cache import (
+    _TokenCache,
     _parse_jwt_exp,
     compute_expires_at,
 )
@@ -112,3 +113,49 @@ class TestComputeExpiresAt:
         before = time.monotonic()
         result = compute_expires_at({"expires_in": "not-a-number"}, cfg)
         assert before + 300 - 1 <= result <= before + 300 + 1
+
+
+class TestTokenCacheClientIdIsolation:
+    """Tokens are isolated by client_id — same user JWT, different credentials, no sharing."""
+
+    def test_system_tokens_isolated_by_client_id(self):
+        cache = _TokenCache(ClientConfig())
+        expires_at = time.monotonic() + 600
+
+        cache.set_system_token("token-a", expires_at, "client-a")
+        cache.set_system_token("token-b", expires_at, "client-b")
+
+        assert cache.get_system_token("client-a") == "token-a"
+        assert cache.get_system_token("client-b") == "token-b"
+
+    def test_user_tokens_isolated_by_client_id(self):
+        cache = _TokenCache(ClientConfig())
+        expires_at = time.monotonic() + 600
+
+        cache.set_user_token("user-jwt", "token-a", expires_at, "client-a")
+        cache.set_user_token("user-jwt", "token-b", expires_at, "client-b")
+
+        assert cache.get_user_token("user-jwt", "client-a") == "token-a"
+        assert cache.get_user_token("user-jwt", "client-b") == "token-b"
+
+    def test_invalidate_system_token_does_not_affect_other_clients(self):
+        cache = _TokenCache(ClientConfig())
+        expires_at = time.monotonic() + 600
+
+        cache.set_system_token("token-a", expires_at, "client-a")
+        cache.set_system_token("token-b", expires_at, "client-b")
+        cache.invalidate_system_token("client-a")
+
+        assert cache.get_system_token("client-a") is None
+        assert cache.get_system_token("client-b") == "token-b"
+
+    def test_invalidate_user_token_does_not_affect_other_clients(self):
+        cache = _TokenCache(ClientConfig())
+        expires_at = time.monotonic() + 600
+
+        cache.set_user_token("user-jwt", "token-a", expires_at, "client-a")
+        cache.set_user_token("user-jwt", "token-b", expires_at, "client-b")
+        cache.invalidate_user_token("user-jwt", "client-a")
+
+        assert cache.get_user_token("user-jwt", "client-a") is None
+        assert cache.get_user_token("user-jwt", "client-b") == "token-b"


### PR DESCRIPTION
## Description

Add in-process token cache for both customer and LoB agent flows. Previously every `list_mcp_tools()` / `call_mcp_tool()` call fetched fresh IAS token via mTLS - unnecessary latency in agentic loops.

**Changes:**

- **`_token_cache.py`** (new): `_TokenCache` - TTL + LRU eviction for system tokens (key: `client_id`) and user tokens (key: `sha256(user_jwt+"|"+client_id)[:16]`). Expiry is from `expires_in`, `id_token` exp claim, or fallback TTL.
- **`_customer.py`**: `get_system_token_mtls` / `exchange_user_token` to consult/populate cache. 401 response from MCP server → invalidate stale token + retry once
- **`_lob.py`**: `get_system_auth` / `get_user_auth` now check cache before calling BTP Destination Service. `get_mcp_tools_lob` reuses system auth across all fragments (single fetch per discovery call). `call_mcp_tool_lob` caches user token per `(fragment, tenant)` scope. Both functions retry once on 401 with cache invalidation - same pattern as customer flow
- **`agw_client.py`**: `AgentGatewayClient` passes `_TokenCache` to both customer and LoB functions
- **`config.py`**: 4 new `ClientConfig` fields added - `token_expiry_buffer_seconds` (60 s), `max_system_token_cache_size` (10 s), `max_user_token_cache_size` (10 s), `fallback_token_ttl_seconds` (300 s)

## Type of Change

Please check the relevant option:

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

Describe how reviewers can test your changes:

1. Programmatically:
    ```python
    async def verify_token_caching(agw_client) -> bool:
        """Verify system token is cached across list_mcp_tools calls.
    
        Patches _request_token_mtls to count real HTTP token requests.
        First call must fetch at least one token; second call must reuse cache.
        Returns True if caching works correctly.
        """
        original = _customer_mod._request_token_mtls
        call_count = 0
    
        def counting(*args, **kwargs):
            nonlocal call_count
            call_count += 1
            return original(*args, **kwargs)
    
        _customer_mod._request_token_mtls = counting
        try:
            await agw_client.list_mcp_tools()
            after_first = call_count
    
            await agw_client.list_mcp_tools()
            after_second = call_count
    
            agw_client.clear_token_cache()
            await agw_client.list_mcp_tools()
            after_clear = call_count
        finally:
            _customer_mod._request_token_mtls = original
    
        cache_hit = after_second == after_first
        invalidate_works = after_clear > after_second
    
        print("\nToken Caching")
        print("-" * 40)
        print(f"  1st call  token requests : {after_first}")
        print(f"  2nd call  token requests : {after_second - after_first}  {'✓ cache hit' if cache_hit else '✗ expected 0'}")
        print(f"  post-clear token requests: {after_clear - after_second}  {'✓ re-fetched' if invalidate_works else '✗ expected ≥1'}")
    
        return cache_hit and invalidate_works
    ...
    async def main():
        agw_client = create_client()
    
        ok = await verify_token_caching(agw_client)
        if not ok:
            print("\nWARNING: token caching check failed")
    ...
    ```
2. Unit tests:
   ```bash
   pytest tests/agentgateway/unit/test_token_cache.py tests/agentgateway/unit/test_customer.py tests/agentgateway/unit/test_agw_client.py
   ```

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None. Cache internal to `AgentGatewayClient` - existing `create_client()` calls get caching automatically. `ClientConfig` new fields all have defaults.

## Additional Notes

**Thread safety:** GIL makes individual `OrderedDict` ops atomic, but check-then-set is not. Concurrent coroutines on same key may both miss and both fetch - redundant requests, not corruption. Acceptable for agentic loop use case.

**401 retry:** Both `get_mcp_tools_customer` and `call_mcp_tool_customer` invalidate + retry once on 401, handling server-side revocation before token expiry.
