### PR TITLE
chore: standardize workflow names across CI/CD workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build:
-    name: Build SDK
+    name: Build & Package
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}
     permissions:
       contents: read

--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check-version-bump:
-    name: Enforce version bump when src/ is modified
+    name: Check Version Bump
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/commit-validation.yaml
+++ b/.github/workflows/commit-validation.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   commit-validation:
+    name: Commit Validation
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   integration-tests:
+    name: Integration Tests
     # Skip integration tests for PRs from forks (they don't have access to secrets)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}

--- a/.github/workflows/proto-verify.yaml
+++ b/.github/workflows/proto-verify.yaml
@@ -1,4 +1,4 @@
-name: Proto generation check
+name: Proto Generation Check
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   verify-proto:
-    name: Verify generated proto code is up-to-date
+    name: Proto Generation Check
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-internal.yml
+++ b/.github/workflows/release-internal.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish to Artifactory
+    name: Publish Package to Internal Artifactory
     runs-on: ["self-hosted"]
     environment: 'artifactory:sap-cloud-sdk'
     if: ${{ !contains(github.server_url, 'github.com') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    name: Publish to PyPI
+    name: Publish Package to PyPI
     runs-on: ubuntu-latest
     environment: 'pypi:sap-cloud-sdk'
     steps:

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   check-reuse-compliance:
+    name: REUSE Compliance Check
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   sync:
+    name: Sync from External Repository
     runs-on: ["self-hosted"]
     if: ${{ !contains(github.server_url, 'github.com') && contains(github.repository, 'application-foundation') }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   test:
-    name: Unit Tests with Coverage
+    name: Tests & Coverage
     runs-on: ${{ contains(github.server_url, 'github.com') && 'ubuntu-latest' || fromJSON('["self-hosted"]') }}
     steps:
       - name: "Checkout Repository"


### PR DESCRIPTION
## Description

Standardizes the job name (`name:` field) across all CI/CD workflows so that GitHub Actions displays consistent, readable labels in the checks UI. This change will facilitate the enforcement of checks during PR reviews.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Dependency update

## How to Test

1. Open a PR with these changes.
2. Verify that the GitHub Actions checks panel shows the new job names (e.g. `Build & Package`, `Tests & Coverage`, `Check Version Bump`).
3. Confirm no workflow triggers, conditions, or logic have changed — only display names differ.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages