### PR TITLE
fix(deps): pin opentelemetry-exporter-otlp-proto-common to ~=1.42.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "hatchling~=1.27.0",
     "opentelemetry-exporter-otlp-proto-grpc~=1.42.1",
     "opentelemetry-exporter-otlp-proto-http~=1.42.1",
+    "opentelemetry-exporter-otlp-proto-common~=1.42.1",
     "opentelemetry-processor-baggage~=0.61b0",
     "traceloop-sdk~=0.61.0",
     "opentelemetry-instrumentation-langchain>=0.61.0",


### PR DESCRIPTION
## Summary

- Adds `opentelemetry-exporter-otlp-proto-common~=1.42.1` as an explicit dependency in `pyproject.toml`
- The grpc exporter 1.42.1 requires `common==1.42.1` exactly (it imports `_exporter_metrics` introduced in 1.35.0), but without declaring common directly, pip can resolve it to an older incompatible version when competing constraints exist in the consumer's environment
- Observed in a2a-agent after upgrading from `sap-cloud-sdk==0.18.1` to `0.25.0`: pods were crashing with `ModuleNotFoundError: No module named 'opentelemetry.exporter.otlp.proto.common._exporter_metrics'`

## Test plan

- [ ] Verify existing telemetry integration tests pass
- [ ] Confirm a2a-agent (or any consumer) no longer hits the `_exporter_metrics` import error after picking up the next SDK release