### PR TITLE
test(destination): add regression test for multi-label OData filter

### DIFF
--- a/tests/destination/unit/test_models.py
+++ b/tests/destination/unit/test_models.py
@@ -767,6 +767,17 @@ class TestListOptionsLabelFilter:
         params = opts.to_query_params()
         assert params["$filter"] == "Label['env'] HAS ('prod') AND Label['team'] HAS ('platform')"
 
+    def test_multiple_labels_real_keys(self):
+        opts = ListOptions(filter_labels=[
+            Label(key="sap-managed-runtime-type", values=["agw.a2a.server"]),
+            Label(key="sap-managed-runtime-ordid", values=["d95a09d8-2152-40c9-abfd-52f3a53f6150"]),
+        ])
+        params = opts.to_query_params()
+        assert params["$filter"] == (
+            "Label['sap-managed-runtime-type'] HAS ('agw.a2a.server') AND "
+            "Label['sap-managed-runtime-ordid'] HAS ('d95a09d8-2152-40c9-abfd-52f3a53f6150')"
+        )
+
     def test_filter_labels_and_filter_names_raises(self):
         opts = ListOptions(
             filter_names=["dest1"],


### PR DESCRIPTION
## Summary

- Adds `test_multiple_labels_real_keys` to `TestListOptionsLabelFilter` — a regression guard that verifies `ListOptions` with two `filter_labels` produces the correct OData `HAS ... AND ...` expression using real `sap-managed-runtime-*` label keys

The ticket claimed the multi-label filter was broken and required parentheses around each clause. Testing against the live Destination Service API proved the opposite:

| Format | Result |
|---|---|
| `Label['a'] HAS ('v') AND Label['b'] HAS ('v')` — current SDK output | `200 OK` |
| `(Label['a'] HAS ('v')) AND (Label['b'] HAS ('v'))` — format ticket described as "required" | `400 The provided filter is not recognized` |

The no-parens format the SDK already generates is correct. UC-9455 (connectivity team fix) enabled multi-label support on the service side — confirmed working end-to-end against `app-fnd-sdk-test-canary-eu12` with real fragments.

## Test plan

- `pytest tests/destination/unit/test_models.py::TestListOptionsLabelFilter` — all 11 tests pass