### PR TITLE
fix: optional mcp tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.27.0"
+version = "0.27.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -74,7 +74,10 @@ def mcp_tool_to_langchain(
 
     # Build args schema from input_schema
     properties = mcp_tool.input_schema.get("properties", {})
-    fields: dict[str, Any] = {k: (str, ...) for k in properties}
+    required = set(mcp_tool.input_schema.get("required", []))
+    fields: dict[str, Any] = {
+        k: (str, ...) if k in required else (str | None, None) for k in properties
+    }
     args_schema = create_model(f"{mcp_tool.name}_args", **fields) if fields else None
 
     return StructuredTool.from_function(

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -78,6 +78,31 @@ class TestMcpToolToLangchain:
         assert result.name == "simple_tool"
         assert result.args_schema is not None
 
+    def test_optional_fields_not_required_in_args_schema(self):
+        """Fields absent from 'required' must be optional in the generated Pydantic model."""
+        tool = MCPTool(
+            name="get_supplier_bid",
+            server_name="ariba",
+            description="Gets all supplier bids for the specified event",
+            input_schema={
+                "type": "object",
+                "required": ["eventid"],
+                "properties": {
+                    "eventid": {"description": "Unique identifier of the event"},
+                    "showdeclinedreason": {"description": "Show supplier decline reason"},
+                    "datafetchmode": {"description": "Level of detail for the response"},
+                },
+            },
+            url="https://example.com/mcp",
+        )
+
+        result = mcp_tool_to_langchain(tool, AsyncMock(return_value="result"), lambda: "token")
+
+        fields = result.args_schema.model_fields
+        assert fields["eventid"].is_required(), "eventid should be required"
+        assert not fields["showdeclinedreason"].is_required(), "showdeclinedreason should be optional"
+        assert not fields["datafetchmode"].is_required(), "datafetchmode should be optional"
+
     def test_handles_input_schema_without_properties(self):
         """Handle MCPTool with input schema but no properties."""
         tool = MCPTool(

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -98,6 +98,9 @@ class TestMcpToolToLangchain:
 
         result = mcp_tool_to_langchain(tool, AsyncMock(return_value="result"), lambda: "token")
 
+        from pydantic import BaseModel
+
+        assert result.args_schema is not None and isinstance(result.args_schema, type) and issubclass(result.args_schema, BaseModel)
         fields = result.args_schema.model_fields
         assert fields["eventid"].is_required(), "eventid should be required"
         assert not fields["showdeclinedreason"].is_required(), "showdeclinedreason should be optional"

--- a/tests/core/integration/telemetry/_agent.py
+++ b/tests/core/integration/telemetry/_agent.py
@@ -17,9 +17,9 @@ def build_langgraph_agent():
         from typing import Annotated
 
         from langchain_core.messages import BaseMessage
-        from langchain_litellm import ChatLiteLLM  # ty: ignore[unresolved-import]
-        from langgraph.graph import END, StateGraph  # ty: ignore[unresolved-import]
-        from langgraph.graph.message import add_messages  # ty: ignore[unresolved-import]
+        from langchain_litellm import ChatLiteLLM
+        from langgraph.graph import END, StateGraph
+        from langgraph.graph.message import add_messages
     except ImportError:
         pytest.skip("langchain-litellm or langgraph not installed")
 

--- a/tests/core/integration/telemetry/test_telemetry_bdd.py
+++ b/tests/core/integration/telemetry/test_telemetry_bdd.py
@@ -127,7 +127,7 @@ def _llm_call():
     Uses ChatLiteLLM so Traceloop's LangChain instrumentor fires and emits a span
     with gen_ai.usage.* token counts.
     """
-    from langchain_litellm import ChatLiteLLM  # ty: ignore[unresolved-import]
+    from langchain_litellm import ChatLiteLLM
     from langchain_core.messages import HumanMessage as LCHumanMessage
     model_name = os.environ.get("AICORE_MODEL", "anthropic--claude-4.5-sonnet")
     llm = ChatLiteLLM(model=f"sap/{model_name}")


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Fixes a bug in `mcp_tool_to_langchain` (`agentgateway/converters.py`) where all MCP tool parameters were unconditionally marked as required in the generated Pydantic `args_schema`, regardless of what the tool's `input_schema` declared as optional.

**Root cause:** The field mapping `{k: (str, ...) for k in properties}` used the Pydantic sentinel `...` (required) for every field. Fields not listed in the JSON Schema `"required"` array were never treated as optional.

**Fix:** The converter now reads the `"required"` array from `input_schema` and maps fields accordingly — fields in `"required"` remain `(str, ...)`, while all other fields become `(str | None, None)` (optional, defaulting to `None`).

This means LangChain agents and any Pydantic-aware consumer using `mcp_tool_to_langchain` will no longer raise validation errors when optional MCP tool parameters are omitted.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Define an `MCPTool` whose `input_schema` has both required and optional properties:
   ```python
   tool = MCPTool(
       name="get_supplier_bid",
       server_name="ariba",
       description="Gets supplier bids",
       input_schema={
           "type": "object",
           "required": ["eventid"],
           "properties": {
               "eventid": {"description": "Event ID"},
               "datafetchmode": {"description": "Detail level"},
           },
       },
       url="https://example.com/mcp",
   )
   ```
2. Convert it: `langchain_tool = mcp_tool_to_langchain(tool, call_tool, get_user_token)`
3. Inspect `langchain_tool.args_schema.model_fields`:
   - `eventid` must be required (`is_required() == True`)
   - `datafetchmode` must be optional (`is_required() == False`)
4. Run the unit tests: `pytest tests/agentgateway/unit/test_converters.py -v`

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

The fix is confined to the `mcp_tool_to_langchain` reference converter. The core `AgentGatewayClient.call_mcp_tool()` is unaffected — it still passes `**kwargs` through to the MCP server without schema validation.
