### PR TITLE
test(destination): make BDD subaccount creation idempotent

### DIFF
--- a/tests/destination/integration/test_destination_bdd.py
+++ b/tests/destination/integration/test_destination_bdd.py
@@ -292,6 +292,13 @@ def create_destination_instance(context, destination_client):
 @when("I create the destination at subaccount level")
 def create_destination_subaccount(context, destination_client):
     """Create destination at subaccount level."""
+    # Try to delete first to avoid 409 conflicts (idempotent cleanup)
+    try:
+        destination_client.delete_destination(context.destination.name, level=Level.SUB_ACCOUNT)
+    except Exception:
+        # Ignore cleanup errors (destination may not exist)
+        pass
+
     try:
         destination_client.create_destination(context.destination, level=Level.SUB_ACCOUNT)
         context.operation_success = True


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

The BDD integration tests for destination creation at subaccount level fail if a previous test run fails or is interrupted before cleanup, leaving the destination on the BTP subaccount. The next run then attempts to create it again and receives an error, causing the test to fail for reasons unrelated to the code under test.

This PR fixes that by replicating the idempotent cleanup pattern already used in other steps, attempting to delete the destination before creating it. The delete is wrapped in a try/except so it is silently skipped if the destination does not exist yet, making the step safe for both first runs and reruns.

## Related Issue

N/A

## Type of Change

Please check the relevant option:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Create a destination with name 'test-dest-delete', type HTTP and url 'https://delete.example.com' on your BTP subaccount
2. Run the integration tests for destination: uv run pytest tests/destination/integration/ -v
3. Check that tests/destination/integration/test_destination_bdd.py::test_delete_destination fails with the current code. With this PR, the same test should pass and 'test-dest-delete' should be automatically deleted

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None

## Additional Notes

N/A
