### PR TITLE
fix: mcp tool converter sending none values

### DIFF
--- a/.env_integration_tests.example
+++ b/.env_integration_tests.example
@@ -11,6 +11,7 @@ CLOUD_SDK_CFG_ADMS_DEFAULT_RESOURCE=urn:sap:identity:application:provider:name:y
 CLOUD_SDK_CFG_AGW_DEFAULT_LANDSCAPE=your-landscape-here
 CLOUD_SDK_CFG_AGW_DEFAULT_TENANT_SUBDOMAIN=your-tenant-subdomain-here
 CLOUD_SDK_CFG_AGW_DEFAULT_USER_TOKEN=your-user-jwt-here
+CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL=your-sample-mcp-tool-name-here
 
 # AGENT MEMORY
 CLOUD_SDK_CFG_HANA_AGENT_MEMORY_DEFAULT_APPLICATION_URL=https://your-agent-memory-api-url-here

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -63,8 +63,7 @@ CLOUD_SDK_CFG_AGW_DEFAULT_TENANT_SUBDOMAIN=your-tenant-subdomain-here
 # If not set, user auth scenarios are automatically skipped
 CLOUD_SDK_CFG_AGW_DEFAULT_USER_TOKEN=your-user-jwt-here
 
-# Name of a no-argument MCP tool available in your environment (e.g. a health-check tool)
-# If not set, tool call and converter scenarios are automatically skipped
+# Name of a MCP tool available in your environment
 CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL=your-sample-mcp-tool-name-here
 ```
 

--- a/docs/INTEGRATION_TESTS.md
+++ b/docs/INTEGRATION_TESTS.md
@@ -62,6 +62,10 @@ CLOUD_SDK_CFG_AGW_DEFAULT_TENANT_SUBDOMAIN=your-tenant-subdomain-here
 # User JWT for token exchange scenarios (get_user_auth)
 # If not set, user auth scenarios are automatically skipped
 CLOUD_SDK_CFG_AGW_DEFAULT_USER_TOKEN=your-user-jwt-here
+
+# Name of a no-argument MCP tool available in your environment (e.g. a health-check tool)
+# If not set, tool call and converter scenarios are automatically skipped
+CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL=your-sample-mcp-tool-name-here
 ```
 
 ### Agent Memory Integration Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.28.1"
+version = "0.29.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -76,7 +76,7 @@ def mcp_tool_to_langchain(
     properties = mcp_tool.input_schema.get("properties", {})
     required = set(mcp_tool.input_schema.get("required", []))
     fields: dict[str, Any] = {
-        k: (str, ...) if k in required else (str, Field(default=None)) for k in properties
+        k: (str, ...) if k in required else (str | None, Field(default=None)) for k in properties
     }
     args_schema = create_model(f"{mcp_tool.name}_args", **fields) if fields else None
 

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -76,7 +76,8 @@ def mcp_tool_to_langchain(
     properties = mcp_tool.input_schema.get("properties", {})
     required = set(mcp_tool.input_schema.get("required", []))
     fields: dict[str, Any] = {
-        k: (str, ...) if k in required else (str | None, Field(default=None)) for k in properties
+        k: (str, ...) if k in required else (str | None, Field(default=None))
+        for k in properties
     }
     args_schema = create_model(f"{mcp_tool.name}_args", **fields) if fields else None
 

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
 
-from pydantic import create_model
+from pydantic import Field, create_model
 
 from sap_cloud_sdk.agentgateway._models import MCPTool
 
@@ -69,14 +69,14 @@ def mcp_tool_to_langchain(
         return await call_tool(
             mcp_tool,
             user_token=get_user_token,
-            **kwargs,
+            **{k: v for k, v in kwargs.items() if v is not None},
         )
 
     # Build args schema from input_schema
     properties = mcp_tool.input_schema.get("properties", {})
     required = set(mcp_tool.input_schema.get("required", []))
     fields: dict[str, Any] = {
-        k: (str, ...) if k in required else (str | None, None) for k in properties
+        k: (str, ...) if k in required else (str, Field(default=None)) for k in properties
     }
     args_schema = create_model(f"{mcp_tool.name}_args", **fields) if fields else None
 

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -21,6 +21,8 @@ def mcp_tool_to_langchain(
     mcp_tool: MCPTool,
     call_tool: Callable,
     get_user_token: Callable[[], str],
+    *,
+    omit_none: bool = True,
 ) -> StructuredTool:
     """Convert MCPTool to LangChain StructuredTool.
 
@@ -31,6 +33,8 @@ def mcp_tool_to_langchain(
         mcp_tool: MCPTool object from list_mcp_tools().
         call_tool: Callable to invoke the MCP tool (e.g., agw_client.call_mcp_tool).
         get_user_token: Callable that returns the user's JWT token.
+        omit_none: If True (default), optional parameters with a None value are not
+            forwarded to call_tool. Set to False to forward None values explicitly.
 
     Returns:
         LangChain StructuredTool that invokes the MCP tool.
@@ -66,10 +70,13 @@ def mcp_tool_to_langchain(
         ) from None
 
     async def run(**kwargs) -> str:
+        resolved = (
+            {k: v for k, v in kwargs.items() if v is not None} if omit_none else kwargs
+        )
         return await call_tool(
             mcp_tool,
             user_token=get_user_token,
-            **{k: v for k, v in kwargs.items() if v is not None},
+            **resolved,
         )
 
     # Build args schema from input_schema

--- a/src/sap_cloud_sdk/agentgateway/user-guide.md
+++ b/src/sap_cloud_sdk/agentgateway/user-guide.md
@@ -52,9 +52,7 @@ config = ClientConfig(timeout=30.0)
 agw_client = create_client(tenant_subdomain="my-tenant", config=config)
 
 # Discover tools (auto-discovered from destination fragments)
-tools = await agw_client.list_mcp_tools()
-
-# Discover tools with user principal propagation
+# Pass user_token to use principal propagation when listing tools
 tools = await agw_client.list_mcp_tools(user_token="user-jwt")
 
 # Invoke a tool (user_token required for principal propagation)
@@ -74,7 +72,7 @@ from sap_cloud_sdk.agentgateway import create_client
 from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain
 
 agw_client = create_client(tenant_subdomain="my-tenant")
-tools = await agw_client.list_mcp_tools()
+tools = await agw_client.list_mcp_tools(user_token="user-jwt")
 
 langchain_tools = [
     mcp_tool_to_langchain(
@@ -87,6 +85,17 @@ langchain_tools = [
 
 # Use with LangChain agent
 llm_with_tools = llm.bind_tools(langchain_tools)
+```
+
+By default, optional tool parameters that resolve to `None` are not forwarded to `call_mcp_tool`. Set `omit_none=False` to forward them explicitly:
+
+```python
+mcp_tool_to_langchain(
+    t,
+    agw_client.call_mcp_tool,
+    get_user_token=lambda: request.headers["Authorization"],
+    omit_none=False,
+)
 ```
 
 ## Concepts

--- a/tests/agentgateway/integration/agw_auth.feature
+++ b/tests/agentgateway/integration/agw_auth.feature
@@ -41,14 +41,26 @@ Feature: Agent Gateway Auth Integration
     And the error message should mention "user_token is required"
 
   Scenario: List MCP tools returns a non-empty list of tools
+    Given I have a valid user token
     When I call list_mcp_tools
     Then the result should be a list of MCPTool
     And the list should be non-empty
     And each tool should have a non-empty name
     And each tool should have a non-empty url
+    And each tool should have a valid input_schema
 
-  Scenario: Call search_workflows tool returns a non-empty result
+  Scenario: Call sample MCP tool returns a non-empty result
     Given I have a valid user token
+    And I have a sample MCP tool name
     When I call list_mcp_tools
-    And I call call_mcp_tool with "search_workflows" and the user token
+    And I call call_mcp_tool with the sample MCP tool and the user token
     Then the tool result should be a non-empty string
+
+  Scenario: Convert sample MCP tool to LangChain StructuredTool
+    Given I have a valid user token
+    And I have a sample MCP tool name
+    When I call list_mcp_tools
+    And I convert the sample MCP tool to a LangChain StructuredTool
+    Then the LangChain tool should have the sample MCP tool name
+    And the LangChain tool should have a non-empty description
+    And the LangChain tool should require no arguments

--- a/tests/agentgateway/integration/agw_auth.feature
+++ b/tests/agentgateway/integration/agw_auth.feature
@@ -55,12 +55,3 @@ Feature: Agent Gateway Auth Integration
     When I call list_mcp_tools
     And I call call_mcp_tool with the sample MCP tool and the user token
     Then the tool result should be a non-empty string
-
-  Scenario: Convert sample MCP tool to LangChain StructuredTool
-    Given I have a valid user token
-    And I have a sample MCP tool name
-    When I call list_mcp_tools
-    And I convert the sample MCP tool to a LangChain StructuredTool
-    Then the LangChain tool should have the sample MCP tool name
-    And the LangChain tool should have a non-empty description
-    And the LangChain tool should require no arguments

--- a/tests/agentgateway/integration/test_agw_bdd.py
+++ b/tests/agentgateway/integration/test_agw_bdd.py
@@ -266,4 +266,3 @@ def tool_result_is_non_empty_string(context: ScenarioContext):
     assert context.tool_result is not None
     assert isinstance(context.tool_result, str)
     assert context.tool_result.strip(), "Expected a non-empty tool result"
-

--- a/tests/agentgateway/integration/test_agw_bdd.py
+++ b/tests/agentgateway/integration/test_agw_bdd.py
@@ -5,6 +5,7 @@ Run against a live BTP tenant:
     CLOUD_SDK_CFG_AGW_DEFAULT_TENANT_SUBDOMAIN=<tenant-subdomain> \\
     CLOUD_SDK_CFG_AGW_DEFAULT_LANDSCAPE=<landscape> \\
     CLOUD_SDK_CFG_AGW_DEFAULT_USER_TOKEN=<user-jwt> \\
+    CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL=<tool-name> \\
     CLOUD_SDK_CFG_DESTINATION_DEFAULT_CLIENTID=... \\
     CLOUD_SDK_CFG_DESTINATION_DEFAULT_CLIENTSECRET=... \\
     CLOUD_SDK_CFG_DESTINATION_DEFAULT_URL=... \\
@@ -15,13 +16,14 @@ Run against a live BTP tenant:
 
 import asyncio
 import os
-from typing import Optional
+from typing import Optional, Any
 
 import pytest
 from pytest_bdd import scenarios, given, when, then, parsers
 
 from sap_cloud_sdk.agentgateway import AgentGatewayClient, AuthResult, AgentGatewaySDKError
 from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain
 
 scenarios("agw_auth.feature")
 
@@ -52,6 +54,8 @@ class ScenarioContext:
         self.user_token: Optional[str] = None
         self.tools: Optional[list[MCPTool]] = None
         self.tool_result: Optional[str] = None
+        self.langchain_tool: Optional[Any] = None
+        self.sample_mcp_tool_name: Optional[str] = None
 
 
 @pytest.fixture
@@ -76,6 +80,15 @@ def have_valid_user_token(context: ScenarioContext):
     if not token:
         pytest.skip("CLOUD_SDK_CFG_AGW_DEFAULT_USER_TOKEN is not set — skipping user auth scenario")
     context.user_token = token
+
+
+@given("I have a sample MCP tool name")
+def have_sample_mcp_tool_name(context: ScenarioContext):
+    """Load sample MCP tool name from environment variable."""
+    tool_name = os.environ.get("CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL", "")
+    if not tool_name:
+        pytest.skip("CLOUD_SDK_CFG_AGW_DEFAULT_SAMPLE_MCP_TOOL is not set — skipping tool scenario")
+    context.sample_mcp_tool_name = tool_name
 
 
 # ==================== WHEN ====================
@@ -119,7 +132,7 @@ def call_get_user_auth_empty_token(context: ScenarioContext, agw_client: AgentGa
 @when("I call list_mcp_tools")
 def call_list_mcp_tools(context: ScenarioContext, agw_client: AgentGatewayClient):
     """Call list_mcp_tools and store the result."""
-    context.tools = run(agw_client.list_mcp_tools())
+    context.tools = run(agw_client.list_mcp_tools(user_token=context.user_token))
 
 
 @when(parsers.parse('I call call_mcp_tool with "{tool_name}" and the user token'))
@@ -133,6 +146,34 @@ def call_call_mcp_tool(
         pytest.fail(f"Tool '{tool_name}' not found in list_mcp_tools result")
     context.tool_result = run(
         agw_client.call_mcp_tool(tool, user_token=context.user_token)
+    )
+
+
+@when("I call call_mcp_tool with the sample MCP tool and the user token")
+def call_call_mcp_tool_sample(context: ScenarioContext, agw_client: AgentGatewayClient):
+    """Find the sample MCP tool and call it."""
+    assert context.tools is not None, "call list_mcp_tools before calling a tool"
+    assert context.sample_mcp_tool_name is not None
+    tool = next((t for t in context.tools if t.name == context.sample_mcp_tool_name), None)
+    if tool is None:
+        pytest.fail(f"Tool '{context.sample_mcp_tool_name}' not found in list_mcp_tools result")
+    context.tool_result = run(
+        agw_client.call_mcp_tool(tool, user_token=context.user_token)
+    )
+
+
+@when("I convert the sample MCP tool to a LangChain StructuredTool")
+def convert_sample_tool_to_langchain(context: ScenarioContext, agw_client: AgentGatewayClient):
+    """Convert the sample MCP tool to a LangChain StructuredTool."""
+    assert context.tools is not None, "call list_mcp_tools before converting a tool"
+    assert context.sample_mcp_tool_name is not None
+    tool = next((t for t in context.tools if t.name == context.sample_mcp_tool_name), None)
+    if tool is None:
+        pytest.fail(f"Tool '{context.sample_mcp_tool_name}' not found in list_mcp_tools result")
+    context.langchain_tool = mcp_tool_to_langchain(
+        tool,
+        agw_client.call_mcp_tool,
+        get_user_token=lambda: context.user_token,
     )
 
 
@@ -237,9 +278,71 @@ def each_tool_has_non_empty_url(context: ScenarioContext):
         )
 
 
+@then("each tool should have a valid input_schema")
+def each_tool_has_valid_input_schema(context: ScenarioContext):
+    """Verify every tool has an input_schema dict with type=object."""
+    assert context.tools is not None
+    for tool in context.tools:
+        assert isinstance(tool.input_schema, dict), (
+            f"Tool '{tool.name}' input_schema is not a dict: {tool.input_schema!r}"
+        )
+        assert tool.input_schema.get("type") == "object", (
+            f"Tool '{tool.name}' input_schema missing type=object: {tool.input_schema}"
+        )
+
+
 @then("the tool result should be a non-empty string")
 def tool_result_is_non_empty_string(context: ScenarioContext):
     """Verify the tool invocation returned a non-empty string."""
     assert context.tool_result is not None
     assert isinstance(context.tool_result, str)
     assert context.tool_result.strip(), "Expected a non-empty tool result"
+
+
+@when(parsers.parse('I convert the "{tool_name}" tool to a LangChain StructuredTool'))
+def convert_tool_to_langchain(
+    context: ScenarioContext, agw_client: AgentGatewayClient, tool_name: str
+):
+    """Convert the named MCPTool to a LangChain StructuredTool."""
+    assert context.tools is not None, "call list_mcp_tools before converting a tool"
+    tool = next((t for t in context.tools if t.name == tool_name), None)
+    if tool is None:
+        pytest.fail(f"Tool '{tool_name}' not found in list_mcp_tools result")
+    context.langchain_tool = mcp_tool_to_langchain(
+        tool,
+        agw_client.call_mcp_tool,
+        get_user_token=lambda: context.user_token,
+    )
+
+
+@then(parsers.parse('the LangChain tool should have name "{expected_name}"'))
+def langchain_tool_has_name(context: ScenarioContext, expected_name: str):
+    """Verify the converted LangChain tool has the expected name."""
+    assert context.langchain_tool is not None
+    assert context.langchain_tool.name == expected_name
+
+
+@then("the LangChain tool should have the sample MCP tool name")
+def langchain_tool_has_sample_name(context: ScenarioContext):
+    """Verify the converted LangChain tool name matches the sample MCP tool name."""
+    assert context.langchain_tool is not None
+    assert context.langchain_tool.name == context.sample_mcp_tool_name
+
+
+@then("the LangChain tool should have a non-empty description")
+def langchain_tool_has_description(context: ScenarioContext):
+    """Verify the converted LangChain tool has a non-empty description."""
+    assert context.langchain_tool is not None
+    assert isinstance(context.langchain_tool.description, str)
+    assert context.langchain_tool.description.strip()
+
+
+@then("the LangChain tool should require no arguments")
+def langchain_tool_requires_no_arguments(context: ScenarioContext):
+    """Verify the converted LangChain tool has no required fields in its args schema."""
+    assert context.langchain_tool is not None
+    schema = context.langchain_tool.args_schema
+    if schema is not None:
+        fields = schema.model_fields
+        required = [name for name, f in fields.items() if f.is_required()]
+        assert required == [], f"Expected no required args, got: {required}"

--- a/tests/agentgateway/integration/test_agw_bdd.py
+++ b/tests/agentgateway/integration/test_agw_bdd.py
@@ -173,7 +173,7 @@ def convert_sample_tool_to_langchain(context: ScenarioContext, agw_client: Agent
     context.langchain_tool = mcp_tool_to_langchain(
         tool,
         agw_client.call_mcp_tool,
-        get_user_token=lambda: context.user_token,
+        get_user_token=lambda: context.user_token or "",
     )
 
 
@@ -311,7 +311,7 @@ def convert_tool_to_langchain(
     context.langchain_tool = mcp_tool_to_langchain(
         tool,
         agw_client.call_mcp_tool,
-        get_user_token=lambda: context.user_token,
+        get_user_token=lambda: context.user_token or "",
     )
 
 

--- a/tests/agentgateway/integration/test_agw_bdd.py
+++ b/tests/agentgateway/integration/test_agw_bdd.py
@@ -16,14 +16,13 @@ Run against a live BTP tenant:
 
 import asyncio
 import os
-from typing import Optional, Any
+from typing import Optional
 
 import pytest
 from pytest_bdd import scenarios, given, when, then, parsers
 
 from sap_cloud_sdk.agentgateway import AgentGatewayClient, AuthResult, AgentGatewaySDKError
 from sap_cloud_sdk.agentgateway._models import MCPTool
-from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain
 
 scenarios("agw_auth.feature")
 
@@ -54,7 +53,6 @@ class ScenarioContext:
         self.user_token: Optional[str] = None
         self.tools: Optional[list[MCPTool]] = None
         self.tool_result: Optional[str] = None
-        self.langchain_tool: Optional[Any] = None
         self.sample_mcp_tool_name: Optional[str] = None
 
 
@@ -135,20 +133,6 @@ def call_list_mcp_tools(context: ScenarioContext, agw_client: AgentGatewayClient
     context.tools = run(agw_client.list_mcp_tools(user_token=context.user_token))
 
 
-@when(parsers.parse('I call call_mcp_tool with "{tool_name}" and the user token'))
-def call_call_mcp_tool(
-    context: ScenarioContext, agw_client: AgentGatewayClient, tool_name: str
-):
-    """Find tool by name from list_mcp_tools result and call it."""
-    assert context.tools is not None, "call list_mcp_tools before calling a tool"
-    tool = next((t for t in context.tools if t.name == tool_name), None)
-    if tool is None:
-        pytest.fail(f"Tool '{tool_name}' not found in list_mcp_tools result")
-    context.tool_result = run(
-        agw_client.call_mcp_tool(tool, user_token=context.user_token)
-    )
-
-
 @when("I call call_mcp_tool with the sample MCP tool and the user token")
 def call_call_mcp_tool_sample(context: ScenarioContext, agw_client: AgentGatewayClient):
     """Find the sample MCP tool and call it."""
@@ -159,21 +143,6 @@ def call_call_mcp_tool_sample(context: ScenarioContext, agw_client: AgentGateway
         pytest.fail(f"Tool '{context.sample_mcp_tool_name}' not found in list_mcp_tools result")
     context.tool_result = run(
         agw_client.call_mcp_tool(tool, user_token=context.user_token)
-    )
-
-
-@when("I convert the sample MCP tool to a LangChain StructuredTool")
-def convert_sample_tool_to_langchain(context: ScenarioContext, agw_client: AgentGatewayClient):
-    """Convert the sample MCP tool to a LangChain StructuredTool."""
-    assert context.tools is not None, "call list_mcp_tools before converting a tool"
-    assert context.sample_mcp_tool_name is not None
-    tool = next((t for t in context.tools if t.name == context.sample_mcp_tool_name), None)
-    if tool is None:
-        pytest.fail(f"Tool '{context.sample_mcp_tool_name}' not found in list_mcp_tools result")
-    context.langchain_tool = mcp_tool_to_langchain(
-        tool,
-        agw_client.call_mcp_tool,
-        get_user_token=lambda: context.user_token or "",
     )
 
 
@@ -298,51 +267,3 @@ def tool_result_is_non_empty_string(context: ScenarioContext):
     assert isinstance(context.tool_result, str)
     assert context.tool_result.strip(), "Expected a non-empty tool result"
 
-
-@when(parsers.parse('I convert the "{tool_name}" tool to a LangChain StructuredTool'))
-def convert_tool_to_langchain(
-    context: ScenarioContext, agw_client: AgentGatewayClient, tool_name: str
-):
-    """Convert the named MCPTool to a LangChain StructuredTool."""
-    assert context.tools is not None, "call list_mcp_tools before converting a tool"
-    tool = next((t for t in context.tools if t.name == tool_name), None)
-    if tool is None:
-        pytest.fail(f"Tool '{tool_name}' not found in list_mcp_tools result")
-    context.langchain_tool = mcp_tool_to_langchain(
-        tool,
-        agw_client.call_mcp_tool,
-        get_user_token=lambda: context.user_token or "",
-    )
-
-
-@then(parsers.parse('the LangChain tool should have name "{expected_name}"'))
-def langchain_tool_has_name(context: ScenarioContext, expected_name: str):
-    """Verify the converted LangChain tool has the expected name."""
-    assert context.langchain_tool is not None
-    assert context.langchain_tool.name == expected_name
-
-
-@then("the LangChain tool should have the sample MCP tool name")
-def langchain_tool_has_sample_name(context: ScenarioContext):
-    """Verify the converted LangChain tool name matches the sample MCP tool name."""
-    assert context.langchain_tool is not None
-    assert context.langchain_tool.name == context.sample_mcp_tool_name
-
-
-@then("the LangChain tool should have a non-empty description")
-def langchain_tool_has_description(context: ScenarioContext):
-    """Verify the converted LangChain tool has a non-empty description."""
-    assert context.langchain_tool is not None
-    assert isinstance(context.langchain_tool.description, str)
-    assert context.langchain_tool.description.strip()
-
-
-@then("the LangChain tool should require no arguments")
-def langchain_tool_requires_no_arguments(context: ScenarioContext):
-    """Verify the converted LangChain tool has no required fields in its args schema."""
-    assert context.langchain_tool is not None
-    schema = context.langchain_tool.args_schema
-    if schema is not None:
-        fields = schema.model_fields
-        required = [name for name, f in fields.items() if f.is_required()]
-        assert required == [], f"Expected no required args, got: {required}"

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -1,5 +1,6 @@
 """Unit tests for MCP tool converters."""
 
+import pytest
 from unittest.mock import AsyncMock
 
 from sap_cloud_sdk.agentgateway import MCPTool
@@ -121,3 +122,85 @@ class TestMcpToolToLangchain:
         result = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
 
         assert result.args_schema is not None
+
+
+class TestMcpToolToLangchainInvocation:
+    """End-to-end invocation tests for mcp_tool_to_langchain."""
+
+    @pytest.mark.asyncio
+    async def test_required_param_forwarded(self):
+        """Required parameters are forwarded to call_tool."""
+        tool = MCPTool(
+            name="get_supplier_bid",
+            server_name="ariba",
+            description="Gets supplier bids",
+            input_schema={
+                "type": "object",
+                "required": ["eventid"],
+                "properties": {
+                    "eventid": {"type": "string"},
+                    "showdeclinedreason": {"type": "string"},
+                },
+            },
+            url="https://example.com/mcp",
+        )
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+
+        await lc_tool.arun({"eventid": "E001"})
+
+        call_tool.assert_awaited_once()
+        kwargs = call_tool.call_args.kwargs
+        assert kwargs["eventid"] == "E001"
+
+    @pytest.mark.asyncio
+    async def test_optional_params_omitted_when_not_supplied(self):
+        """Optional parameters not supplied by the LLM must not be forwarded as None."""
+        tool = MCPTool(
+            name="get_supplier_bid",
+            server_name="ariba",
+            description="Gets supplier bids",
+            input_schema={
+                "type": "object",
+                "required": ["eventid"],
+                "properties": {
+                    "eventid": {"type": "string"},
+                    "showdeclinedreason": {"type": "string"},
+                    "datafetchmode": {"type": "string"},
+                },
+            },
+            url="https://example.com/mcp",
+        )
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+
+        await lc_tool.arun({"eventid": "E001"})
+
+        kwargs = call_tool.call_args.kwargs
+        assert "showdeclinedreason" not in kwargs
+        assert "datafetchmode" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_optional_param_forwarded_when_supplied(self):
+        """Optional parameters that the LLM does supply are forwarded."""
+        tool = MCPTool(
+            name="get_supplier_bid",
+            server_name="ariba",
+            description="Gets supplier bids",
+            input_schema={
+                "type": "object",
+                "required": ["eventid"],
+                "properties": {
+                    "eventid": {"type": "string"},
+                    "showdeclinedreason": {"type": "string"},
+                },
+            },
+            url="https://example.com/mcp",
+        )
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+
+        await lc_tool.arun({"eventid": "E001", "showdeclinedreason": "true"})
+
+        kwargs = call_tool.call_args.kwargs
+        assert kwargs["showdeclinedreason"] == "true"

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -2,177 +2,106 @@
 
 import pytest
 from unittest.mock import AsyncMock
+from pydantic import BaseModel
 
 from sap_cloud_sdk.agentgateway import MCPTool
 from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain
 
 
-class TestMcpToolToLangchain:
-    """Tests for mcp_tool_to_langchain converter."""
+def _make_tool(*, required=("eventid",), optional=("showdeclinedreason", "datafetchmode")):
+    properties = {k: {"type": "string"} for k in (*required, *optional)}
+    return MCPTool(
+        name="get_supplier_bid",
+        server_name="ariba",
+        description="Gets all supplier bids for the specified event",
+        input_schema={"type": "object", "required": list(required), "properties": properties},
+        url="https://example.com/mcp",
+    )
 
-    def test_creates_structured_tool(self):
-        """Create LangChain StructuredTool from MCPTool."""
-        tool = MCPTool(
-            name="create_order",
-            server_name="s4hana",
-            description="Create a purchase order",
-            input_schema={
-                "type": "object",
-                "properties": {"order_id": {"type": "string"}},
-            },
-            url="https://example.com/mcp",
-        )
 
-        call_tool = AsyncMock(return_value="result")
-        get_user_token = lambda: "user-jwt"
+class TestMcpToolToLangchainStructure:
+    """Tests that the converter produces a correctly structured LangChain StructuredTool."""
 
-        result = mcp_tool_to_langchain(tool, call_tool, get_user_token)
+    def test_tool_metadata_matches_mcp_tool(self):
+        """name, description, and coroutine are taken from the MCPTool."""
+        lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-        assert result.name == "create_order"
-        assert result.description == "Create a purchase order"
-        assert result.coroutine is not None
+        assert lc_tool.name == "get_supplier_bid"
+        assert lc_tool.description == "Gets all supplier bids for the specified event"
+        assert lc_tool.coroutine is not None
 
-    def test_creates_args_schema_from_input_schema(self):
-        """Create args schema from MCPTool input schema properties."""
-        tool = MCPTool(
-            name="test_tool",
-            server_name="server",
-            description="Test tool",
-            input_schema={
-                "type": "object",
-                "properties": {
-                    "param1": {"type": "string"},
-                    "param2": {"type": "integer"},
-                },
-            },
-            url="https://example.com/mcp",
-        )
+    def test_args_schema_is_pydantic_model_with_all_properties(self):
+        """args_schema is a Pydantic BaseModel that includes every property from input_schema."""
+        lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-        call_tool = AsyncMock(return_value="result")
+        assert lc_tool.args_schema is not None
+        assert isinstance(lc_tool.args_schema, type) and issubclass(lc_tool.args_schema, BaseModel)
+        fields = lc_tool.args_schema.model_fields
+        assert "eventid" in fields
+        assert "showdeclinedreason" in fields
+        assert "datafetchmode" in fields
 
-        result = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+    def test_required_fields_are_required_in_args_schema(self):
+        """Fields listed in 'required' must be required in the Pydantic model."""
+        lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-        assert result.args_schema is not None
-        from pydantic import BaseModel
+        assert lc_tool.args_schema.model_fields["eventid"].is_required()
 
-        assert isinstance(result.args_schema, type) and issubclass(
-            result.args_schema, BaseModel
-        )
-        schema_fields = result.args_schema.model_fields
-        assert "param1" in schema_fields
-        assert "param2" in schema_fields
+    def test_optional_fields_are_not_required_in_args_schema(self):
+        """Fields absent from 'required' must be optional in the Pydantic model."""
+        lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-    def test_handles_empty_input_schema(self):
-        """Handle MCPTool with empty input schema."""
+        fields = lc_tool.args_schema.model_fields
+        assert not fields["showdeclinedreason"].is_required()
+        assert not fields["datafetchmode"].is_required()
+
+    def test_empty_input_schema_produces_valid_tool(self):
+        """MCPTool with no properties at all still produces a usable StructuredTool."""
         tool = MCPTool(
             name="simple_tool",
             server_name="server",
-            description="Simple tool with no params",
+            description="No params",
             input_schema={},
             url="https://example.com/mcp",
         )
+        lc_tool = mcp_tool_to_langchain(tool, AsyncMock(return_value="ok"), lambda: "token")
 
-        call_tool = AsyncMock(return_value="result")
+        assert lc_tool.name == "simple_tool"
+        assert lc_tool.args_schema is not None
 
-        result = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
-
-        assert result.name == "simple_tool"
-        assert result.args_schema is not None
-
-    def test_optional_fields_not_required_in_args_schema(self):
-        """Fields absent from 'required' must be optional in the generated Pydantic model."""
+    def test_input_schema_without_properties_key(self):
+        """MCPTool with a type-only schema (no 'properties' key) produces a valid tool."""
         tool = MCPTool(
-            name="get_supplier_bid",
-            server_name="ariba",
-            description="Gets all supplier bids for the specified event",
-            input_schema={
-                "type": "object",
-                "required": ["eventid"],
-                "properties": {
-                    "eventid": {"description": "Unique identifier of the event"},
-                    "showdeclinedreason": {"description": "Show supplier decline reason"},
-                    "datafetchmode": {"description": "Level of detail for the response"},
-                },
-            },
-            url="https://example.com/mcp",
-        )
-
-        result = mcp_tool_to_langchain(tool, AsyncMock(return_value="result"), lambda: "token")
-
-        from pydantic import BaseModel
-
-        assert result.args_schema is not None and isinstance(result.args_schema, type) and issubclass(result.args_schema, BaseModel)
-        fields = result.args_schema.model_fields
-        assert fields["eventid"].is_required(), "eventid should be required"
-        assert not fields["showdeclinedreason"].is_required(), "showdeclinedreason should be optional"
-        assert not fields["datafetchmode"].is_required(), "datafetchmode should be optional"
-
-    def test_handles_input_schema_without_properties(self):
-        """Handle MCPTool with input schema but no properties."""
-        tool = MCPTool(
-            name="tool",
+            name="typed_tool",
             server_name="server",
-            description="Tool",
+            description="Type only",
             input_schema={"type": "object"},
             url="https://example.com/mcp",
         )
+        lc_tool = mcp_tool_to_langchain(tool, AsyncMock(return_value="ok"), lambda: "token")
 
-        call_tool = AsyncMock(return_value="result")
-
-        result = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
-
-        assert result.args_schema is not None
+        assert lc_tool.args_schema is not None
 
 
 class TestMcpToolToLangchainInvocation:
-    """End-to-end invocation tests for mcp_tool_to_langchain."""
+    """End-to-end invocation tests: verify what actually reaches call_tool."""
 
     @pytest.mark.asyncio
     async def test_required_param_forwarded(self):
-        """Required parameters are forwarded to call_tool."""
-        tool = MCPTool(
-            name="get_supplier_bid",
-            server_name="ariba",
-            description="Gets supplier bids",
-            input_schema={
-                "type": "object",
-                "required": ["eventid"],
-                "properties": {
-                    "eventid": {"type": "string"},
-                    "showdeclinedreason": {"type": "string"},
-                },
-            },
-            url="https://example.com/mcp",
-        )
+        """Required parameters supplied by the LLM are forwarded to call_tool."""
         call_tool = AsyncMock(return_value="ok")
-        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
         await lc_tool.arun({"eventid": "E001"})
 
         call_tool.assert_awaited_once()
-        kwargs = call_tool.call_args.kwargs
-        assert kwargs["eventid"] == "E001"
+        assert call_tool.call_args.kwargs["eventid"] == "E001"
 
     @pytest.mark.asyncio
     async def test_optional_params_omitted_when_not_supplied(self):
-        """Optional parameters not supplied by the LLM must not be forwarded as None."""
-        tool = MCPTool(
-            name="get_supplier_bid",
-            server_name="ariba",
-            description="Gets supplier bids",
-            input_schema={
-                "type": "object",
-                "required": ["eventid"],
-                "properties": {
-                    "eventid": {"type": "string"},
-                    "showdeclinedreason": {"type": "string"},
-                    "datafetchmode": {"type": "string"},
-                },
-            },
-            url="https://example.com/mcp",
-        )
+        """Optional parameters absent from the LLM response must not reach call_tool as None."""
         call_tool = AsyncMock(return_value="ok")
-        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
         await lc_tool.arun({"eventid": "E001"})
 
@@ -181,26 +110,23 @@ class TestMcpToolToLangchainInvocation:
         assert "datafetchmode" not in kwargs
 
     @pytest.mark.asyncio
-    async def test_optional_param_forwarded_when_supplied(self):
-        """Optional parameters that the LLM does supply are forwarded."""
-        tool = MCPTool(
-            name="get_supplier_bid",
-            server_name="ariba",
-            description="Gets supplier bids",
-            input_schema={
-                "type": "object",
-                "required": ["eventid"],
-                "properties": {
-                    "eventid": {"type": "string"},
-                    "showdeclinedreason": {"type": "string"},
-                },
-            },
-            url="https://example.com/mcp",
-        )
+    async def test_optional_params_omitted_when_llm_sends_none(self):
+        """Optional parameters explicitly set to None by the LLM must not reach call_tool."""
         call_tool = AsyncMock(return_value="ok")
-        lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
+
+        await lc_tool.arun({"eventid": "E001", "showdeclinedreason": None, "datafetchmode": None})
+
+        kwargs = call_tool.call_args.kwargs
+        assert "showdeclinedreason" not in kwargs
+        assert "datafetchmode" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_optional_param_forwarded_when_supplied(self):
+        """Optional parameters with a real value supplied by the LLM are forwarded."""
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
         await lc_tool.arun({"eventid": "E001", "showdeclinedreason": "true"})
 
-        kwargs = call_tool.call_args.kwargs
-        assert kwargs["showdeclinedreason"] == "true"
+        assert call_tool.call_args.kwargs["showdeclinedreason"] == "true"

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -136,3 +136,15 @@ class TestMcpToolToLangchainInvocation:
         await lc_tool.arun({"eventid": "E001", "showdeclinedreason": "true"})
 
         assert call_tool.call_args.kwargs["showdeclinedreason"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_none_values_forwarded_when_omit_none_false(self):
+        """When omit_none=False, None values are forwarded to call_tool as-is."""
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token", omit_none=False)
+
+        await lc_tool.arun({"eventid": "E001", "showdeclinedreason": None})
+
+        kwargs = call_tool.call_args.kwargs
+        assert "showdeclinedreason" in kwargs
+        assert kwargs["showdeclinedreason"] is None

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -8,6 +8,13 @@ from sap_cloud_sdk.agentgateway import MCPTool
 from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain
 
 
+def _schema_fields(lc_tool):
+    """Narrow args_schema to BaseModel and return model_fields."""
+    schema = lc_tool.args_schema
+    assert isinstance(schema, type) and issubclass(schema, BaseModel)
+    return schema.model_fields
+
+
 def _make_tool(*, required=("eventid",), optional=("showdeclinedreason", "datafetchmode")):
     properties = {k: {"type": "string"} for k in (*required, *optional)}
     return MCPTool(
@@ -35,8 +42,7 @@ class TestMcpToolToLangchainStructure:
         lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
         assert lc_tool.args_schema is not None
-        assert isinstance(lc_tool.args_schema, type) and issubclass(lc_tool.args_schema, BaseModel)
-        fields = lc_tool.args_schema.model_fields
+        fields = _schema_fields(lc_tool)
         assert "eventid" in fields
         assert "showdeclinedreason" in fields
         assert "datafetchmode" in fields
@@ -45,13 +51,13 @@ class TestMcpToolToLangchainStructure:
         """Fields listed in 'required' must be required in the Pydantic model."""
         lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-        assert lc_tool.args_schema.model_fields["eventid"].is_required()
+        assert _schema_fields(lc_tool)["eventid"].is_required()
 
     def test_optional_fields_are_not_required_in_args_schema(self):
         """Fields absent from 'required' must be optional in the Pydantic model."""
         lc_tool = mcp_tool_to_langchain(_make_tool(), AsyncMock(return_value="ok"), lambda: "token")
 
-        fields = lc_tool.args_schema.model_fields
+        fields = _schema_fields(lc_tool)
         assert not fields["showdeclinedreason"].is_required()
         assert not fields["datafetchmode"].is_required()
 

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.28.1"
+version = "0.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Fixes `mcp_tool_to_langchain` in the Agent Gateway converter so that optional MCP tool parameters are no longer forwarded to `call_mcp_tool` as `None` values, and adds an `omit_none` configuration option to control this behaviour.

**Root cause:** Optional fields in the generated Pydantic `args_schema` were typed as `str | None` with a plain `None` default. LangChain passes all schema fields — including optional ones the LLM did not supply — to the tool's `run` closure as keyword arguments. This caused `call_mcp_tool` to receive explicit `None` for every optional parameter, which breaks downstream MCP tool invocations that distinguish between an absent parameter and a null one.

**Changes:**
- Optional fields are now typed as `str | None` with `Field(default=None)` so Pydantic accepts `None` from LangChain's validation layer, while the field is still not in `required`.
- The `run` closure strips `None` values from `kwargs` before forwarding to `call_tool` (controlled by the new `omit_none` flag).
- New keyword-only parameter `omit_none: bool = True` on `mcp_tool_to_langchain` — set to `False` to forward `None` values explicitly to the MCP server.
- Test suite refactored: shared `_make_tool()` fixture removes duplication; new `TestMcpToolToLangchainInvocation` class covers end-to-end LangChain tool invocation including the `omit_none=False` path.
- Removed stale `# ty: ignore` comments from `tests/adms/unit/test_client.py` and `tests/destination/unit/test_client.py` that caused `ty` type-check pre-commit failures.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Install the package: `uv sync`
2. Run the converter unit tests:
   ```
   uv run pytest tests/agentgateway/unit/test_converters.py -v
   ```
3. Verify the default behaviour (None omitted):
   ```python
   import asyncio
   from unittest.mock import AsyncMock
   from sap_cloud_sdk.agentgateway import MCPTool
   from sap_cloud_sdk.agentgateway.converters import mcp_tool_to_langchain

   tool = MCPTool(
       name="get_supplier_bid", server_name="ariba",
       description="Gets supplier bids",
       input_schema={
           "type": "object", "required": ["eventid"],
           "properties": {"eventid": {"type": "string"}, "showdeclinedreason": {"type": "string"}},
       },
       url="https://example.com/mcp",
   )
   call_tool = AsyncMock(return_value="ok")
   lc_tool = mcp_tool_to_langchain(tool, call_tool, lambda: "token")
   asyncio.run(lc_tool.arun({"eventid": "E001"}))
   assert "showdeclinedreason" not in call_tool.call_args.kwargs  # omitted, not None
   ```
4. Verify `omit_none=False` forwards `None` explicitly:
   ```python
   call_tool2 = AsyncMock(return_value="ok")
   lc_tool2 = mcp_tool_to_langchain(tool, call_tool2, lambda: "token", omit_none=False)
   asyncio.run(lc_tool2.arun({"eventid": "E001", "showdeclinedreason": None}))
   assert call_tool2.call_args.kwargs["showdeclinedreason"] is None  # forwarded as None
   ```
5. Run the full pre-commit suite: `uvx pre-commit run --all-files`

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

`omit_none` is keyword-only (declared after `*`) to prevent positional misuse. The default `True` preserves existing behaviour — no changes needed for current callers.
