### PR TITLE
chore: remove unused ty ignore comments after ty 0.0.52 upgrade

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -34,7 +34,7 @@ Tip:
 ## Type Check
 
 ```bash
-uv run ty check .
+uvx ty check .
 ```
 
 ## Code Quality Checks
@@ -49,7 +49,7 @@ uv run ruff check .
 uv run ruff format --check .
 
 # Type check
-uv run ty check .
+uvx ty check .
 ```
 
 ## Pre-commit Hooks (Recommended)

--- a/tests/adms/unit/test_client.py
+++ b/tests/adms/unit/test_client.py
@@ -88,8 +88,8 @@ def _make_httpx_response(
 
 def _make_token_fetcher(config: AdmsConfig) -> IasTokenFetcher:
     fetcher = IasTokenFetcher(config=config)
-    fetcher.get_token = MagicMock(return_value="test-bearer-token")  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-    fetcher.exchange_token = MagicMock(return_value="user-bearer-token")  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+    fetcher.get_token = MagicMock(return_value="test-bearer-token")  # type: ignore[method-assign]
+    fetcher.exchange_token = MagicMock(return_value="user-bearer-token")  # type: ignore[method-assign]
     return fetcher
 
 
@@ -423,13 +423,13 @@ class TestAsyncAdmsClient:
         http = _make_async_http(config, fetcher)
         mock_user_http = MagicMock(spec=AsyncAdmsHttp)
         mock_user_http._client = AsyncMock(spec=httpx.AsyncClient)
-        http.with_user_jwt = MagicMock(return_value=mock_user_http)  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        http.with_user_jwt = MagicMock(return_value=mock_user_http)  # type: ignore[method-assign]
 
         client = AsyncAdmsClient(http)
         new_client = client.with_user_jwt("my-jwt")
 
         assert new_client is not client
-        http.with_user_jwt.assert_called_once_with("my-jwt")  # type: ignore[union-attr]  # ty: ignore[unresolved-attribute]
+        http.with_user_jwt.assert_called_once_with("my-jwt")  # type: ignore[union-attr]
         assert new_client._http is mock_user_http
 
     @pytest.mark.asyncio

--- a/tests/destination/unit/test_client.py
+++ b/tests/destination/unit/test_client.py
@@ -1704,7 +1704,7 @@ class TestDestinationClientEdgeCases:
         with pytest.raises(DestinationOperationError) as exc_info:
             client.get_subaccount_destination(
                 "test-dest",
-                access_strategy=unknown_strategy,  # ty: ignore[invalid-argument-type]
+                access_strategy=unknown_strategy,
                 tenant="test-tenant"
             )
 
@@ -1802,7 +1802,7 @@ class TestDestinationClientEdgeCases:
 
         with pytest.raises(DestinationOperationError) as exc_info:
             client._apply_access_strategy(
-                access_strategy=unknown_strategy,  # ty: ignore[invalid-argument-type]
+                access_strategy=unknown_strategy,
                 tenant="test-tenant",
                 fetch_func=mock_fetch
             )


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

`ty` 0.0.52 (released 2026-06-22) made two changes that together broke the Code Quality CI job:

1. Fixed type inference for attribute assignments on MagicMock objects — several `ty: ignore[invalid-assignment]` and `ty: ignore[unresolved-attribute]` comments that were suppressing real (false positive) errors in older `ty` became unnecessary.
2. Made `--error-on-warning` the default — `unused-ignore-comment` warnings now cause a non-zero exit code, so those stale comments started failing CI.

This PR removes the 6 comments that `ty` 0.0.52 identified as unused across two test files.

## Related Issue

N/A

## Type of Change

Please check the relevant option:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Run `uvx pre-commit run --all-files`
2. Expected result: all hooks pass, including `ty type check`

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None

## Additional Notes

The removed comments were originally valid suppressions against a false positive in older `ty`. They are no longer needed after the upstream fix in `ty` 0.0.52.
