### PR TITLE
feat(agw): new customer agents auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.29.0"
+version = "0.30.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -231,7 +231,8 @@ def load_customer_credentials_from_env() -> CustomerCredentials:
         )
 
     logger.debug(
-        "Loaded %d integration dependencies from environment", len(integration_dependencies)
+        "Loaded %d integration dependencies from environment",
+        len(integration_dependencies),
     )
 
     return CustomerCredentials(
@@ -387,7 +388,8 @@ def _request_token_transparent(
             )
 
         logger.debug(
-            "Token acquired successfully (transparent mode, length: %d)", len(access_token)
+            "Token acquired successfully (transparent mode, length: %d)",
+            len(access_token),
         )
         return token_data
 
@@ -417,6 +419,11 @@ def _request_token_mtls(
     Raises:
         AgentGatewaySDKError: If token request fails.
     """
+    if credentials.certificate is None or credentials.private_key is None:
+        raise AgentGatewaySDKError(
+            "mTLS token request requires certificate and private_key. "
+            "Use _request_token_transparent() for TlsMode.TRANSPARENT."
+        )
     ssl_context = _create_ssl_context(credentials.certificate, credentials.private_key)
 
     data = {

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -114,18 +114,76 @@ def detect_customer_agent_credentials(
     return None
 
 
-def load_customer_credentials(path: str) -> CustomerCredentials:
-    """Load and parse customer credentials from file.
+def load_customer_credentials(
+    path: str | None,
+    tls_mode: TlsMode = TlsMode.STANDARD,
+) -> CustomerCredentials:
+    """Load customer credentials from a file (standard mode) or environment variables (transparent mode).
+
+    In transparent mode (``tls_mode=TlsMode.TRANSPARENT``) the OpenShell Gateway
+    injects the mTLS client certificate at the TLS layer. Credentials are read
+    from environment variables and ``certificate``/``private_key`` are set to
+    ``None``.
+
+    In standard mode ``path`` must point to a valid JSON credentials file.
 
     Args:
-        path: Path to the credentials JSON file.
+        path: Path to the credentials JSON file. Required in standard mode,
+            ignored in transparent mode.
+        tls_mode: TLS handling mode. When TRANSPARENT, loads from env vars.
 
     Returns:
         Parsed CustomerCredentials.
 
     Raises:
-        AgentGatewaySDKError: If file cannot be read or is missing required fields.
+        AgentGatewaySDKError: If credentials cannot be loaded or required fields
+            are missing.
     """
+    if tls_mode == TlsMode.TRANSPARENT:
+        logger.debug("TLS_MODE=transparent: loading credentials from environment variables")
+        required = [_ENV_CLIENT_ID, _ENV_TOKEN_SERVICE_URL, _ENV_GATEWAY_URL]
+        missing = [v for v in required if not os.environ.get(v)]
+        if missing:
+            raise AgentGatewaySDKError(
+                f"TLS_MODE=transparent requires environment variables: {missing}"
+            )
+
+        raw_deps = os.environ.get(_ENV_INTEGRATION_DEPENDENCIES, "[]")
+        try:
+            deps_data = json.loads(raw_deps)
+            integration_dependencies = [
+                IntegrationDependency(
+                    ord_id=dep[_CredentialFields.ORD_ID],
+                    global_tenant_id=dep[_CredentialFields.GLOBAL_TENANT_ID],
+                )
+                for dep in deps_data
+            ]
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            raise AgentGatewaySDKError(
+                f"Failed to parse INTEGRATION_DEPENDENCIES: {e}. "
+                'Expected format: [{"ordId": "...", "globalTenantId": "..."}]'
+            )
+
+        logger.debug(
+            "Loaded %d integration dependencies from environment",
+            len(integration_dependencies),
+        )
+
+        return CustomerCredentials(
+            token_service_url=os.environ[_ENV_TOKEN_SERVICE_URL],
+            client_id=os.environ[_ENV_CLIENT_ID],
+            certificate=None,
+            private_key=None,
+            gateway_url=os.environ[_ENV_GATEWAY_URL].rstrip("/"),
+            integration_dependencies=integration_dependencies,
+        )
+
+    # Standard mode: file-based credentials
+    if not path:
+        raise AgentGatewaySDKError(
+            "Credentials file path is required in standard TLS mode."
+        )
+
     logger.debug("Loading customer credentials from: %s", path)
 
     try:
@@ -134,8 +192,6 @@ def load_customer_credentials(path: str) -> CustomerCredentials:
     except (OSError, json.JSONDecodeError) as e:
         raise AgentGatewaySDKError(f"Failed to load credentials from '{path}': {e}")
 
-    # Map credential file keys to dataclass fields
-    # Credential file uses camelCase, we use snake_case
     required_fields = {
         _CredentialFields.TOKEN_SERVICE_URL: "token_service_url",
         _CredentialFields.CLIENT_ID: "client_id",
@@ -144,13 +200,12 @@ def load_customer_credentials(path: str) -> CustomerCredentials:
         _CredentialFields.GATEWAY_URL: "gateway_url",
     }
 
-    missing = [k for k in required_fields if k not in data]
-    if missing:
+    missing_fields = [k for k in required_fields if k not in data]
+    if missing_fields:
         raise AgentGatewaySDKError(
-            f"Credentials file missing required fields: {missing}"
+            f"Credentials file missing required fields: {missing_fields}"
         )
 
-    # Parse integrationDependencies (required)
     if _CredentialFields.INTEGRATION_DEPENDENCIES not in data:
         raise AgentGatewaySDKError(
             "Credentials file missing required field: integrationDependencies. "
@@ -184,64 +239,6 @@ def load_customer_credentials(path: str) -> CustomerCredentials:
         private_key=data[_CredentialFields.PRIVATE_KEY],
         gateway_url=data[_CredentialFields.GATEWAY_URL].rstrip("/"),
         integration_dependencies=integration_deps,
-    )
-
-
-def load_customer_credentials_from_env() -> CustomerCredentials:
-    """Load customer credentials from environment variables (transparent mode).
-
-    Used when TlsMode.TRANSPARENT is active and the OpenShell Gateway handles
-    mTLS. Certificate and private key are not required — they are injected at
-    the TLS layer by the gateway.
-
-    Environment variables:
-        CLIENT_ID: IAS client ID (may be a gateway-resolved placeholder at runtime)
-        TOKEN_SERVICE_URL: IAS token service endpoint
-        GATEWAY_URL: Agent Gateway base URL
-        INTEGRATION_DEPENDENCIES: JSON array of {ordId, globalTenantId} objects
-
-    Returns:
-        CustomerCredentials with certificate and private_key set to None.
-
-    Raises:
-        AgentGatewaySDKError: If required environment variables are missing or
-            INTEGRATION_DEPENDENCIES cannot be parsed.
-    """
-    required = [_ENV_CLIENT_ID, _ENV_TOKEN_SERVICE_URL, _ENV_GATEWAY_URL]
-    missing = [v for v in required if not os.environ.get(v)]
-    if missing:
-        raise AgentGatewaySDKError(
-            f"TLS_MODE=transparent requires environment variables: {missing}"
-        )
-
-    raw_deps = os.environ.get(_ENV_INTEGRATION_DEPENDENCIES, "[]")
-    try:
-        deps_data = json.loads(raw_deps)
-        integration_dependencies = [
-            IntegrationDependency(
-                ord_id=dep[_CredentialFields.ORD_ID],
-                global_tenant_id=dep[_CredentialFields.GLOBAL_TENANT_ID],
-            )
-            for dep in deps_data
-        ]
-    except (json.JSONDecodeError, KeyError, TypeError) as e:
-        raise AgentGatewaySDKError(
-            f"Failed to parse INTEGRATION_DEPENDENCIES: {e}. "
-            'Expected format: [{"ordId": "...", "globalTenantId": "..."}]'
-        )
-
-    logger.debug(
-        "Loaded %d integration dependencies from environment",
-        len(integration_dependencies),
-    )
-
-    return CustomerCredentials(
-        token_service_url=os.environ[_ENV_TOKEN_SERVICE_URL],
-        client_id=os.environ[_ENV_CLIENT_ID],
-        certificate=None,
-        private_key=None,
-        gateway_url=os.environ[_ENV_GATEWAY_URL].rstrip("/"),
-        integration_dependencies=integration_dependencies,
     )
 
 

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -3,9 +3,14 @@
 Customer agents read credentials from a file mounted on the pod filesystem.
 This flow is used when credential files are detected.
 
+In transparent TLS mode (TlsMode.TRANSPARENT) the OpenShell Gateway handles
+the mTLS handshake and credential injection. The agent reads only endpoint URLs
+from environment variables and never loads certificate or private key material.
+
 Authentication flow:
-- Tool discovery: mTLS client credentials → system-scoped token
-- Tool invocation: mTLS + jwt-bearer grant → user-scoped token (principal propagation)
+- Standard mode: mTLS client credentials → system-scoped token
+- Transparent mode: plain HTTPS (gateway-injected mTLS) → system-scoped token
+- Tool invocation: jwt-bearer grant → user-scoped token (principal propagation)
 """
 
 import json
@@ -25,6 +30,7 @@ from sap_cloud_sdk.agentgateway._models import (
     MCPTool,
 )
 from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
+from sap_cloud_sdk.agentgateway.config import TlsMode
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 
 logger = logging.getLogger(__name__)
@@ -41,6 +47,12 @@ _AGW_RESOURCE_URN = "urn:sap:identity:application:provider:name:agent-gateway"
 # OAuth2 grant types
 _GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials"
 _GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+# Environment variables for transparent mode
+_ENV_CLIENT_ID = "CLIENT_ID"
+_ENV_TOKEN_SERVICE_URL = "TOKEN_SERVICE_URL"
+_ENV_GATEWAY_URL = "GATEWAY_URL"
+_ENV_INTEGRATION_DEPENDENCIES = "INTEGRATION_DEPENDENCIES"
 
 
 def _cache_scope_key(credentials: CustomerCredentials, app_tid: str | None) -> str:
@@ -62,16 +74,30 @@ class _CredentialFields:
     GLOBAL_TENANT_ID = "globalTenantId"
 
 
-def detect_customer_agent_credentials() -> str | None:
+def detect_customer_agent_credentials(
+    tls_mode: TlsMode = TlsMode.STANDARD,
+) -> str | None:
     """Check if customer agent credentials file exists.
 
-    Checks for credential file in the following order:
+    In transparent mode the agent never uses a credentials file — the OpenShell
+    Gateway injects certificates at the TLS layer and the agent reads only
+    endpoint URLs from environment variables. Returns None immediately so the
+    caller falls through to load_customer_credentials_from_env().
+
+    In standard mode checks for a credential file in the following order:
     1. Path specified in AGW_CREDENTIALS_PATH env var
     2. Default mounted path: /etc/ums/credentials/credentials
 
+    Args:
+        tls_mode: TLS handling mode. When TRANSPARENT, skips file detection.
+
     Returns:
-        Path to credentials file if found, None otherwise.
+        Path to credentials file if found (standard mode only), None otherwise.
     """
+    if tls_mode == TlsMode.TRANSPARENT:
+        logger.debug("TLS_MODE=transparent: skipping credentials file detection")
+        return None
+
     # Check env var first (path may be customized)
     path_from_env = os.environ.get(_CREDENTIALS_PATH_ENV)
     if path_from_env and os.path.isfile(path_from_env):
@@ -161,6 +187,63 @@ def load_customer_credentials(path: str) -> CustomerCredentials:
     )
 
 
+def load_customer_credentials_from_env() -> CustomerCredentials:
+    """Load customer credentials from environment variables (transparent mode).
+
+    Used when TlsMode.TRANSPARENT is active and the OpenShell Gateway handles
+    mTLS. Certificate and private key are not required — they are injected at
+    the TLS layer by the gateway.
+
+    Environment variables:
+        CLIENT_ID: IAS client ID (may be a gateway-resolved placeholder at runtime)
+        TOKEN_SERVICE_URL: IAS token service endpoint
+        GATEWAY_URL: Agent Gateway base URL
+        INTEGRATION_DEPENDENCIES: JSON array of {ordId, globalTenantId} objects
+
+    Returns:
+        CustomerCredentials with certificate and private_key set to None.
+
+    Raises:
+        AgentGatewaySDKError: If required environment variables are missing or
+            INTEGRATION_DEPENDENCIES cannot be parsed.
+    """
+    required = [_ENV_CLIENT_ID, _ENV_TOKEN_SERVICE_URL, _ENV_GATEWAY_URL]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        raise AgentGatewaySDKError(
+            f"TLS_MODE=transparent requires environment variables: {missing}"
+        )
+
+    raw_deps = os.environ.get(_ENV_INTEGRATION_DEPENDENCIES, "[]")
+    try:
+        deps_data = json.loads(raw_deps)
+        integration_dependencies = [
+            IntegrationDependency(
+                ord_id=dep[_CredentialFields.ORD_ID],
+                global_tenant_id=dep[_CredentialFields.GLOBAL_TENANT_ID],
+            )
+            for dep in deps_data
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        raise AgentGatewaySDKError(
+            f"Failed to parse INTEGRATION_DEPENDENCIES: {e}. "
+            'Expected format: [{"ordId": "...", "globalTenantId": "..."}]'
+        )
+
+    logger.debug(
+        "Loaded %d integration dependencies from environment", len(integration_dependencies)
+    )
+
+    return CustomerCredentials(
+        token_service_url=os.environ[_ENV_TOKEN_SERVICE_URL],
+        client_id=os.environ[_ENV_CLIENT_ID],
+        certificate=None,
+        private_key=None,
+        gateway_url=os.environ[_ENV_GATEWAY_URL].rstrip("/"),
+        integration_dependencies=integration_dependencies,
+    )
+
+
 def _create_ssl_context(certificate: str, private_key: str) -> ssl.SSLContext:
     """Create SSL context for mTLS from in-memory certificate and key.
 
@@ -210,6 +293,106 @@ def _create_ssl_context(certificate: str, private_key: str) -> ssl.SSLContext:
             os.unlink(cert_file.name)
         if key_file and os.path.exists(key_file.name):
             os.unlink(key_file.name)
+
+
+def _create_http_client_transparent(timeout: float) -> httpx.Client:
+    """Create an HTTP client for transparent TLS mode.
+
+    The OpenShell Gateway handles TLS and mTLS on behalf of the agent, so no
+    SSL context is configured. All HTTPS requests are routed through the proxy
+    set in the HTTPS_PROXY environment variable.
+
+    Args:
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        httpx.Client without any custom SSL context.
+    """
+    return httpx.Client(timeout=timeout)
+
+
+def _request_token_transparent(
+    credentials: CustomerCredentials,
+    grant_type: str,
+    timeout: float,
+    app_tid: str | None = None,
+    extra_data: dict | None = None,
+) -> dict:
+    """Make a token request in transparent TLS mode.
+
+    The OpenShell Gateway intercepts the HTTPS connection and:
+    1. Injects the client certificate at the TLS layer (mTLS handshake).
+    2. Rewrites the client_id placeholder in the request body.
+
+    The agent sends the OAuth2 POST body without loading any certificate or key.
+
+    Args:
+        credentials: Customer credentials (certificate/private_key are None).
+        grant_type: OAuth2 grant type.
+        timeout: HTTP timeout in seconds.
+        app_tid: BTP Application Tenant ID of subscriber (optional).
+        extra_data: Additional form data for the token request.
+
+    Returns:
+        Token response payload.
+
+    Raises:
+        AgentGatewaySDKError: If token request fails.
+    """
+    data: dict = {
+        "client_id": credentials.client_id,
+        "grant_type": grant_type,
+        "resource": _AGW_RESOURCE_URN,
+    }
+
+    if app_tid:
+        data["app_tid"] = app_tid
+
+    if extra_data:
+        data.update(extra_data)
+
+    logger.debug(
+        "Requesting token (transparent mode) from %s with grant_type=%s",
+        credentials.token_service_url,
+        grant_type,
+    )
+
+    try:
+        with _create_http_client_transparent(timeout) as client:
+            response = client.post(
+                credentials.token_service_url,
+                data=data,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
+            )
+
+        if response.status_code != 200:
+            logger.error(
+                "Token request failed with status %d: %s",
+                response.status_code,
+                response.text[:500],
+            )
+            raise AgentGatewaySDKError(
+                f"Token request failed with status {response.status_code}: {response.text[:200]}"
+            )
+
+        token_data = response.json()
+        access_token = token_data.get("access_token")
+
+        if not access_token:
+            raise AgentGatewaySDKError(
+                f"Token response missing 'access_token'. Keys: {list(token_data.keys())}"
+            )
+
+        logger.debug(
+            "Token acquired successfully (transparent mode, length: %d)", len(access_token)
+        )
+        return token_data
+
+    except httpx.RequestError as e:
+        raise AgentGatewaySDKError(f"Token request failed: {e}")
 
 
 def _request_token_mtls(
@@ -341,6 +524,53 @@ def get_system_token_mtls(
     return access_token
 
 
+def get_system_token_transparent(
+    credentials: CustomerCredentials,
+    timeout: float,
+    app_tid: str | None = None,
+    token_cache: _TokenCache | None = None,
+) -> str:
+    """Get system-scoped token in transparent TLS mode.
+
+    Equivalent to get_system_token_mtls() but uses _request_token_transparent()
+    so the agent never performs a TLS handshake directly.
+
+    Args:
+        credentials: Customer credentials loaded from environment variables.
+        timeout: HTTP timeout in seconds.
+        app_tid: BTP Application Tenant ID of subscriber (optional).
+        token_cache: Optional token cache.
+
+    Returns:
+        System-scoped access token, fetched or served from cache.
+    """
+    scope_key = _cache_scope_key(credentials, app_tid)
+    if token_cache:
+        cached_token = token_cache.get_system_token(scope_key)
+        if cached_token:
+            logger.debug("Using cached system token for scope '%s'", scope_key)
+            return cached_token
+
+    logger.info("Acquiring system token via transparent mode (gateway-injected mTLS)")
+    token_data = _request_token_transparent(
+        credentials,
+        grant_type=_GRANT_TYPE_CLIENT_CREDENTIALS,
+        timeout=timeout,
+        app_tid=app_tid,
+        extra_data={"response_type": "token"},
+    )
+    access_token = token_data["access_token"]
+
+    if token_cache:
+        token_cache.set_system_token(
+            access_token,
+            token_cache.compute_expires_at(token_data),
+            scope_key,
+        )
+
+    return access_token
+
+
 def exchange_user_token(
     credentials: CustomerCredentials,
     user_token: str,
@@ -373,6 +603,61 @@ def exchange_user_token(
 
     logger.info("Exchanging user token for AGW-scoped token via jwt-bearer grant")
     token_data = _request_token_mtls(
+        credentials,
+        grant_type=_GRANT_TYPE_JWT_BEARER,
+        timeout=timeout,
+        app_tid=app_tid,
+        extra_data={
+            "assertion": user_token,
+            "token_format": "jwt",
+        },
+    )
+    access_token = token_data["access_token"]
+
+    if token_cache:
+        token_cache.set_user_token(
+            user_token,
+            access_token,
+            token_cache.compute_expires_at(token_data),
+            scope_key,
+        )
+
+    return access_token
+
+
+def exchange_user_token_transparent(
+    credentials: CustomerCredentials,
+    user_token: str,
+    timeout: float,
+    app_tid: str | None = None,
+    token_cache: _TokenCache | None = None,
+) -> str:
+    """Exchange user token for AGW-scoped token in transparent TLS mode.
+
+    Equivalent to exchange_user_token() but uses _request_token_transparent()
+    so the agent never performs a TLS handshake directly.
+
+    Args:
+        credentials: Customer credentials loaded from environment variables.
+        user_token: User's JWT token to exchange.
+        timeout: HTTP timeout in seconds.
+        app_tid: BTP Application Tenant ID of subscriber (optional).
+        token_cache: Optional token cache.
+
+    Returns:
+        AGW-scoped access token with user identity, fetched or served from cache.
+    """
+    scope_key = _cache_scope_key(credentials, app_tid)
+    if token_cache:
+        cached_token = token_cache.get_user_token(user_token, scope_key)
+        if cached_token:
+            logger.debug("Using cached exchanged user token for scope '%s'", scope_key)
+            return cached_token
+
+    logger.info(
+        "Exchanging user token for AGW-scoped token via jwt-bearer grant (transparent mode)"
+    )
+    token_data = _request_token_transparent(
         credentials,
         grant_type=_GRANT_TYPE_JWT_BEARER,
         timeout=timeout,

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -140,7 +140,9 @@ def load_customer_credentials(
             are missing.
     """
     if tls_mode == TlsMode.TRANSPARENT:
-        logger.debug("TLS_MODE=transparent: loading credentials from environment variables")
+        logger.debug(
+            "TLS_MODE=transparent: loading credentials from environment variables"
+        )
         required = [_ENV_CLIENT_ID, _ENV_TOKEN_SERVICE_URL, _ENV_GATEWAY_URL]
         missing = [v for v in required if not os.environ.get(v)]
         if missing:

--- a/src/sap_cloud_sdk/agentgateway/_models.py
+++ b/src/sap_cloud_sdk/agentgateway/_models.py
@@ -74,21 +74,23 @@ class IntegrationDependency:
 class CustomerCredentials:
     """Credentials for customer agent mTLS authentication.
 
-    Loaded from the credentials file mounted on the pod filesystem.
-    Used internally by the customer agent flow.
+    Loaded from the credentials file mounted on the pod filesystem, or from
+    environment variables when TlsMode.TRANSPARENT is active (in which case
+    certificate and private_key are None — the OpenShell Gateway injects them
+    at the TLS layer).
 
     Attributes:
         token_service_url: IAS token service endpoint URL
         client_id: IAS client ID
-        certificate: PEM-encoded client certificate
-        private_key: PEM-encoded private key
+        certificate: PEM-encoded client certificate. None in transparent mode.
+        private_key: PEM-encoded private key. None in transparent mode.
         gateway_url: Agent Gateway base URL
         integration_dependencies: List of MCP servers with their ord_id and global_tenant_id.
     """
 
     token_service_url: str
     client_id: str
-    certificate: str
-    private_key: str
+    certificate: str | None
+    private_key: str | None
     gateway_url: str
     integration_dependencies: list[IntegrationDependency]

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -11,14 +11,17 @@ import asyncio
 import logging
 from typing import Callable
 
-from sap_cloud_sdk.agentgateway.config import ClientConfig
+from sap_cloud_sdk.agentgateway.config import ClientConfig, TlsMode
 from sap_cloud_sdk.agentgateway._customer import (
     call_mcp_tool_customer,
     detect_customer_agent_credentials,
     exchange_user_token,
+    exchange_user_token_transparent,
     get_mcp_tools_customer,
     get_system_token_mtls,
+    get_system_token_transparent,
     load_customer_credentials,
+    load_customer_credentials_from_env,
 )
 from sap_cloud_sdk.agentgateway._lob import (
     call_mcp_tool_lob,
@@ -172,7 +175,7 @@ class AgentGatewayClient:
             ```
         """
         try:
-            credentials_path = detect_customer_agent_credentials()
+            credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
             if credentials_path:
                 logger.info(
                     "Customer agent credentials detected at '%s'", credentials_path
@@ -182,6 +185,23 @@ class AgentGatewayClient:
                 token = await loop.run_in_executor(
                     None,
                     get_system_token_mtls,
+                    credentials,
+                    self._config.timeout,
+                    app_tid,
+                    self._token_cache,
+                )
+                return AuthResult(
+                    access_token=token,
+                    gateway_url=credentials.gateway_url,
+                )
+
+            if self._config.tls_mode == TlsMode.TRANSPARENT:
+                logger.info("Customer agent transparent mode detected")
+                credentials = load_customer_credentials_from_env()
+                loop = asyncio.get_running_loop()
+                token = await loop.run_in_executor(
+                    None,
+                    get_system_token_transparent,
                     credentials,
                     self._config.timeout,
                     app_tid,
@@ -249,7 +269,7 @@ class AgentGatewayClient:
                 "user_token is required for token exchange.",
             )
 
-            credentials_path = detect_customer_agent_credentials()
+            credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
             if credentials_path:
                 logger.info(
                     "Customer agent credentials detected at '%s'", credentials_path
@@ -259,6 +279,24 @@ class AgentGatewayClient:
                 token = await loop.run_in_executor(
                     None,
                     exchange_user_token,
+                    credentials,
+                    resolved_user_token,
+                    self._config.timeout,
+                    app_tid,
+                    self._token_cache,
+                )
+                return AuthResult(
+                    access_token=token,
+                    gateway_url=credentials.gateway_url,
+                )
+
+            if self._config.tls_mode == TlsMode.TRANSPARENT:
+                logger.info("Customer agent transparent mode detected")
+                credentials = load_customer_credentials_from_env()
+                loop = asyncio.get_running_loop()
+                token = await loop.run_in_executor(
+                    None,
+                    exchange_user_token_transparent,
                     credentials,
                     resolved_user_token,
                     self._config.timeout,
@@ -333,12 +371,23 @@ class AgentGatewayClient:
         """
         try:
             # Check for customer agent credentials
-            credentials_path = detect_customer_agent_credentials()
+            credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
             if credentials_path:
                 logger.info(
                     "Customer agent credentials detected at '%s'", credentials_path
                 )
                 credentials = load_customer_credentials(credentials_path)
+                if user_token:
+                    auth = await self.get_user_auth(user_token, app_tid)
+                else:
+                    auth = await self.get_system_auth(app_tid=app_tid)
+                return await get_mcp_tools_customer(
+                    credentials, auth.access_token, self._config.timeout
+                )
+
+            if self._config.tls_mode == TlsMode.TRANSPARENT:
+                logger.info("Customer agent transparent mode detected")
+                credentials = load_customer_credentials_from_env()
                 if user_token:
                     auth = await self.get_user_auth(user_token, app_tid)
                 else:
@@ -420,7 +469,7 @@ class AgentGatewayClient:
         """
         try:
             # Check for customer agent credentials
-            credentials_path = detect_customer_agent_credentials()
+            credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
             if credentials_path:
                 logger.info(
                     "Customer agent credentials detected at '%s'", credentials_path
@@ -433,6 +482,21 @@ class AgentGatewayClient:
                     # TODO: IBD workaround - use system token when user_token
                     # is not available. This bypasses principal propagation.
                     # Remove this fallback once IBD supports proper user token flow.
+                    logger.warning(
+                        "No user_token provided - using system token for tool "
+                        "invocation. Principal propagation will NOT work."
+                    )
+                    auth = await self.get_system_auth(app_tid)
+
+                return await call_mcp_tool_customer(
+                    tool, auth.access_token, self._config.timeout, **kwargs
+                )
+
+            if self._config.tls_mode == TlsMode.TRANSPARENT:
+                logger.info("Customer agent transparent mode detected")
+                if user_token:
+                    auth = await self.get_user_auth(user_token, app_tid)
+                else:
                     logger.warning(
                         "No user_token provided - using system token for tool "
                         "invocation. Principal propagation will NOT work."

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -21,7 +21,6 @@ from sap_cloud_sdk.agentgateway._customer import (
     get_system_token_mtls,
     get_system_token_transparent,
     load_customer_credentials,
-    load_customer_credentials_from_env,
 )
 from sap_cloud_sdk.agentgateway._lob import (
     call_mcp_tool_lob,
@@ -40,12 +39,18 @@ logger = logging.getLogger(__name__)
 class AgentGatewayClient:
     """Client for discovering and invoking MCP tools via SAP Agent Gateway.
 
-    Automatically detects agent type (LoB vs Customer) based on the
-    presence of credential files.
+    Automatically detects agent type (LoB vs Customer) based on credential file
+    presence and the configured TLS mode.
 
-    - LoB agents: Requires tenant_subdomain, uses BTP Destination Service
-    - Customer agents: Uses file-based credentials with mTLS authentication.
-      MCP servers are read from integrationDependencies in the credentials file.
+    - LoB agents: Requires tenant_subdomain, uses BTP Destination Service.
+    - Customer agents (standard mode): Reads credentials from a file mounted on
+      the pod filesystem. The agent performs mTLS directly using the certificate
+      and private key from the credentials file.
+    - Customer agents (transparent mode): The OpenShell Gateway injects the mTLS
+      client certificate at the TLS layer. The agent reads only endpoint URLs from
+      environment variables and never loads certificate or private key material.
+      Activate with ``AGW_TLS_MODE=transparent`` or
+      ``ClientConfig(tls_mode=TlsMode.TRANSPARENT)``.
 
     Example (LoB agent):
         ```python
@@ -53,10 +58,7 @@ class AgentGatewayClient:
 
         agw_client = create_client(tenant_subdomain="my-tenant")
 
-        # Discover tools
         tools = await agw_client.list_mcp_tools()
-
-        # Invoke a tool
         result = await agw_client.call_mcp_tool(
             tool=tools[0],
             user_token="user-jwt",
@@ -64,16 +66,29 @@ class AgentGatewayClient:
         )
         ```
 
-    Example (Customer agent):
+    Example (Customer agent — standard mode):
         ```python
         from sap_cloud_sdk.agentgateway import create_client
 
         agw_client = create_client()
 
-        # Discover tools (reads all servers from credentials integrationDependencies)
         tools = await agw_client.list_mcp_tools()
+        result = await agw_client.call_mcp_tool(
+            tool=tools[0],
+            user_token="user-jwt",
+            cost_center="1000",
+        )
+        ```
 
-        # Invoke a tool
+    Example (Customer agent — transparent mode):
+        ```python
+        from sap_cloud_sdk.agentgateway import create_client
+        from sap_cloud_sdk.agentgateway.config import ClientConfig
+
+        # Reads AGW_TLS_MODE, CLIENT_ID, TOKEN_SERVICE_URL, GATEWAY_URL from env
+        agw_client = create_client(config=ClientConfig.from_env())
+
+        tools = await agw_client.list_mcp_tools()
         result = await agw_client.call_mcp_tool(
             tool=tools[0],
             user_token="user-jwt",
@@ -87,12 +102,10 @@ class AgentGatewayClient:
 
         agw_client = create_client(tenant_subdomain="my-tenant")
 
-        # Get system-scoped auth (token + gateway URL)
         auth = await agw_client.get_system_auth()
         print(auth.access_token)  # raw JWT
         print(auth.gateway_url)   # "https://agw.example.com"
 
-        # Get user-scoped auth (token exchange + gateway URL)
         auth = await agw_client.get_user_auth(user_token="user-jwt")
         print(auth.access_token)  # exchanged JWT with user identity
         print(auth.gateway_url)   # "https://agw.example.com"
@@ -113,7 +126,7 @@ class AgentGatewayClient:
             config: Client configuration. Uses defaults if not provided.
         """
         self._tenant_subdomain = tenant_subdomain
-        self._config = config or ClientConfig()
+        self._config = config or ClientConfig.from_env()
         self._token_cache = _TokenCache(self._config)
         self._gateway_url_cache = _GatewayUrlCache()
 
@@ -176,32 +189,24 @@ class AgentGatewayClient:
         """
         try:
             credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
-            if credentials_path:
+            if credentials_path or self._config.tls_mode == TlsMode.TRANSPARENT:
                 logger.info(
-                    "Customer agent credentials detected at '%s'", credentials_path
+                    "Customer agent detected (path=%s, tls_mode=%s)",
+                    credentials_path,
+                    self._config.tls_mode.value,
                 )
-                credentials = load_customer_credentials(credentials_path)
+                credentials = load_customer_credentials(
+                    credentials_path, self._config.tls_mode
+                )
                 loop = asyncio.get_running_loop()
+                token_fn = (
+                    get_system_token_transparent
+                    if self._config.tls_mode == TlsMode.TRANSPARENT
+                    else get_system_token_mtls
+                )
                 token = await loop.run_in_executor(
                     None,
-                    get_system_token_mtls,
-                    credentials,
-                    self._config.timeout,
-                    app_tid,
-                    self._token_cache,
-                )
-                return AuthResult(
-                    access_token=token,
-                    gateway_url=credentials.gateway_url,
-                )
-
-            if self._config.tls_mode == TlsMode.TRANSPARENT:
-                logger.info("Customer agent transparent mode detected")
-                credentials = load_customer_credentials_from_env()
-                loop = asyncio.get_running_loop()
-                token = await loop.run_in_executor(
-                    None,
-                    get_system_token_transparent,
+                    token_fn,
                     credentials,
                     self._config.timeout,
                     app_tid,
@@ -270,33 +275,24 @@ class AgentGatewayClient:
             )
 
             credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
-            if credentials_path:
+            if credentials_path or self._config.tls_mode == TlsMode.TRANSPARENT:
                 logger.info(
-                    "Customer agent credentials detected at '%s'", credentials_path
+                    "Customer agent detected (path=%s, tls_mode=%s)",
+                    credentials_path,
+                    self._config.tls_mode.value,
                 )
-                credentials = load_customer_credentials(credentials_path)
+                credentials = load_customer_credentials(
+                    credentials_path, self._config.tls_mode
+                )
                 loop = asyncio.get_running_loop()
+                token_fn = (
+                    exchange_user_token_transparent
+                    if self._config.tls_mode == TlsMode.TRANSPARENT
+                    else exchange_user_token
+                )
                 token = await loop.run_in_executor(
                     None,
-                    exchange_user_token,
-                    credentials,
-                    resolved_user_token,
-                    self._config.timeout,
-                    app_tid,
-                    self._token_cache,
-                )
-                return AuthResult(
-                    access_token=token,
-                    gateway_url=credentials.gateway_url,
-                )
-
-            if self._config.tls_mode == TlsMode.TRANSPARENT:
-                logger.info("Customer agent transparent mode detected")
-                credentials = load_customer_credentials_from_env()
-                loop = asyncio.get_running_loop()
-                token = await loop.run_in_executor(
-                    None,
-                    exchange_user_token_transparent,
+                    token_fn,
                     credentials,
                     resolved_user_token,
                     self._config.timeout,
@@ -372,22 +368,15 @@ class AgentGatewayClient:
         try:
             # Check for customer agent credentials
             credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
-            if credentials_path:
+            if credentials_path or self._config.tls_mode == TlsMode.TRANSPARENT:
                 logger.info(
-                    "Customer agent credentials detected at '%s'", credentials_path
+                    "Customer agent detected (path=%s, tls_mode=%s)",
+                    credentials_path,
+                    self._config.tls_mode.value,
                 )
-                credentials = load_customer_credentials(credentials_path)
-                if user_token:
-                    auth = await self.get_user_auth(user_token, app_tid)
-                else:
-                    auth = await self.get_system_auth(app_tid=app_tid)
-                return await get_mcp_tools_customer(
-                    credentials, auth.access_token, self._config.timeout
+                credentials = load_customer_credentials(
+                    credentials_path, self._config.tls_mode
                 )
-
-            if self._config.tls_mode == TlsMode.TRANSPARENT:
-                logger.info("Customer agent transparent mode detected")
-                credentials = load_customer_credentials_from_env()
                 if user_token:
                     auth = await self.get_user_auth(user_token, app_tid)
                 else:
@@ -470,33 +459,18 @@ class AgentGatewayClient:
         try:
             # Check for customer agent credentials
             credentials_path = detect_customer_agent_credentials(self._config.tls_mode)
-            if credentials_path:
+            if credentials_path or self._config.tls_mode == TlsMode.TRANSPARENT:
                 logger.info(
-                    "Customer agent credentials detected at '%s'", credentials_path
+                    "Customer agent detected (path=%s, tls_mode=%s)",
+                    credentials_path,
+                    self._config.tls_mode.value,
                 )
-
-                # Resolve user_token if provided (optional for customer flow)
                 if user_token:
                     auth = await self.get_user_auth(user_token, app_tid)
                 else:
                     # TODO: IBD workaround - use system token when user_token
                     # is not available. This bypasses principal propagation.
                     # Remove this fallback once IBD supports proper user token flow.
-                    logger.warning(
-                        "No user_token provided - using system token for tool "
-                        "invocation. Principal propagation will NOT work."
-                    )
-                    auth = await self.get_system_auth(app_tid)
-
-                return await call_mcp_tool_customer(
-                    tool, auth.access_token, self._config.timeout, **kwargs
-                )
-
-            if self._config.tls_mode == TlsMode.TRANSPARENT:
-                logger.info("Customer agent transparent mode detected")
-                if user_token:
-                    auth = await self.get_user_auth(user_token, app_tid)
-                else:
                     logger.warning(
                         "No user_token provided - using system token for tool "
                         "invocation. Principal propagation will NOT work."
@@ -540,14 +514,16 @@ def create_client(
 ) -> AgentGatewayClient:
     """Create an Agent Gateway client for discovering and invoking MCP tools.
 
-    Automatically detects agent type (LoB vs Customer) based on
-    credential file presence.
+    Automatically detects agent type (LoB vs Customer) based on credential file
+    presence and the configured TLS mode.
 
     Args:
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
             Can be a string or a callable returning a string.
             Required for LoB agents, ignored for Customer agents.
         config: Client configuration. Uses defaults if not provided.
+            Pass ``ClientConfig.from_env()`` to read ``AGW_TLS_MODE`` from the
+            environment for transparent mode customer agents.
 
     Returns:
         AgentGatewayClient instance.
@@ -558,47 +534,41 @@ def create_client(
 
         agw_client = create_client(tenant_subdomain="my-tenant")
 
-        # Discover tools
         tools = await agw_client.list_mcp_tools()
-
-        # Invoke a tool
-        # Note: kwargs are tool-specific input parameters.
-        # Check tool.input_schema for expected parameters.
         result = await agw_client.call_mcp_tool(
             tool=tools[0],
             user_token="user-jwt",
-            order_id="12345",  # example tool-specific parameter
+            order_id="12345",
         )
         ```
 
-    Example (Customer agent):
+    Example (Customer agent — standard mode):
         ```python
         from sap_cloud_sdk.agentgateway import create_client
 
         agw_client = create_client()
 
-        # Discover tools (reads all servers from credentials integrationDependencies)
         tools = await agw_client.list_mcp_tools()
-
-        # Invoke a tool
-        # Note: kwargs are tool-specific input parameters.
-        # Check tool.input_schema for expected parameters.
         result = await agw_client.call_mcp_tool(
             tool=tools[0],
             user_token="user-jwt",
-            cost_center="1000",  # example tool-specific parameter
+            cost_center="1000",
         )
         ```
 
-    Example (auth fetching):
+    Example (Customer agent — transparent mode):
         ```python
         from sap_cloud_sdk.agentgateway import create_client
+        from sap_cloud_sdk.agentgateway.config import ClientConfig
 
-        agw_client = create_client(tenant_subdomain="my-tenant")
+        agw_client = create_client(config=ClientConfig.from_env())
 
-        # Get auth for external use
-        auth = await agw_client.get_system_auth()
-        user_auth = await agw_client.get_user_auth(user_token="user-jwt")
+        tools = await agw_client.list_mcp_tools()
+        result = await agw_client.call_mcp_tool(
+            tool=tools[0],
+            user_token="user-jwt",
+            cost_center="1000",
+        )
         ```
     """
     return AgentGatewayClient(tenant_subdomain=tenant_subdomain, config=config)

--- a/src/sap_cloud_sdk/agentgateway/config.py
+++ b/src/sap_cloud_sdk/agentgateway/config.py
@@ -68,5 +68,9 @@ class ClientConfig:
             otherwise STANDARD.
         """
         raw = os.environ.get(_ENV_TLS_MODE, "").lower()
-        tls_mode = TlsMode.TRANSPARENT if raw == TlsMode.TRANSPARENT.value else TlsMode.STANDARD
+        tls_mode = (
+            TlsMode.TRANSPARENT
+            if raw == TlsMode.TRANSPARENT.value
+            else TlsMode.STANDARD
+        )
         return ClientConfig(tls_mode=tls_mode)

--- a/src/sap_cloud_sdk/agentgateway/config.py
+++ b/src/sap_cloud_sdk/agentgateway/config.py
@@ -1,12 +1,30 @@
 """Configuration for Agent Gateway client."""
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+from enum import Enum
 
 DEFAULT_TIMEOUT_SECONDS = 60.0
 DEFAULT_FALLBACK_TOKEN_TTL_SECONDS = 300.0
 DEFAULT_TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
 DEFAULT_MAX_SYSTEM_TOKEN_CACHE_SIZE = 32
 DEFAULT_MAX_USER_TOKEN_CACHE_SIZE = 256
+
+_ENV_TLS_MODE = "AGW_TLS_MODE"
+
+
+class TlsMode(Enum):
+    """TLS handling mode for the Agent Gateway client.
+
+    STANDARD: Agent performs the TLS handshake directly using a client
+        certificate loaded from the credentials file (default behaviour).
+    TRANSPARENT: The OpenShell Gateway intercepts the TLS handshake and
+        injects the client certificate at the network layer. The agent
+        never loads certificate or private key material.
+    """
+
+    STANDARD = "standard"
+    TRANSPARENT = "transparent"
 
 
 @dataclass
@@ -22,6 +40,9 @@ class ClientConfig:
             token expiries before a cached token is considered stale.
         max_system_token_cache_size: Maximum number of cached system tokens.
         max_user_token_cache_size: Maximum number of cached user tokens.
+        tls_mode: TLS handling mode. Use TlsMode.TRANSPARENT when the
+            OpenShell Gateway handles mTLS on behalf of the agent.
+            Defaults to TlsMode.STANDARD.
     """
 
     timeout: float = DEFAULT_TIMEOUT_SECONDS
@@ -29,6 +50,7 @@ class ClientConfig:
     token_expiry_buffer_seconds: float = DEFAULT_TOKEN_EXPIRY_BUFFER_SECONDS
     max_system_token_cache_size: int = DEFAULT_MAX_SYSTEM_TOKEN_CACHE_SIZE
     max_user_token_cache_size: int = DEFAULT_MAX_USER_TOKEN_CACHE_SIZE
+    tls_mode: TlsMode = field(default=TlsMode.STANDARD)
 
     def __post_init__(self) -> None:
         if self.token_expiry_buffer_seconds >= self.fallback_token_ttl_seconds:
@@ -36,3 +58,15 @@ class ClientConfig:
                 f"token_expiry_buffer_seconds ({self.token_expiry_buffer_seconds}) "
                 f"must be less than fallback_token_ttl_seconds ({self.fallback_token_ttl_seconds})"
             )
+
+    @staticmethod
+    def from_env() -> "ClientConfig":
+        """Create a ClientConfig with tls_mode resolved from AGW_TLS_MODE env var.
+
+        Returns:
+            ClientConfig with tls_mode set to TRANSPARENT when AGW_TLS_MODE=transparent,
+            otherwise STANDARD.
+        """
+        raw = os.environ.get(_ENV_TLS_MODE, "").lower()
+        tls_mode = TlsMode.TRANSPARENT if raw == TlsMode.TRANSPARENT.value else TlsMode.STANDARD
+        return ClientConfig(tls_mode=tls_mode)

--- a/src/sap_cloud_sdk/agentgateway/user-guide.md
+++ b/src/sap_cloud_sdk/agentgateway/user-guide.md
@@ -14,9 +14,9 @@ pip install sap-cloud-sdk[langchain]
 
 ## Quick Start
 
-### Customer Agent Flow
+### Customer Agent Flow — Standard Mode (file-based mTLS)
 
-Customer agents use file-based credentials with mTLS authentication. MCP servers are read from `integrationDependencies` in the credentials file.
+Customer agents use file-based credentials with mTLS authentication. The SDK reads the credentials file from the path in `AGW_CREDENTIALS_PATH`, or falls back to the default Kyma mount path `/etc/ums/credentials/credentials`. MCP servers are read from `integrationDependencies` in the credentials file.
 
 ```python
 from sap_cloud_sdk.agentgateway import create_client
@@ -38,8 +38,54 @@ result = await agw_client.call_mcp_tool(
     user_token="user-jwt",
     cost_center="1000",
 )
-
 ```
+
+### Customer Agent Flow — Transparent Mode (gateway-injected mTLS)
+
+In transparent mode the OpenShell Gateway intercepts HTTPS connections and injects the mTLS client certificate at the TLS layer. The agent never loads certificate or private key material — only the service endpoint URLs need to be visible to the agent process.
+
+Set `AGW_TLS_MODE=transparent` and provide the required environment variables:
+
+```bash
+export AGW_TLS_MODE="transparent"
+export CLIENT_ID="sb-abc123|xsuaa_std!b318"
+export TOKEN_SERVICE_URL="https://your-tenant.accounts.ondemand.com/oauth2/token"
+export GATEWAY_URL="https://agent-gateway.example.com"
+export INTEGRATION_DEPENDENCIES='[{"ordId": "sap.app:apiResource:my-tool:v1", "globalTenantId": "123456"}]'
+export HTTPS_PROXY="https://openshell-gateway:3128"  # set automatically by OpenShell
+```
+
+```python
+from sap_cloud_sdk.agentgateway import create_client
+from sap_cloud_sdk.agentgateway.config import ClientConfig
+
+# Option 1: read AGW_TLS_MODE from environment
+client = create_client(config=ClientConfig.from_env())
+
+# Option 2: set explicitly in code
+from sap_cloud_sdk.agentgateway.config import TlsMode
+client = create_client(config=ClientConfig(tls_mode=TlsMode.TRANSPARENT))
+
+# Usage is identical to standard mode
+tools = await client.list_mcp_tools()
+result = await client.call_mcp_tool(tool=tools[0], user_token="user-jwt", cost_center="1000")
+```
+
+**When to use transparent mode:**
+
+- The agent runs inside an OpenShell Gateway sandbox with a `PolicyClass` configured for `tls: terminate` and `credentialRewrite: requestBody: true` on the IAS endpoint.
+- You want to eliminate TLS certificates and private keys from the agent process memory and filesystem entirely.
+- Credential rotation without pod restarts is required (secrets are updated in the gateway, not the agent).
+
+**Credential visibility comparison:**
+
+| Credential | Standard mode | Transparent mode |
+|---|---|---|
+| `CLIENT_ID` | In credentials file | In env var (gateway resolves placeholder) |
+| `CERTIFICATE` | In credentials file + SSLContext | Never in agent — gateway-injected |
+| `PRIVATE_KEY` | In credentials file + SSLContext | Never in agent — gateway-injected |
+| `TOKEN_SERVICE_URL` | In credentials file | In env var |
+| `GATEWAY_URL` | In credentials file | In env var |
 
 ### LoB Agent Flow
 
@@ -103,9 +149,11 @@ mcp_tool_to_langchain(
 ### Agent Types
 
 - **LoB (Line of Business) Agent**: Uses BTP Destination Service for credentials. Requires `tenant_subdomain`. Tools are auto-discovered from destination fragments.
-- **Customer Agent**: Uses file-based credentials mounted on the pod filesystem with mTLS authentication. MCP servers are defined in the credentials file's `integrationDependencies`.
+- **Customer Agent**: Uses credentials for mTLS authentication against IAS. MCP servers are defined in `integrationDependencies`. Supports two sub-modes:
+  - **Standard mode** (default): credentials are read from a file mounted on the pod filesystem. The agent loads the certificate and private key into an `ssl.SSLContext` and performs the mTLS handshake directly.
+  - **Transparent mode** (`AGW_TLS_MODE=transparent`): the OpenShell Gateway intercepts HTTPS connections and injects the client certificate at the TLS layer. The agent reads only endpoint URLs from environment variables and never accesses certificate or private key material.
 
-The SDK automatically detects the agent type based on the presence of a credentials file.
+The SDK automatically selects the agent type and TLS mode based on credential file presence and the `AGW_TLS_MODE` environment variable.
 
 
 ## API
@@ -124,10 +172,11 @@ def create_client(
 
 ### ClientConfig
 
-Use `ClientConfig` to tune request timeouts and token cache behavior for a client instance.
+Use `ClientConfig` to tune request timeouts, token cache behaviour, and TLS mode for a client instance.
 
 ```python
 from sap_cloud_sdk.agentgateway import ClientConfig, create_client
+from sap_cloud_sdk.agentgateway.config import TlsMode
 
 config = ClientConfig(
     timeout=30.0,
@@ -135,9 +184,17 @@ config = ClientConfig(
     token_expiry_buffer_seconds=30.0,
     max_system_token_cache_size=32,
     max_user_token_cache_size=256,
+    tls_mode=TlsMode.STANDARD,  # or TlsMode.TRANSPARENT
 )
 
 agw_client = create_client(tenant_subdomain="my-tenant", config=config)
+```
+
+Use `ClientConfig.from_env()` to resolve `tls_mode` automatically from the `AGW_TLS_MODE` environment variable:
+
+```python
+config = ClientConfig.from_env()  # reads AGW_TLS_MODE; defaults to STANDARD
+agw_client = create_client(config=config)
 ```
 
 - `timeout`: HTTP timeout in seconds for token requests and MCP calls. Default: `60.0`.
@@ -145,6 +202,7 @@ agw_client = create_client(tenant_subdomain="my-tenant", config=config)
 - `token_expiry_buffer_seconds`: Safety buffer subtracted from explicit token expiries before a cached token is reused. Default: `30.0`.
 - `max_system_token_cache_size`: Maximum number of cached system tokens per client instance. Default: `32`.
 - `max_user_token_cache_size`: Maximum number of cached exchanged user tokens per client instance. Default: `256`.
+- `tls_mode`: `TlsMode.STANDARD` (default) or `TlsMode.TRANSPARENT`. Controls whether the agent performs mTLS directly or delegates it to the OpenShell Gateway. See [Transparent Mode](#customer-agent-flow--transparent-mode-gateway-injected-mtls) above.
 
 The SDK keeps token caches per `AgentGatewayClient` instance and reuses valid cached tokens for repeated authentication calls. System and user token caches are bounded independently with least-recently-used eviction.
 

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -11,6 +11,7 @@ from sap_cloud_sdk.agentgateway import (
     MCPTool,
     AgentGatewaySDKError,
 )
+from sap_cloud_sdk.agentgateway.config import TlsMode
 
 
 # ============================================================
@@ -165,7 +166,7 @@ class TestGetSystemAuth:
             assert isinstance(result, AuthResult)
             assert result.access_token == "customer-system-token"
             assert result.gateway_url == "https://agw.customer.com"
-            mock_load.assert_called_once_with("/path/to/credentials")
+            mock_load.assert_called_once_with("/path/to/credentials", TlsMode.STANDARD)
             mock_mtls.assert_called_once_with(
                 mock_creds, 60.0, "test-tid", token_cache
             )
@@ -733,7 +734,7 @@ class TestCallMcpTool:
 
             assert result == "customer result"
             # load_customer_credentials is called once in get_user_auth()
-            mock_load.assert_called_once_with("/path/to/credentials")
+            mock_load.assert_called_once_with("/path/to/credentials", TlsMode.STANDARD)
             mock_customer.assert_called_once_with(
                 mock_tool, "exchanged-token", 60.0
             )

--- a/tests/agentgateway/unit/test_config.py
+++ b/tests/agentgateway/unit/test_config.py
@@ -76,4 +76,3 @@ class TestClientConfigFromEnv:
         with patch.dict(os.environ, {"AGW_TLS_MODE": "unknown"}):
             config = ClientConfig.from_env()
         assert config.tls_mode == TlsMode.STANDARD
-

--- a/tests/agentgateway/unit/test_config.py
+++ b/tests/agentgateway/unit/test_config.py
@@ -1,6 +1,12 @@
 """Unit tests for ClientConfig."""
 
+import os
+from unittest.mock import patch
+
+import pytest
+
 from sap_cloud_sdk.agentgateway import ClientConfig, create_client
+from sap_cloud_sdk.agentgateway.config import TlsMode
 
 
 class TestClientConfig:
@@ -31,3 +37,43 @@ class TestClientConfig:
         """create_client uses default config when none provided."""
         client = create_client()
         assert client._config.timeout == 60.0
+
+    def test_default_tls_mode_is_standard(self):
+        """Default tls_mode is STANDARD."""
+        config = ClientConfig()
+        assert config.tls_mode == TlsMode.STANDARD
+
+    def test_explicit_transparent_tls_mode(self):
+        """ClientConfig accepts TRANSPARENT tls_mode."""
+        config = ClientConfig(tls_mode=TlsMode.TRANSPARENT)
+        assert config.tls_mode == TlsMode.TRANSPARENT
+
+
+class TestClientConfigFromEnv:
+    """Tests for ClientConfig.from_env()."""
+
+    def test_from_env_defaults_to_standard(self):
+        """from_env() returns STANDARD when AGW_TLS_MODE is unset."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGW_TLS_MODE", None)
+            config = ClientConfig.from_env()
+        assert config.tls_mode == TlsMode.STANDARD
+
+    def test_from_env_transparent(self):
+        """from_env() returns TRANSPARENT when AGW_TLS_MODE=transparent."""
+        with patch.dict(os.environ, {"AGW_TLS_MODE": "transparent"}):
+            config = ClientConfig.from_env()
+        assert config.tls_mode == TlsMode.TRANSPARENT
+
+    def test_from_env_transparent_case_insensitive(self):
+        """AGW_TLS_MODE comparison is case-insensitive."""
+        with patch.dict(os.environ, {"AGW_TLS_MODE": "TRANSPARENT"}):
+            config = ClientConfig.from_env()
+        assert config.tls_mode == TlsMode.TRANSPARENT
+
+    def test_from_env_unknown_value_falls_back_to_standard(self):
+        """Unknown AGW_TLS_MODE value falls back to STANDARD."""
+        with patch.dict(os.environ, {"AGW_TLS_MODE": "unknown"}):
+            config = ClientConfig.from_env()
+        assert config.tls_mode == TlsMode.STANDARD
+

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -1017,4 +1017,3 @@ class TestExchangeUserTokenTransparent:
         call_kwargs = mock_req.call_args
         assert call_kwargs.kwargs["extra_data"]["assertion"] == "user-jwt"
         assert call_kwargs.kwargs["grant_type"] == "urn:ietf:params:oauth:grant-type:jwt-bearer"
-

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -8,13 +8,21 @@ from unittest.mock import patch, AsyncMock, MagicMock
 from sap_cloud_sdk.agentgateway._customer import (
     detect_customer_agent_credentials,
     load_customer_credentials,
+    load_customer_credentials_from_env,
     get_system_token_mtls,
+    get_system_token_transparent,
     exchange_user_token,
+    exchange_user_token_transparent,
     get_mcp_tools_customer,
     call_mcp_tool_customer,
     _build_mcp_url,
+    _request_token_transparent,
     _CREDENTIALS_PATH_ENV,
     _CREDENTIALS_DEFAULT_PATH,
+    _ENV_CLIENT_ID,
+    _ENV_TOKEN_SERVICE_URL,
+    _ENV_GATEWAY_URL,
+    _ENV_INTEGRATION_DEPENDENCIES,
 )
 from sap_cloud_sdk.agentgateway._models import (
     CustomerCredentials,
@@ -22,7 +30,7 @@ from sap_cloud_sdk.agentgateway._models import (
     MCPTool,
 )
 from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
-from sap_cloud_sdk.agentgateway.config import ClientConfig
+from sap_cloud_sdk.agentgateway.config import ClientConfig, TlsMode
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 
 
@@ -741,3 +749,272 @@ class TestCallMcpToolCustomer:
             )
 
             assert result == ""
+
+
+# ============================================================
+# Test: detect_customer_agent_credentials — transparent mode
+# ============================================================
+
+
+class TestDetectCustomerAgentCredentialsTransparentMode:
+    """Tests for credential detection when TlsMode.TRANSPARENT is active."""
+
+    def test_transparent_mode_returns_none_immediately(self, tmp_path):
+        """In transparent mode, credential file detection is skipped."""
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text('{"clientid": "test"}')
+
+        with patch.dict(os.environ, {_CREDENTIALS_PATH_ENV: str(creds_file)}):
+            result = detect_customer_agent_credentials(TlsMode.TRANSPARENT)
+
+        assert result is None
+
+    def test_transparent_mode_ignores_default_path(self):
+        """In transparent mode, default credential path is not checked."""
+        with patch("os.path.isfile", return_value=True):
+            result = detect_customer_agent_credentials(TlsMode.TRANSPARENT)
+
+        assert result is None
+
+    def test_standard_mode_still_detects_file(self, tmp_path):
+        """Standard mode (default) continues to detect credential files."""
+        creds_file = tmp_path / "credentials.json"
+        creds_file.write_text('{"clientid": "test"}')
+
+        with patch.dict(os.environ, {_CREDENTIALS_PATH_ENV: str(creds_file)}):
+            result = detect_customer_agent_credentials(TlsMode.STANDARD)
+
+        assert result == str(creds_file)
+
+
+# ============================================================
+# Test: load_customer_credentials_from_env
+# ============================================================
+
+_TRANSPARENT_ENV = {
+    _ENV_CLIENT_ID: "test-client-id",
+    _ENV_TOKEN_SERVICE_URL: "https://ias.example.com/oauth/token",
+    _ENV_GATEWAY_URL: "https://agw.example.com",
+}
+
+
+class TestLoadCustomerCredentialsFromEnv:
+    """Tests for loading customer credentials from environment variables."""
+
+    def test_loads_required_fields(self):
+        """Loads credentials from the three required environment variables."""
+        with patch.dict(os.environ, _TRANSPARENT_ENV, clear=False):
+            os.environ.pop(_ENV_INTEGRATION_DEPENDENCIES, None)
+            creds = load_customer_credentials_from_env()
+
+        assert creds.client_id == "test-client-id"
+        assert creds.token_service_url == "https://ias.example.com/oauth/token"
+        assert creds.gateway_url == "https://agw.example.com"
+        assert creds.certificate is None
+        assert creds.private_key is None
+        assert creds.integration_dependencies == []
+
+    def test_strips_trailing_slash_from_gateway_url(self):
+        """Trailing slash is stripped from GATEWAY_URL."""
+        env = {**_TRANSPARENT_ENV, _ENV_GATEWAY_URL: "https://agw.example.com/"}
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop(_ENV_INTEGRATION_DEPENDENCIES, None)
+            creds = load_customer_credentials_from_env()
+
+        assert creds.gateway_url == "https://agw.example.com"
+
+    def test_parses_integration_dependencies(self):
+        """INTEGRATION_DEPENDENCIES JSON array is parsed correctly."""
+        deps = json.dumps([{"ordId": "sap.app:res:v1", "globalTenantId": "tenant-1"}])
+        env = {**_TRANSPARENT_ENV, _ENV_INTEGRATION_DEPENDENCIES: deps}
+        with patch.dict(os.environ, env, clear=False):
+            creds = load_customer_credentials_from_env()
+
+        assert len(creds.integration_dependencies) == 1
+        assert creds.integration_dependencies[0].ord_id == "sap.app:res:v1"
+        assert creds.integration_dependencies[0].global_tenant_id == "tenant-1"
+
+    def test_missing_client_id_raises(self):
+        """Missing CLIENT_ID raises AgentGatewaySDKError."""
+        env = {
+            _ENV_TOKEN_SERVICE_URL: "https://ias.example.com/oauth/token",
+            _ENV_GATEWAY_URL: "https://agw.example.com",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop(_ENV_CLIENT_ID, None)
+            with pytest.raises(AgentGatewaySDKError, match="transparent"):
+                load_customer_credentials_from_env()
+
+    def test_missing_token_service_url_raises(self):
+        """Missing TOKEN_SERVICE_URL raises AgentGatewaySDKError."""
+        env = {
+            _ENV_CLIENT_ID: "test-client-id",
+            _ENV_GATEWAY_URL: "https://agw.example.com",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop(_ENV_TOKEN_SERVICE_URL, None)
+            with pytest.raises(AgentGatewaySDKError, match="transparent"):
+                load_customer_credentials_from_env()
+
+    def test_invalid_integration_dependencies_json_raises(self):
+        """Invalid INTEGRATION_DEPENDENCIES JSON raises AgentGatewaySDKError."""
+        env = {**_TRANSPARENT_ENV, _ENV_INTEGRATION_DEPENDENCIES: "not-json"}
+        with patch.dict(os.environ, env, clear=False):
+            with pytest.raises(AgentGatewaySDKError, match="INTEGRATION_DEPENDENCIES"):
+                load_customer_credentials_from_env()
+
+
+# ============================================================
+# Test: _request_token_transparent
+# ============================================================
+
+
+class TestRequestTokenTransparent:
+    """Tests for token requests in transparent TLS mode."""
+
+    def _make_credentials(self) -> CustomerCredentials:
+        return CustomerCredentials(
+            token_service_url="https://ias.example.com/oauth/token",
+            client_id="test-client-id",
+            certificate=None,
+            private_key=None,
+            gateway_url="https://agw.example.com",
+            integration_dependencies=[],
+        )
+
+    def test_no_ssl_context_used(self):
+        """In transparent mode, httpx.Client is created without verify/ssl_context."""
+        creds = self._make_credentials()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "token123", "expires_in": 3600}
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client_instance = MagicMock()
+            mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client_instance.__exit__ = MagicMock(return_value=False)
+            mock_client_instance.post.return_value = mock_response
+            mock_client_class.return_value = mock_client_instance
+
+            result = _request_token_transparent(creds, "client_credentials", 60.0)
+
+        assert result["access_token"] == "token123"
+        call_kwargs = mock_client_class.call_args.kwargs
+        assert "verify" not in call_kwargs, "SSL context must not be passed in transparent mode"
+
+    def test_request_body_contains_client_id(self):
+        """Token request body includes client_id from credentials."""
+        creds = self._make_credentials()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"access_token": "token123", "expires_in": 3600}
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client_instance = MagicMock()
+            mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client_instance.__exit__ = MagicMock(return_value=False)
+            mock_client_instance.post.return_value = mock_response
+            mock_client_class.return_value = mock_client_instance
+
+            _request_token_transparent(creds, "client_credentials", 60.0)
+
+        post_kwargs = mock_client_instance.post.call_args.kwargs
+        assert post_kwargs["data"]["client_id"] == "test-client-id"
+        assert post_kwargs["data"]["grant_type"] == "client_credentials"
+
+    def test_non_200_status_raises(self):
+        """Non-200 response raises AgentGatewaySDKError."""
+        creds = self._make_credentials()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+
+        with patch("httpx.Client") as mock_client_class:
+            mock_client_instance = MagicMock()
+            mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+            mock_client_instance.__exit__ = MagicMock(return_value=False)
+            mock_client_instance.post.return_value = mock_response
+            mock_client_class.return_value = mock_client_instance
+
+            with pytest.raises(AgentGatewaySDKError, match="401"):
+                _request_token_transparent(creds, "client_credentials", 60.0)
+
+
+# ============================================================
+# Test: get_system_token_transparent
+# ============================================================
+
+
+class TestGetSystemTokenTransparent:
+    """Tests for system token acquisition in transparent mode."""
+
+    def _make_credentials(self) -> CustomerCredentials:
+        return CustomerCredentials(
+            token_service_url="https://ias.example.com/oauth/token",
+            client_id="test-client-id",
+            certificate=None,
+            private_key=None,
+            gateway_url="https://agw.example.com",
+            integration_dependencies=[],
+        )
+
+    def test_returns_access_token(self):
+        """Returns access token from token response."""
+        creds = self._make_credentials()
+        with patch(
+            "sap_cloud_sdk.agentgateway._customer._request_token_transparent",
+            return_value={"access_token": "system-token", "expires_in": 3600},
+        ):
+            token = get_system_token_transparent(creds, 60.0)
+
+        assert token == "system-token"
+
+    def test_uses_cache_when_available(self):
+        """Returns cached token without making a new request."""
+        creds = self._make_credentials()
+        config = ClientConfig()
+        cache = _TokenCache(config)
+        scope_key = f"customer::{creds.client_id}::"
+        cache.set_system_token("cached-token", float("inf"), scope_key)
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._customer._request_token_transparent"
+        ) as mock_req:
+            token = get_system_token_transparent(creds, 60.0, token_cache=cache)
+
+        assert token == "cached-token"
+        mock_req.assert_not_called()
+
+
+# ============================================================
+# Test: exchange_user_token_transparent
+# ============================================================
+
+
+class TestExchangeUserTokenTransparent:
+    """Tests for user token exchange in transparent mode."""
+
+    def _make_credentials(self) -> CustomerCredentials:
+        return CustomerCredentials(
+            token_service_url="https://ias.example.com/oauth/token",
+            client_id="test-client-id",
+            certificate=None,
+            private_key=None,
+            gateway_url="https://agw.example.com",
+            integration_dependencies=[],
+        )
+
+    def test_returns_exchanged_token(self):
+        """Returns exchanged access token."""
+        creds = self._make_credentials()
+        with patch(
+            "sap_cloud_sdk.agentgateway._customer._request_token_transparent",
+            return_value={"access_token": "user-token", "expires_in": 3600},
+        ) as mock_req:
+            token = exchange_user_token_transparent(creds, "user-jwt", 60.0)
+
+        assert token == "user-token"
+        call_kwargs = mock_req.call_args
+        assert call_kwargs.kwargs["extra_data"]["assertion"] == "user-jwt"
+        assert call_kwargs.kwargs["grant_type"] == "urn:ietf:params:oauth:grant-type:jwt-bearer"
+

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -8,7 +8,6 @@ from unittest.mock import patch, AsyncMock, MagicMock
 from sap_cloud_sdk.agentgateway._customer import (
     detect_customer_agent_credentials,
     load_customer_credentials,
-    load_customer_credentials_from_env,
     get_system_token_mtls,
     get_system_token_transparent,
     exchange_user_token,
@@ -788,7 +787,7 @@ class TestDetectCustomerAgentCredentialsTransparentMode:
 
 
 # ============================================================
-# Test: load_customer_credentials_from_env
+# Test: load_customer_credentials — transparent mode (env vars)
 # ============================================================
 
 _TRANSPARENT_ENV = {
@@ -799,13 +798,13 @@ _TRANSPARENT_ENV = {
 
 
 class TestLoadCustomerCredentialsFromEnv:
-    """Tests for loading customer credentials from environment variables."""
+    """Tests for loading customer credentials from environment variables (transparent mode)."""
 
     def test_loads_required_fields(self):
         """Loads credentials from the three required environment variables."""
         with patch.dict(os.environ, _TRANSPARENT_ENV, clear=False):
             os.environ.pop(_ENV_INTEGRATION_DEPENDENCIES, None)
-            creds = load_customer_credentials_from_env()
+            creds = load_customer_credentials(None, TlsMode.TRANSPARENT)
 
         assert creds.client_id == "test-client-id"
         assert creds.token_service_url == "https://ias.example.com/oauth/token"
@@ -819,7 +818,7 @@ class TestLoadCustomerCredentialsFromEnv:
         env = {**_TRANSPARENT_ENV, _ENV_GATEWAY_URL: "https://agw.example.com/"}
         with patch.dict(os.environ, env, clear=False):
             os.environ.pop(_ENV_INTEGRATION_DEPENDENCIES, None)
-            creds = load_customer_credentials_from_env()
+            creds = load_customer_credentials(None, TlsMode.TRANSPARENT)
 
         assert creds.gateway_url == "https://agw.example.com"
 
@@ -828,7 +827,7 @@ class TestLoadCustomerCredentialsFromEnv:
         deps = json.dumps([{"ordId": "sap.app:res:v1", "globalTenantId": "tenant-1"}])
         env = {**_TRANSPARENT_ENV, _ENV_INTEGRATION_DEPENDENCIES: deps}
         with patch.dict(os.environ, env, clear=False):
-            creds = load_customer_credentials_from_env()
+            creds = load_customer_credentials(None, TlsMode.TRANSPARENT)
 
         assert len(creds.integration_dependencies) == 1
         assert creds.integration_dependencies[0].ord_id == "sap.app:res:v1"
@@ -843,7 +842,7 @@ class TestLoadCustomerCredentialsFromEnv:
         with patch.dict(os.environ, env, clear=False):
             os.environ.pop(_ENV_CLIENT_ID, None)
             with pytest.raises(AgentGatewaySDKError, match="transparent"):
-                load_customer_credentials_from_env()
+                load_customer_credentials(None, TlsMode.TRANSPARENT)
 
     def test_missing_token_service_url_raises(self):
         """Missing TOKEN_SERVICE_URL raises AgentGatewaySDKError."""
@@ -854,14 +853,14 @@ class TestLoadCustomerCredentialsFromEnv:
         with patch.dict(os.environ, env, clear=False):
             os.environ.pop(_ENV_TOKEN_SERVICE_URL, None)
             with pytest.raises(AgentGatewaySDKError, match="transparent"):
-                load_customer_credentials_from_env()
+                load_customer_credentials(None, TlsMode.TRANSPARENT)
 
     def test_invalid_integration_dependencies_json_raises(self):
         """Invalid INTEGRATION_DEPENDENCIES JSON raises AgentGatewaySDKError."""
         env = {**_TRANSPARENT_ENV, _ENV_INTEGRATION_DEPENDENCIES: "not-json"}
         with patch.dict(os.environ, env, clear=False):
             with pytest.raises(AgentGatewaySDKError, match="INTEGRATION_DEPENDENCIES"):
-                load_customer_credentials_from_env()
+                load_customer_credentials(None, TlsMode.TRANSPARENT)
 
 
 # ============================================================

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Adds **transparent TLS mode** for customer agents running under the OpenShell Gateway. In this mode the gateway intercepts the HTTPS connection and injects the mTLS client certificate at the TLS layer, so the agent process never loads certificate or private key material. The agent only needs three environment variables (`CLIENT_ID`, `TOKEN_SERVICE_URL`, `GATEWAY_URL`) instead of a full credentials file with embedded PEM strings.

Changes:

- `config.py`: new `TlsMode` enum (`STANDARD` / `TRANSPARENT`) and `tls_mode` field on `ClientConfig`. `ClientConfig.from_env()` resolves the mode from the `AGW_TLS_MODE` environment variable.
- `_models.py`: `CustomerCredentials.certificate` and `private_key` are now `str | None` (both are `None` in transparent mode).
- `_customer.py`:
  - `detect_customer_agent_credentials(tls_mode)` skips file detection when `tls_mode=TRANSPARENT`.
  - `load_customer_credentials_from_env()` — loads credentials from env vars for transparent mode.
  - `_create_http_client_transparent()` — creates `httpx.Client` without an SSL context.
  - `_request_token_transparent()` — sends the OAuth2 POST body without touching certificates.
  - `get_system_token_transparent()` and `exchange_user_token_transparent()` — caching-aware wrappers for the transparent token flows.
- `agw_client.py`: all four public methods (`get_system_auth`, `get_user_auth`, `list_mcp_tools`, `call_mcp_tool`) pass `tls_mode` to credential detection and branch into the transparent path when needed.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

**Standard mode (existing behaviour — should be unchanged):**

1. Ensure no `AGW_TLS_MODE` environment variable is set.
2. Mount a credentials file at the default path or set `AGW_CREDENTIALS_PATH`.
3. `create_client()` → `list_mcp_tools()` should work exactly as before.

**Transparent mode (new):**

1. Set `AGW_TLS_MODE=transparent` in the environment.
2. Set `CLIENT_ID`, `TOKEN_SERVICE_URL`, `GATEWAY_URL` (and optionally `INTEGRATION_DEPENDENCIES`).
3. Ensure `HTTPS_PROXY` points to a running OpenShell Gateway.
4. Run:
   ```python
   from sap_cloud_sdk.agentgateway import create_client
   from sap_cloud_sdk.agentgateway.config import ClientConfig

   client = create_client(config=ClientConfig.from_env())
   auth = await client.get_system_auth()
   print(auth.access_token)  # token acquired via gateway-injected mTLS
   ```
5. Verify that no `ssl.SSLContext` is created and no temp cert/key files are written.

**Unit tests:**
```bash
uv run pytest tests/agentgateway/unit/test_config.py tests/agentgateway/unit/test_customer.py -q
```
Expected: all 51 tests pass.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
