### PR TITLE
feat: add agent-card list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.29.1"
+version = "0.30.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/__init__.py
+++ b/src/sap_cloud_sdk/agentgateway/__init__.py
@@ -52,7 +52,7 @@ Usage (Customer agent):
     ]
 """
 
-from sap_cloud_sdk.agentgateway._models import AuthResult, MCPTool
+from sap_cloud_sdk.agentgateway._models import AuthResult, MCPTool, Agent, AgentCard, AgentCardFilter
 from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.agw_client import create_client, AgentGatewayClient
 from sap_cloud_sdk.agentgateway.exceptions import (
@@ -71,6 +71,9 @@ __all__ = [
     # Data models
     "AuthResult",
     "MCPTool",
+    "Agent",
+    "AgentCard",
+    "AgentCardFilter",
     # Exceptions
     "AgentGatewaySDKError",
     "MCPServerNotFoundError",

--- a/src/sap_cloud_sdk/agentgateway/__init__.py
+++ b/src/sap_cloud_sdk/agentgateway/__init__.py
@@ -52,7 +52,13 @@ Usage (Customer agent):
     ]
 """
 
-from sap_cloud_sdk.agentgateway._models import AuthResult, MCPTool, Agent, AgentCard, AgentCardFilter
+from sap_cloud_sdk.agentgateway._models import (
+    AuthResult,
+    MCPTool,
+    Agent,
+    AgentCard,
+    AgentCardFilter,
+)
 from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.agw_client import create_client, AgentGatewayClient
 from sap_cloud_sdk.agentgateway.exceptions import (

--- a/src/sap_cloud_sdk/agentgateway/_fragments.py
+++ b/src/sap_cloud_sdk/agentgateway/_fragments.py
@@ -7,6 +7,7 @@ Centralises all BTP Destination Service fragment operations:
 """
 
 import logging
+from enum import Enum
 
 from sap_cloud_sdk.destination import (
     create_fragment_client,
@@ -21,20 +22,23 @@ logger = logging.getLogger(__name__)
 # Shared label key for all managed-runtime fragment types
 LABEL_KEY = "sap-managed-runtime-type"
 
-# Label values for fragment discovery
-MCP_LABEL_VALUE = "agw.mcp.server"
-IAS_LABEL_VALUE = "subscriber.ias"
-IAS_USER_LABEL_VALUE = "subscriber.ias.user"
-A2A_LABEL_VALUE = "agw.a2a.server"
-
 _DESTINATION_INSTANCE = "default"
 
 
-def _list_fragments_by_label(label_value: str, tenant_subdomain: str) -> list:
+class FragmentLabel(str, Enum):
+    """Label values for the sap-managed-runtime-type fragment label key."""
+
+    MCP = "agw.mcp.server"
+    A2A = "agw.a2a.server"
+    IAS = "subscriber.ias"
+    IAS_USER = "subscriber.ias.user"
+
+
+def _list_fragments_by_label(label: FragmentLabel, tenant_subdomain: str) -> list:
     client = create_fragment_client(instance=_DESTINATION_INSTANCE)
     return client.list_instance_fragments(
         filter=ListOptions(
-            filter_labels=[Label(key=LABEL_KEY, values=[label_value])]
+            filter_labels=[Label(key=LABEL_KEY, values=[label.value])]
         ),
         tenant=tenant_subdomain,
     )
@@ -50,7 +54,7 @@ def list_mcp_fragments(tenant_subdomain: str) -> list:
         List of fragments with sap-managed-runtime-type=agw.mcp.server label.
     """
     logger.debug("Fetching MCP fragments for tenant '%s'", tenant_subdomain)
-    return _list_fragments_by_label(MCP_LABEL_VALUE, tenant_subdomain)
+    return _list_fragments_by_label(FragmentLabel.MCP, tenant_subdomain)
 
 
 def list_a2a_fragments(tenant_subdomain: str) -> list:
@@ -63,7 +67,7 @@ def list_a2a_fragments(tenant_subdomain: str) -> list:
         List of fragments with sap-managed-runtime-type=agw.a2a.server label.
     """
     logger.debug("Fetching A2A fragments for tenant '%s'", tenant_subdomain)
-    return _list_fragments_by_label(A2A_LABEL_VALUE, tenant_subdomain)
+    return _list_fragments_by_label(FragmentLabel.A2A, tenant_subdomain)
 
 
 def get_ias_fragment_name(tenant_subdomain: str) -> str:
@@ -81,10 +85,10 @@ def get_ias_fragment_name(tenant_subdomain: str) -> str:
     Raises:
         MCPServerNotFoundError: If no IAS fragment is found.
     """
-    fragments = _list_fragments_by_label(IAS_LABEL_VALUE, tenant_subdomain)
+    fragments = _list_fragments_by_label(FragmentLabel.IAS, tenant_subdomain)
     if not fragments:
         raise MCPServerNotFoundError(
-            f"No IAS fragment found (label {LABEL_KEY}={IAS_LABEL_VALUE}) "
+            f"No IAS fragment found (label {LABEL_KEY}={FragmentLabel.IAS.value}) "
             f"for tenant '{tenant_subdomain}'"
         )
     return fragments[0].name
@@ -105,10 +109,10 @@ def get_ias_user_fragment_name(tenant_subdomain: str) -> str:
     Raises:
         MCPServerNotFoundError: If no IAS user fragment is found.
     """
-    fragments = _list_fragments_by_label(IAS_USER_LABEL_VALUE, tenant_subdomain)
+    fragments = _list_fragments_by_label(FragmentLabel.IAS_USER, tenant_subdomain)
     if not fragments:
         raise MCPServerNotFoundError(
-            f"No IAS user fragment found (label {LABEL_KEY}={IAS_USER_LABEL_VALUE}) "
+            f"No IAS user fragment found (label {LABEL_KEY}={FragmentLabel.IAS_USER.value}) "
             f"for tenant '{tenant_subdomain}'"
         )
     return fragments[0].name

--- a/src/sap_cloud_sdk/agentgateway/_fragments.py
+++ b/src/sap_cloud_sdk/agentgateway/_fragments.py
@@ -37,9 +37,7 @@ class FragmentLabel(str, Enum):
 def _list_fragments_by_label(label: FragmentLabel, tenant_subdomain: str) -> list:
     client = create_fragment_client(instance=_DESTINATION_INSTANCE)
     return client.list_instance_fragments(
-        filter=ListOptions(
-            filter_labels=[Label(key=LABEL_KEY, values=[label.value])]
-        ),
+        filter=ListOptions(filter_labels=[Label(key=LABEL_KEY, values=[label.value])]),
         tenant=tenant_subdomain,
     )
 

--- a/src/sap_cloud_sdk/agentgateway/_fragments.py
+++ b/src/sap_cloud_sdk/agentgateway/_fragments.py
@@ -1,0 +1,114 @@
+"""Fragment discovery for Agent Gateway LoB flow.
+
+Centralises all BTP Destination Service fragment operations:
+- Label constants for managed-runtime fragment types
+- Fragment listing by label (MCP, A2A, IAS)
+- IAS fragment name lookup for auth flows
+"""
+
+import logging
+
+from sap_cloud_sdk.destination import (
+    create_fragment_client,
+    Label,
+    ListOptions,
+)
+
+from sap_cloud_sdk.agentgateway.exceptions import MCPServerNotFoundError
+
+logger = logging.getLogger(__name__)
+
+# Shared label key for all managed-runtime fragment types
+LABEL_KEY = "sap-managed-runtime-type"
+
+# Label values for fragment discovery
+MCP_LABEL_VALUE = "agw.mcp.server"
+IAS_LABEL_VALUE = "subscriber.ias"
+IAS_USER_LABEL_VALUE = "subscriber.ias.user"
+A2A_LABEL_VALUE = "agw.a2a.server"
+
+_DESTINATION_INSTANCE = "default"
+
+
+def _list_fragments_by_label(label_value: str, tenant_subdomain: str) -> list:
+    client = create_fragment_client(instance=_DESTINATION_INSTANCE)
+    return client.list_instance_fragments(
+        filter=ListOptions(
+            filter_labels=[Label(key=LABEL_KEY, values=[label_value])]
+        ),
+        tenant=tenant_subdomain,
+    )
+
+
+def list_mcp_fragments(tenant_subdomain: str) -> list:
+    """List destination fragments with MCP server label.
+
+    Args:
+        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+
+    Returns:
+        List of fragments with sap-managed-runtime-type=agw.mcp.server label.
+    """
+    logger.debug("Fetching MCP fragments for tenant '%s'", tenant_subdomain)
+    return _list_fragments_by_label(MCP_LABEL_VALUE, tenant_subdomain)
+
+
+def list_a2a_fragments(tenant_subdomain: str) -> list:
+    """List destination fragments with A2A label.
+
+    Args:
+        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+
+    Returns:
+        List of fragments with sap-managed-runtime-type=agw.a2a.server label.
+    """
+    logger.debug("Fetching A2A fragments for tenant '%s'", tenant_subdomain)
+    return _list_fragments_by_label(A2A_LABEL_VALUE, tenant_subdomain)
+
+
+def get_ias_fragment_name(tenant_subdomain: str) -> str:
+    """Get the IAS fragment name for system (technical) token acquisition.
+
+    Looks up the IAS fragment created during subscription by the
+    sap-managed-runtime-type=subscriber.ias label.
+
+    Args:
+        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+
+    Returns:
+        IAS fragment name.
+
+    Raises:
+        MCPServerNotFoundError: If no IAS fragment is found.
+    """
+    fragments = _list_fragments_by_label(IAS_LABEL_VALUE, tenant_subdomain)
+    if not fragments:
+        raise MCPServerNotFoundError(
+            f"No IAS fragment found (label {LABEL_KEY}={IAS_LABEL_VALUE}) "
+            f"for tenant '{tenant_subdomain}'"
+        )
+    return fragments[0].name
+
+
+def get_ias_user_fragment_name(tenant_subdomain: str) -> str:
+    """Get the IAS user fragment name for token exchange (principal propagation).
+
+    Looks up the IAS user fragment created during subscription by the
+    sap-managed-runtime-type=subscriber.ias.user label.
+
+    Args:
+        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+
+    Returns:
+        IAS user fragment name.
+
+    Raises:
+        MCPServerNotFoundError: If no IAS user fragment is found.
+    """
+    fragments = _list_fragments_by_label(IAS_USER_LABEL_VALUE, tenant_subdomain)
+    if not fragments:
+        raise MCPServerNotFoundError(
+            f"No IAS user fragment found (label {LABEL_KEY}={IAS_USER_LABEL_VALUE}) "
+            f"for tenant '{tenant_subdomain}'"
+        )
+    return fragments[0].name

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -458,6 +458,22 @@ async def _fetch_agent_card(
     return AgentCard(raw=payload)
 
 
+def _ord_id_from_url(url: str) -> str:
+    """Extract the ORD ID from an A2A fragment URL.
+
+    A2A fragment URLs follow the pattern:
+        https://{gateway-host}/v1/a2a/{ordId}/{globalTenantId}
+
+    The ORD ID is the second-to-last non-empty path segment.
+
+    Returns an empty string if the URL path has fewer than two segments.
+    """
+    from urllib.parse import urlparse
+
+    path_segments = [s for s in urlparse(url).path.split("/") if s]
+    return path_segments[-2] if len(path_segments) >= 2 else ""
+
+
 async def get_agent_cards_lob(
     tenant_subdomain: str,
     system_token: str,
@@ -507,24 +523,33 @@ async def get_agent_cards_lob(
         fragments = [
             f
             for f in fragments
-            if (f.properties.get("ordId") or f.properties.get("OrdId")) in ord_ids_set
+            if _ord_id_from_url(
+                {k.lower(): v for k, v in f.properties.items()}.get("url", "")
+            )
+            in ord_ids_set
         ]
 
     agents: list[Agent] = []
 
     for fragment in fragments:
         fragment_name = fragment.name
-        ord_id = fragment.properties.get("ordId") or fragment.properties.get("OrdId")
-        fragment_url = fragment.properties.get("URL") or fragment.properties.get("url")
+        props_lower = {k.lower(): v for k, v in fragment.properties.items()}
+        fragment_url = props_lower.get("url")
 
-        if not ord_id:
-            logger.warning(
-                "A2A fragment '%s' missing 'ordId' property — skipping", fragment_name
-            )
-            continue
         if not fragment_url:
             logger.warning(
-                "A2A fragment '%s' missing 'URL' property — skipping", fragment_name
+                "A2A fragment '%s' missing 'URL' property — skipping (properties: %s)",
+                fragment_name,
+                list(fragment.properties.keys()),
+            )
+            continue
+
+        ord_id = _ord_id_from_url(fragment_url)
+        if not ord_id:
+            logger.warning(
+                "A2A fragment '%s' could not extract ordId from URL '%s' — skipping",
+                fragment_name,
+                fragment_url,
             )
             continue
 

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -21,8 +21,7 @@ from sap_cloud_sdk.destination import (
 
 from sap_cloud_sdk.agentgateway._fragments import (
     LABEL_KEY,
-    MCP_LABEL_VALUE,
-    A2A_LABEL_VALUE,
+    FragmentLabel,
     get_ias_fragment_name,
     get_ias_user_fragment_name,
     list_mcp_fragments,
@@ -328,7 +327,7 @@ async def get_mcp_tools_lob(
 
     if not fragments:
         logger.debug(
-            "No MCP fragments found (label %s=%s)", LABEL_KEY, MCP_LABEL_VALUE
+            "No MCP fragments found (label %s=%s)", LABEL_KEY, FragmentLabel.MCP.value
         )
         return tools
 
@@ -492,7 +491,7 @@ async def get_agent_cards_lob(
 
     if not fragments:
         logger.debug(
-            "No A2A fragments found (label %s=%s)", LABEL_KEY, A2A_LABEL_VALUE
+            "No A2A fragments found (label %s=%s)", LABEL_KEY, FragmentLabel.A2A.value
         )
         return []
 

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -15,26 +15,24 @@ from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from sap_cloud_sdk.destination import (
     create_client as create_destination_client,
-    create_fragment_client,
     ConsumptionLevel,
     ConsumptionOptions,
-    Label,
-    ListOptions,
 )
 
-from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway._fragments import (
+    LABEL_KEY,
+    MCP_LABEL_VALUE,
+    A2A_LABEL_VALUE,
+    get_ias_fragment_name,
+    get_ias_user_fragment_name,
+    list_mcp_fragments,
+    list_a2a_fragments,
+)
+from sap_cloud_sdk.agentgateway._models import Agent, AgentCard, MCPTool
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
-from sap_cloud_sdk.agentgateway.exceptions import MCPServerNotFoundError
+from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
 
 logger = logging.getLogger(__name__)
-
-# Shared label key for all managed-runtime fragment types
-_LABEL_KEY = "sap-managed-runtime-type"
-
-# Label values for fragment discovery
-_MCP_LABEL_VALUE = "agw.mcp.server"
-_IAS_LABEL_VALUE = "subscriber.ias"
-_IAS_USER_LABEL_VALUE = "subscriber.ias.user"
 
 _DESTINATION_INSTANCE = "default"
 
@@ -112,85 +110,6 @@ def _fetch_auth_token(
     gateway_url = (dest.url or "").rstrip("/")
 
     return raw_token, gateway_url
-
-
-def list_mcp_fragments(tenant_subdomain: str) -> list:
-    """List destination fragments with MCP server label.
-
-    Args:
-        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
-
-    Returns:
-        List of fragments with sap-managed-runtime-type=agw.mcp.server label.
-    """
-    logger.debug("Fetching MCP fragments for tenant '%s'", tenant_subdomain)
-    client = create_fragment_client(instance=_DESTINATION_INSTANCE)
-    return client.list_instance_fragments(
-        filter=ListOptions(
-            filter_labels=[Label(key=_LABEL_KEY, values=[_MCP_LABEL_VALUE])]
-        ),
-        tenant=tenant_subdomain,
-    )
-
-
-def get_ias_fragment_name(tenant_subdomain: str) -> str:
-    """Get the IAS fragment name for system (technical) token acquisition.
-
-    Looks up the IAS fragment created during subscription by the
-    sap-managed-runtime-type=subscriber.ias label.
-
-    Args:
-        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
-
-    Returns:
-        IAS fragment name.
-
-    Raises:
-        MCPServerNotFoundError: If no IAS fragment is found.
-    """
-    client = create_fragment_client(instance=_DESTINATION_INSTANCE)
-    fragments = client.list_instance_fragments(
-        filter=ListOptions(
-            filter_labels=[Label(key=_LABEL_KEY, values=[_IAS_LABEL_VALUE])]
-        ),
-        tenant=tenant_subdomain,
-    )
-    if not fragments:
-        raise MCPServerNotFoundError(
-            f"No IAS fragment found (label {_LABEL_KEY}={_IAS_LABEL_VALUE}) "
-            f"for tenant '{tenant_subdomain}'"
-        )
-    return fragments[0].name
-
-
-def get_ias_user_fragment_name(tenant_subdomain: str) -> str:
-    """Get the IAS user fragment name for token exchange (principal propagation).
-
-    Looks up the IAS user fragment created during subscription by the
-    sap-managed-runtime-type=subscriber.ias.user label.
-
-    Args:
-        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
-
-    Returns:
-        IAS user fragment name.
-
-    Raises:
-        MCPServerNotFoundError: If no IAS user fragment is found.
-    """
-    client = create_fragment_client(instance=_DESTINATION_INSTANCE)
-    fragments = client.list_instance_fragments(
-        filter=ListOptions(
-            filter_labels=[Label(key=_LABEL_KEY, values=[_IAS_USER_LABEL_VALUE])]
-        ),
-        tenant=tenant_subdomain,
-    )
-    if not fragments:
-        raise MCPServerNotFoundError(
-            f"No IAS user fragment found (label {_LABEL_KEY}={_IAS_USER_LABEL_VALUE}) "
-            f"for tenant '{tenant_subdomain}'"
-        )
-    return fragments[0].name
 
 
 async def fetch_system_auth(
@@ -409,7 +328,7 @@ async def get_mcp_tools_lob(
 
     if not fragments:
         logger.debug(
-            "No MCP fragments found (label %s=%s)", _LABEL_KEY, _MCP_LABEL_VALUE
+            "No MCP fragments found (label %s=%s)", LABEL_KEY, MCP_LABEL_VALUE
         )
         return tools
 
@@ -482,3 +401,141 @@ async def call_mcp_tool_lob(
                     return ""
                 first = result.content[0]
                 return str(getattr(first, "text", ""))
+
+
+async def _fetch_agent_card(
+    fragment_url: str,
+    auth_token: str,
+    timeout: float,
+) -> AgentCard:
+    """Fetch agent card from the A2A well-known endpoint.
+
+    URL: {fragment_url}/.well-known/agent-card.json
+
+    Args:
+        fragment_url: Base URL from the A2A fragment's URL property.
+        auth_token: Raw access token for authentication.
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        AgentCard with the full parsed response payload.
+
+    Raises:
+        AgentGatewaySDKError: If the request fails or returns a non-200 status.
+    """
+    url = f"{fragment_url.rstrip('/')}/.well-known/agent-card.json"
+    logger.debug("Fetching agent card from '%s'", url)
+
+    async with httpx.AsyncClient(
+        headers={
+            "Authorization": f"Bearer {auth_token}",
+            "x-correlation-id": str(uuid.uuid4()),
+        },
+        timeout=timeout,
+    ) as client:
+        try:
+            response = await client.get(url)
+        except httpx.RequestError as e:
+            raise AgentGatewaySDKError(
+                f"Agent card request failed for '{fragment_url}': {e}"
+            ) from e
+
+    if response.status_code != 200:
+        raise AgentGatewaySDKError(
+            f"Agent card request returned status {response.status_code} "
+            f"for '{fragment_url}': {response.text[:200]}"
+        )
+
+    try:
+        payload = response.json()
+    except Exception as e:
+        raise AgentGatewaySDKError(
+            f"Failed to parse agent card JSON for '{fragment_url}': {e}"
+        ) from e
+
+    return AgentCard(raw=payload)
+
+
+async def get_agent_cards_lob(
+    tenant_subdomain: str,
+    system_token: str,
+    timeout: float,
+    names: list[str] | None = None,
+    ord_ids: list[str] | None = None,
+) -> list[Agent]:
+    """List A2A agents and their agent cards using LoB flow.
+
+    Discovers A2A fragments (label agw.a2a.server), optionally filters them,
+    then fetches the agent card for each from the fragment's URL property.
+
+    Fragment properties used:
+        URL: Base URL of the A2A agent (required).
+            The agent card is fetched at {URL}/.well-known/agent-card.json.
+        ordId: ORD ID of the A2A agent (required).
+
+    Args:
+        tenant_subdomain: Tenant subdomain for multi-tenant lookup.
+        system_token: Pre-fetched raw system token for authentication.
+        timeout: HTTP timeout in seconds.
+        names: Optional list of fragment names to include. If empty or None,
+            all fragments are included.
+        ord_ids: Optional list of ORD IDs to include. If empty or None,
+            all fragments are included.
+
+    Returns:
+        List of Agent objects, each containing ORD ID and fetched AgentCard.
+    """
+    loop = asyncio.get_running_loop()
+
+    logger.info("Listing A2A fragments for tenant '%s'", tenant_subdomain)
+    fragments = await loop.run_in_executor(None, list_a2a_fragments, tenant_subdomain)
+
+    if not fragments:
+        logger.debug(
+            "No A2A fragments found (label %s=%s)", LABEL_KEY, A2A_LABEL_VALUE
+        )
+        return []
+
+    # Apply optional filters
+    if names:
+        names_set = set(names)
+        fragments = [f for f in fragments if f.name in names_set]
+    if ord_ids:
+        ord_ids_set = set(ord_ids)
+        fragments = [
+            f
+            for f in fragments
+            if (f.properties.get("ordId") or f.properties.get("OrdId")) in ord_ids_set
+        ]
+
+    agents: list[Agent] = []
+
+    for fragment in fragments:
+        fragment_name = fragment.name
+        ord_id = fragment.properties.get("ordId") or fragment.properties.get("OrdId")
+        fragment_url = fragment.properties.get("URL") or fragment.properties.get("url")
+
+        if not ord_id:
+            logger.warning(
+                "A2A fragment '%s' missing 'ordId' property — skipping", fragment_name
+            )
+            continue
+        if not fragment_url:
+            logger.warning(
+                "A2A fragment '%s' missing 'URL' property — skipping", fragment_name
+            )
+            continue
+
+        try:
+            card = await _fetch_agent_card(fragment_url, system_token, timeout)
+            agents.append(Agent(ord_id=ord_id, agent_card=card))
+            logger.debug("Fetched agent card for fragment '%s'", fragment_name)
+        except Exception:
+            logger.exception(
+                "Failed to fetch agent card for fragment '%s' — skipping", fragment_name
+            )
+
+    logger.info(
+        "Fetched %d agent card(s) from %d A2A fragment(s)", len(agents), len(fragments)
+    )
+    return agents

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -29,7 +29,10 @@ from sap_cloud_sdk.agentgateway._fragments import (
 )
 from sap_cloud_sdk.agentgateway._models import Agent, AgentCard, MCPTool
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
-from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
+from sap_cloud_sdk.agentgateway.exceptions import (
+    AgentGatewaySDKError,
+    MCPServerNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -478,27 +478,29 @@ async def get_agent_cards_lob(
     tenant_subdomain: str,
     system_token: str,
     timeout: float,
-    names: list[str] | None = None,
+    agent_names: list[str] | None = None,
     ord_ids: list[str] | None = None,
 ) -> list[Agent]:
     """List A2A agents and their agent cards using LoB flow.
 
-    Discovers A2A fragments (label agw.a2a.server), optionally filters them,
-    then fetches the agent card for each from the fragment's URL property.
+    Discovers A2A fragments (label agw.a2a.server), optionally filters by
+    ORD ID before fetching, fetches each agent card, then optionally filters
+    by agent card name.
 
     Fragment properties used:
         URL: Base URL of the A2A agent (required).
             The agent card is fetched at {URL}/.well-known/agent-card.json.
-        ordId: ORD ID of the A2A agent (required).
+            The ORD ID is extracted from the second-to-last URL path segment.
 
     Args:
         tenant_subdomain: Tenant subdomain for multi-tenant lookup.
         system_token: Pre-fetched raw system token for authentication.
         timeout: HTTP timeout in seconds.
-        names: Optional list of fragment names to include. If empty or None,
-            all fragments are included.
-        ord_ids: Optional list of ORD IDs to include. If empty or None,
-            all fragments are included.
+        agent_names: Optional list of agent card names to include (matched
+            against the `name` field in the fetched agent card JSON).
+            Applied after fetching. If empty or None, all are included.
+        ord_ids: Optional list of ORD IDs to include (extracted from URL).
+            Applied before fetching. If empty or None, all are included.
 
     Returns:
         List of Agent objects, each containing ORD ID and fetched AgentCard.
@@ -514,10 +516,7 @@ async def get_agent_cards_lob(
         )
         return []
 
-    # Apply optional filters
-    if names:
-        names_set = set(names)
-        fragments = [f for f in fragments if f.name in names_set]
+    # Pre-fetch filter: ORD ID is extractable from the URL without fetching the card
     if ord_ids:
         ord_ids_set = set(ord_ids)
         fragments = [
@@ -561,6 +560,11 @@ async def get_agent_cards_lob(
             logger.exception(
                 "Failed to fetch agent card for fragment '%s' — skipping", fragment_name
             )
+
+    # Post-fetch filter: agent card name is only known after fetching
+    if agent_names:
+        agent_names_set = set(agent_names)
+        agents = [a for a in agents if a.agent_card.raw.get("name") in agent_names_set]
 
     logger.info(
         "Fetched %d agent card(s) from %d A2A fragment(s)", len(agents), len(fragments)

--- a/src/sap_cloud_sdk/agentgateway/_models.py
+++ b/src/sap_cloud_sdk/agentgateway/_models.py
@@ -141,7 +141,7 @@ class AgentCardFilter:
 
         agents = await agw_client.list_agent_cards(
             filter=AgentCardFilter(
-                agent_names=["Billing Assistant Agent"],
+                agent_names=["Sample Agent"],
                 ord_ids=["sap.s4:apiAccess:agent:v1"],
             )
         )

--- a/src/sap_cloud_sdk/agentgateway/_models.py
+++ b/src/sap_cloud_sdk/agentgateway/_models.py
@@ -1,6 +1,6 @@
 """Data models for Agent Gateway MCP tools."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 
@@ -92,3 +92,59 @@ class CustomerCredentials:
     private_key: str
     gateway_url: str
     integration_dependencies: list[IntegrationDependency]
+
+
+@dataclass
+class AgentCard:
+    """Agent Card as returned by the A2A well-known endpoint.
+
+    Contains the raw payload from /.well-known/agent-card.json, plus
+    the ORD ID and global tenant ID of the agent.
+
+    Attributes:
+        raw: Full parsed JSON payload from the agent card endpoint.
+    """
+
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Agent:
+    """A2A agent discovered via Agent Gateway fragment listing.
+
+    Attributes:
+        ord_id: Open Resource Discovery ID of the agent.
+        agent_card: Agent Card fetched from the A2A well-known endpoint.
+    """
+
+    ord_id: str
+    agent_card: AgentCard
+
+
+@dataclass
+class AgentCardFilter:
+    """Filter options for list_agent_cards.
+
+    All fields are optional. When multiple fields are set they are applied
+    together (AND semantics). Empty lists are treated the same as None (no
+    filtering on that field).
+
+    Attributes:
+        names: Fragment names to include.
+        ord_ids: ORD IDs to include.
+
+    Example:
+        ```python
+        from sap_cloud_sdk.agentgateway import AgentCardFilter
+
+        agents = await agw_client.list_agent_cards(
+            filter=AgentCardFilter(
+                names=["my-fragment"],
+                ord_ids=["sap.s4:apiAccess:agent:v1"],
+            )
+        )
+        ```
+    """
+
+    names: list[str] = field(default_factory=list)
+    ord_ids: list[str] = field(default_factory=list)

--- a/src/sap_cloud_sdk/agentgateway/_models.py
+++ b/src/sap_cloud_sdk/agentgateway/_models.py
@@ -130,8 +130,10 @@ class AgentCardFilter:
     filtering on that field).
 
     Attributes:
-        names: Fragment names to include.
-        ord_ids: ORD IDs to include.
+        agent_names: Agent card names to include (matched against the `name`
+            field in the agent card JSON). Applied after fetching all cards.
+        ord_ids: ORD IDs to include (extracted from the fragment URL).
+            Applied before fetching, skipping non-matching fragments.
 
     Example:
         ```python
@@ -139,12 +141,12 @@ class AgentCardFilter:
 
         agents = await agw_client.list_agent_cards(
             filter=AgentCardFilter(
-                names=["my-fragment"],
+                agent_names=["Billing Assistant Agent"],
                 ord_ids=["sap.s4:apiAccess:agent:v1"],
             )
         )
         ```
     """
 
-    names: list[str] = field(default_factory=list)
+    agent_names: list[str] = field(default_factory=list)
     ord_ids: list[str] = field(default_factory=list)

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -27,7 +27,12 @@ from sap_cloud_sdk.agentgateway._lob import (
     get_agent_cards_lob,
     get_mcp_tools_lob,
 )
-from sap_cloud_sdk.agentgateway._models import Agent, AgentCardFilter, AuthResult, MCPTool
+from sap_cloud_sdk.agentgateway._models import (
+    Agent,
+    AgentCardFilter,
+    AuthResult,
+    MCPTool,
+)
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 from sap_cloud_sdk.core.telemetry import Module, Operation, record_metrics

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -24,9 +24,10 @@ from sap_cloud_sdk.agentgateway._lob import (
     call_mcp_tool_lob,
     fetch_system_auth,
     fetch_user_auth,
+    get_agent_cards_lob,
     get_mcp_tools_lob,
 )
-from sap_cloud_sdk.agentgateway._models import AuthResult, MCPTool
+from sap_cloud_sdk.agentgateway._models import Agent, AgentCardFilter, AuthResult, MCPTool
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
 from sap_cloud_sdk.core.telemetry import Module, Operation, record_metrics
@@ -367,6 +368,72 @@ class AgentGatewayClient:
             logger.exception("Unexpected error during tool discovery")
             cause = _unwrap_exception_group(e)
             raise AgentGatewaySDKError(f"Tool discovery failed: {cause}") from e
+
+    @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_LIST_AGENT_CARDS)
+    async def list_agent_cards(
+        self,
+        filter: AgentCardFilter | None = None,
+    ) -> list[Agent]:
+        """List A2A agents and their agent cards from Agent Gateway.
+
+        Discovers destination fragments labelled as A2A agents and fetches the
+        agent card from each agent's well-known endpoint. Only available for
+        LoB agents.
+
+        Args:
+            filter: Optional filter to narrow results by fragment name or ORD ID.
+                If None or empty, all A2A fragments are included.
+
+        Returns:
+            List of Agent objects, each containing the fragment name, ORD ID,
+            and the fetched AgentCard.
+
+        Raises:
+            AgentGatewaySDKError: If tenant_subdomain is not provided,
+                or if fragment discovery or agent card fetch fails.
+
+        Example:
+            ```python
+            from sap_cloud_sdk.agentgateway import AgentCardFilter
+
+            # All agents
+            agents = await agw_client.list_agent_cards()
+
+            # With filters
+            agents = await agw_client.list_agent_cards(
+                filter=AgentCardFilter(
+                    names=["my-fragment"],
+                    ord_ids=["sap.s4:apiAccess:agent:v1"],
+                )
+            )
+            ```
+        """
+        try:
+            credentials_path = detect_customer_agent_credentials()
+            if credentials_path:
+                # TODO: Add customer agent flow for list_agent_cards.
+                # Customer agents should discover A2A agents from integrationDependencies
+                # in the credentials file (similar to get_mcp_tools_customer) and fetch
+                # agent cards using the credentials gateway_url.
+                raise AgentGatewaySDKError(
+                    "list_agent_cards is not yet supported for customer agents."
+                )
+
+            tenant = self._resolve_tenant_subdomain()
+            auth = await self.get_system_auth()
+            f = filter or AgentCardFilter()
+            return await get_agent_cards_lob(
+                tenant,
+                auth.access_token,
+                self._config.timeout,
+                names=f.names or None,
+                ord_ids=f.ord_ids or None,
+            )
+        except AgentGatewaySDKError:
+            raise
+        except Exception as e:
+            logger.exception("Unexpected error during agent card discovery")
+            raise AgentGatewaySDKError(f"Agent card discovery failed: {e}") from e
 
     @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_CALL_MCP_TOOL)
     async def call_mcp_tool(

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -407,7 +407,7 @@ class AgentGatewayClient:
             # With filters
             agents = await agw_client.list_agent_cards(
                 filter=AgentCardFilter(
-                    names=["my-fragment"],
+                    agent_names=["Sample Agent"],
                     ord_ids=["sap.s4:apiAccess:agent:v1"],
                 )
             )

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -431,7 +431,7 @@ class AgentGatewayClient:
                 tenant,
                 auth.access_token,
                 self._config.timeout,
-                names=f.names or None,
+                agent_names=f.agent_names or None,
                 ord_ids=f.ord_ids or None,
             )
         except AgentGatewaySDKError:

--- a/src/sap_cloud_sdk/agentgateway/user-guide.md
+++ b/src/sap_cloud_sdk/agentgateway/user-guide.md
@@ -64,7 +64,7 @@ result = await agw_client.call_mcp_tool(
 
 ### A2A Agent Cards (LoB only)
 
-Discover A2A agents and their agent cards from destination fragments labelled `agw.a2a.server`. Each fragment must have an `ordId` and a `URL` property; the agent card is fetched from `{URL}/.well-known/agent-card.json`.
+Discover A2A agents and their agent cards from destination fragments labelled `agw.a2a.server`. Each fragment must have a `URL` property; the agent card is fetched from `{URL}/.well-known/agent-card.json` and the ORD ID is extracted from the second-to-last URL path segment.
 
 ```python
 from sap_cloud_sdk.agentgateway import AgentCardFilter, create_client
@@ -78,10 +78,10 @@ for agent in agents:
     print(agent.ord_id)
     print(agent.agent_card.raw)  # full agent card JSON payload
 
-# Filter by fragment name or ORD ID
+# Filter by agent card name (post-fetch) or ORD ID (pre-fetch)
 agents = await agw_client.list_agent_cards(
     filter=AgentCardFilter(
-        names=["my-a2a-fragment"],
+        agent_names=["Sample Agent"],
         ord_ids=["sap.s4:apiAccess:purchaseOrderAI:agent:v1"],
     )
 )
@@ -138,7 +138,7 @@ The SDK discovers resources via BTP Destination Service fragments filtered by th
 | Label value | Resource |
 |---|---|
 | `agw.mcp.server` | MCP tool server — `URL` property points to the MCP endpoint |
-| `agw.a2a.server` | A2A agent — `URL` property is the agent base URL; `ordId` property is the ORD ID |
+| `agw.a2a.server` | A2A agent — `URL` property is the agent base URL; ORD ID is extracted from the second-to-last URL path segment |
 | `subscriber.ias` | IAS credential fragment for system-scoped token acquisition |
 | `subscriber.ias.user` | IAS credential fragment for user-scoped token exchange |
 
@@ -212,12 +212,12 @@ class AgentGatewayClient:
 from sap_cloud_sdk.agentgateway import AgentCardFilter
 
 AgentCardFilter(
-    names=[],    # fragment names to include; empty = no filter
-    ord_ids=[],  # ORD IDs to include; empty = no filter
+    agent_names=[],  # agent card names to include (matched against card JSON `name`); empty = no filter
+    ord_ids=[],      # ORD IDs to include (extracted from fragment URL); empty = no filter
 )
 ```
 
-Both fields default to empty lists. Filters are applied with AND semantics: if both are set, a fragment must match both to be included.
+Both fields default to empty lists. Filters are applied with AND semantics: if both are set, an agent must match both to be included. `agent_names` is applied after fetching (requires reading the card); `ord_ids` is applied before fetching (extracted from the fragment URL, no card request needed).
 
 ### Data Models
 

--- a/src/sap_cloud_sdk/agentgateway/user-guide.md
+++ b/src/sap_cloud_sdk/agentgateway/user-guide.md
@@ -1,6 +1,6 @@
 # Agent Gateway User Guide
 
-This module provides a framework-agnostic client for discovering and invoking MCP tools via SAP Agent Gateway. It automatically detects the agent type (LoB vs Customer) based on credential file presence and handles authentication accordingly.
+This module provides a framework-agnostic client for discovering and invoking MCP tools and A2A agent cards via SAP Agent Gateway. It automatically detects the agent type (LoB vs Customer) based on credential file presence and handles authentication accordingly.
 
 ## Installation
 
@@ -38,12 +38,11 @@ result = await agw_client.call_mcp_tool(
     user_token="user-jwt",
     cost_center="1000",
 )
-
 ```
 
 ### LoB Agent Flow
 
-LoB agents use BTP Destination Service for credential management. Tools are auto-discovered from destination fragments.
+LoB agents use BTP Destination Service for credential management. Tools and A2A agents are auto-discovered from destination fragments.
 
 ```python
 from sap_cloud_sdk.agentgateway import ClientConfig, create_client
@@ -51,7 +50,7 @@ from sap_cloud_sdk.agentgateway import ClientConfig, create_client
 config = ClientConfig(timeout=30.0)
 agw_client = create_client(tenant_subdomain="my-tenant", config=config)
 
-# Discover tools (auto-discovered from destination fragments)
+# Discover MCP tools (auto-discovered from destination fragments)
 # Pass user_token to use principal propagation when listing tools
 tools = await agw_client.list_mcp_tools(user_token="user-jwt")
 
@@ -60,6 +59,31 @@ result = await agw_client.call_mcp_tool(
     tool=tools[0],
     user_token="user-jwt",
     order_id="12345",
+)
+```
+
+### A2A Agent Cards (LoB only)
+
+Discover A2A agents and their agent cards from destination fragments labelled `agw.a2a.server`. Each fragment must have an `ordId` and a `URL` property; the agent card is fetched from `{URL}/.well-known/agent-card.json`.
+
+```python
+from sap_cloud_sdk.agentgateway import AgentCardFilter, create_client
+
+agw_client = create_client(tenant_subdomain="my-tenant")
+
+# Discover all A2A agents
+agents = await agw_client.list_agent_cards()
+
+for agent in agents:
+    print(agent.ord_id)
+    print(agent.agent_card.raw)  # full agent card JSON payload
+
+# Filter by fragment name or ORD ID
+agents = await agw_client.list_agent_cards(
+    filter=AgentCardFilter(
+        names=["my-a2a-fragment"],
+        ord_ids=["sap.s4:apiAccess:purchaseOrderAI:agent:v1"],
+    )
 )
 ```
 
@@ -102,11 +126,21 @@ mcp_tool_to_langchain(
 
 ### Agent Types
 
-- **LoB (Line of Business) Agent**: Uses BTP Destination Service for credentials. Requires `tenant_subdomain`. Tools are auto-discovered from destination fragments.
-- **Customer Agent**: Uses file-based credentials mounted on the pod filesystem with mTLS authentication. MCP servers are defined in the credentials file's `integrationDependencies`.
+- **LoB (Line of Business) Agent**: Uses BTP Destination Service for credentials. Requires `tenant_subdomain`. MCP tools and A2A agent cards are auto-discovered from destination fragments.
+- **Customer Agent**: Uses file-based credentials mounted on the pod filesystem with mTLS authentication. MCP servers are defined in the credentials file's `integrationDependencies`. A2A agent card discovery is not yet supported.
 
 The SDK automatically detects the agent type based on the presence of a credentials file.
 
+### Fragments and Labels
+
+The SDK discovers resources via BTP Destination Service fragments filtered by the `sap-managed-runtime-type` label:
+
+| Label value | Resource |
+|---|---|
+| `agw.mcp.server` | MCP tool server — `URL` property points to the MCP endpoint |
+| `agw.a2a.server` | A2A agent — `URL` property is the agent base URL; `ordId` property is the ORD ID |
+| `subscriber.ias` | IAS credential fragment for system-scoped token acquisition |
+| `subscriber.ias.user` | IAS credential fragment for user-scoped token exchange |
 
 ## API
 
@@ -140,7 +174,7 @@ config = ClientConfig(
 agw_client = create_client(tenant_subdomain="my-tenant", config=config)
 ```
 
-- `timeout`: HTTP timeout in seconds for token requests and MCP calls. Default: `60.0`.
+- `timeout`: HTTP timeout in seconds for token requests, MCP calls, and agent card fetches. Default: `60.0`.
 - `fallback_token_ttl_seconds`: Used when the token response does not include expiry metadata. Default: `300.0`.
 - `token_expiry_buffer_seconds`: Safety buffer subtracted from explicit token expiries before a cached token is reused. Default: `30.0`.
 - `max_system_token_cache_size`: Maximum number of cached system tokens per client instance. Default: `32`.
@@ -165,4 +199,44 @@ class AgentGatewayClient:
         app_tid: str | None = None,
         **kwargs,
     ) -> str
+
+    async def list_agent_cards(
+        self,
+        filter: AgentCardFilter | None = None,
+    ) -> list[Agent]
+```
+
+### AgentCardFilter
+
+```python
+from sap_cloud_sdk.agentgateway import AgentCardFilter
+
+AgentCardFilter(
+    names=[],    # fragment names to include; empty = no filter
+    ord_ids=[],  # ORD IDs to include; empty = no filter
+)
+```
+
+Both fields default to empty lists. Filters are applied with AND semantics: if both are set, a fragment must match both to be included.
+
+### Data Models
+
+```python
+@dataclass
+class Agent:
+    ord_id: str       # ORD ID from fragment ordId property
+    agent_card: AgentCard
+
+@dataclass
+class AgentCard:
+    raw: dict         # full parsed JSON from /.well-known/agent-card.json
+
+@dataclass
+class MCPTool:
+    name: str
+    server_name: str
+    description: str
+    input_schema: dict
+    url: str
+    fragment_name: str | None
 ```

--- a/src/sap_cloud_sdk/core/telemetry/operation.py
+++ b/src/sap_cloud_sdk/core/telemetry/operation.py
@@ -185,6 +185,7 @@ class Operation(str, Enum):
     AGENTGATEWAY_CALL_MCP_TOOL = "call_mcp_tool"
     AGENTGATEWAY_GET_SYSTEM_AUTH = "get_system_auth"
     AGENTGATEWAY_GET_USER_AUTH = "get_user_auth"
+    AGENTGATEWAY_LIST_AGENT_CARDS = "list_agent_cards"
 
     # Agent Memory Operations
     AGENT_MEMORY_ADD_MEMORY = "add_memory"

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -7,6 +7,9 @@ import pytest
 from sap_cloud_sdk.agentgateway import (
     create_client,
     AgentGatewayClient,
+    Agent,
+    AgentCard,
+    AgentCardFilter,
     AuthResult,
     MCPTool,
     AgentGatewaySDKError,
@@ -834,3 +837,146 @@ class TestCallMcpTool:
             )
 
             assert result == "Success: Order created"
+
+
+# ============================================================
+# Test: list_agent_cards
+# ============================================================
+
+
+class TestListAgentCards:
+    """Tests for list_agent_cards async method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_agents_from_lob_flow(self):
+        """Return list of Agent objects from LoB flow."""
+        card = AgentCard(raw={"name": "TestAgent"})
+        agent = Agent(ord_id="sap.s4:agent:v1", agent_card=card)
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+                return_value=None,
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.fetch_system_auth",
+                new_callable=AsyncMock,
+                return_value=("system-token", "https://agw.example.com"),
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.get_agent_cards_lob",
+                new_callable=AsyncMock,
+                return_value=[agent],
+            ) as mock_lob,
+        ):
+            agw_client = create_client(tenant_subdomain="my-tenant")
+            result = await agw_client.list_agent_cards()
+
+        assert result == [agent]
+        mock_lob.assert_called_once_with(
+            "my-tenant",
+            "system-token",
+            60.0,
+            names=None,
+            ord_ids=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_passes_filter_arguments(self):
+        """Pass names and ord_ids from AgentCardFilter through to get_agent_cards_lob."""
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+                return_value=None,
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.fetch_system_auth",
+                new_callable=AsyncMock,
+                return_value=("token", "https://agw.example.com"),
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.get_agent_cards_lob",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_lob,
+        ):
+            agw_client = create_client(tenant_subdomain="my-tenant")
+            await agw_client.list_agent_cards(
+                filter=AgentCardFilter(names=["frag-1"], ord_ids=["sap.s4:agent:v1"])
+            )
+
+        mock_lob.assert_called_once_with(
+            "my-tenant",
+            "token",
+            60.0,
+            names=["frag-1"],
+            ord_ids=["sap.s4:agent:v1"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_customer_agent_flow(self):
+        """Raise AgentGatewaySDKError when called from a customer agent (not yet supported)."""
+        with patch(
+            "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+            return_value="/path/to/credentials",
+        ):
+            agw_client = create_client()
+            with pytest.raises(AgentGatewaySDKError, match="not yet supported for customer agents"):
+                await agw_client.list_agent_cards()
+
+    @pytest.mark.asyncio
+    async def test_raises_when_tenant_subdomain_missing(self):
+        """Raise AgentGatewaySDKError when tenant_subdomain is not provided."""
+        agw_client = create_client()
+        with patch(
+            "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+            return_value=None,
+        ):
+            with pytest.raises(AgentGatewaySDKError, match="tenant_subdomain"):
+                await agw_client.list_agent_cards()
+
+    @pytest.mark.asyncio
+    async def test_propagates_sdk_error(self):
+        """Re-raise AgentGatewaySDKError from get_agent_cards_lob."""
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+                return_value=None,
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.fetch_system_auth",
+                new_callable=AsyncMock,
+                return_value=("token", "https://agw.example.com"),
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.get_agent_cards_lob",
+                new_callable=AsyncMock,
+                side_effect=AgentGatewaySDKError("fragment discovery failed"),
+            ),
+        ):
+            agw_client = create_client(tenant_subdomain="my-tenant")
+            with pytest.raises(AgentGatewaySDKError, match="fragment discovery failed"):
+                await agw_client.list_agent_cards()
+
+    @pytest.mark.asyncio
+    async def test_wraps_unexpected_error(self):
+        """Wrap unexpected errors in AgentGatewaySDKError."""
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_customer_agent_credentials",
+                return_value=None,
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.fetch_system_auth",
+                new_callable=AsyncMock,
+                return_value=("token", "https://agw.example.com"),
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.get_agent_cards_lob",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("unexpected"),
+            ),
+        ):
+            agw_client = create_client(tenant_subdomain="my-tenant")
+            with pytest.raises(AgentGatewaySDKError, match="Agent card discovery failed"):
+                await agw_client.list_agent_cards()

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -877,7 +877,7 @@ class TestListAgentCards:
             "my-tenant",
             "system-token",
             60.0,
-            names=None,
+            agent_names=None,
             ord_ids=None,
         )
 
@@ -902,14 +902,14 @@ class TestListAgentCards:
         ):
             agw_client = create_client(tenant_subdomain="my-tenant")
             await agw_client.list_agent_cards(
-                filter=AgentCardFilter(names=["frag-1"], ord_ids=["sap.s4:agent:v1"])
+                filter=AgentCardFilter(agent_names=["Billing Agent"], ord_ids=["sap.s4:agent:v1"])
             )
 
         mock_lob.assert_called_once_with(
             "my-tenant",
             "token",
             60.0,
-            names=["frag-1"],
+            agent_names=["Billing Agent"],
             ord_ids=["sap.s4:agent:v1"],
         )
 

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -7,10 +7,7 @@ import pytest
 
 from sap_cloud_sdk.agentgateway._fragments import (
     LABEL_KEY,
-    MCP_LABEL_VALUE,
-    IAS_LABEL_VALUE,
-    IAS_USER_LABEL_VALUE,
-    A2A_LABEL_VALUE,
+    FragmentLabel,
     get_ias_fragment_name,
     get_ias_user_fragment_name,
     list_mcp_fragments,
@@ -32,12 +29,12 @@ from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
 from sap_cloud_sdk.destination import ConsumptionLevel
 
-# Aliases kept for backward compat within this test file
+# Aliases for use in existing test assertions
 _LABEL_KEY = LABEL_KEY
-_MCP_LABEL_VALUE = MCP_LABEL_VALUE
-_IAS_LABEL_VALUE = IAS_LABEL_VALUE
-_IAS_USER_LABEL_VALUE = IAS_USER_LABEL_VALUE
-_A2A_LABEL_VALUE = A2A_LABEL_VALUE
+_MCP_LABEL_VALUE = FragmentLabel.MCP.value
+_IAS_LABEL_VALUE = FragmentLabel.IAS.value
+_IAS_USER_LABEL_VALUE = FragmentLabel.IAS_USER.value
+_A2A_LABEL_VALUE = FragmentLabel.A2A.value
 
 
 # ============================================================

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -899,10 +899,15 @@ class TestGetAgentCardsLob:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_filters_by_names(self):
-        """Only include fragments whose name is in the names filter."""
+    async def test_filters_by_agent_names(self):
+        """Fetch all cards then keep only those whose agent card name matches."""
         frag_1 = self._make_fragment("frag-1", "https://agw.example.com/v1/a2a/ord-1/t1")
         frag_2 = self._make_fragment("frag-2", "https://agw.example.com/v1/a2a/ord-2/t2")
+
+        async def _cards_by_ord(fragment_url, token, timeout):
+            if "ord-1" in fragment_url:
+                return AgentCard(raw={"name": "Billing Agent"})
+            return AgentCard(raw={"name": "Other Agent"})
 
         with (
             patch(
@@ -911,17 +916,16 @@ class TestGetAgentCardsLob:
             ),
             patch(
                 "sap_cloud_sdk.agentgateway._lob._fetch_agent_card",
-                new_callable=AsyncMock,
-                return_value=AgentCard(raw={}),
-            ) as mock_fetch,
+                side_effect=_cards_by_ord,
+            ),
         ):
             result = await get_agent_cards_lob(
-                "tenant-sub", "token", 60.0, names=["frag-1"]
+                "tenant-sub", "token", 60.0, agent_names=["Billing Agent"]
             )
 
         assert len(result) == 1
         assert result[0].ord_id == "ord-1"
-        assert mock_fetch.call_count == 1
+        assert result[0].agent_card.raw["name"] == "Billing Agent"
 
     @pytest.mark.asyncio
     async def test_filters_by_ord_ids(self):

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -16,6 +16,7 @@ from sap_cloud_sdk.agentgateway._fragments import (
 from sap_cloud_sdk.agentgateway._lob import (
     _ias_dest_name,
     _fetch_auth_token,
+    _ord_id_from_url,
     fetch_system_auth,
     fetch_user_auth,
     get_mcp_tools_lob,
@@ -702,6 +703,35 @@ class TestCallMcpToolLob:
 # ============================================================
 
 
+# ============================================================
+# Test: _ord_id_from_url
+# ============================================================
+
+
+class TestOrdIdFromUrl:
+    """Tests for _ord_id_from_url helper."""
+
+    def test_extracts_ord_id_from_standard_url(self):
+        """Return the second-to-last path segment as ord_id."""
+        assert _ord_id_from_url(
+            "https://agw.example.com/v1/a2a/sap.s4:agent:v1/tenant-abc"
+        ) == "sap.s4:agent:v1"
+
+    def test_strips_trailing_slash(self):
+        """Handle trailing slash on URL."""
+        assert _ord_id_from_url(
+            "https://agw.example.com/v1/a2a/ord-1/gt-1/"
+        ) == "ord-1"
+
+    def test_returns_empty_for_single_segment(self):
+        """Return empty string when URL has only one path segment."""
+        assert _ord_id_from_url("https://agw.example.com/only-one") == ""
+
+    def test_returns_empty_for_bare_host(self):
+        """Return empty string for bare host URL with no path."""
+        assert _ord_id_from_url("https://agw.example.com") == ""
+
+
 class TestListA2aFragments:
     """Tests for list_a2a_fragments function."""
 
@@ -823,17 +853,19 @@ class TestFetchAgentCard:
 class TestGetAgentCardsLob:
     """Tests for get_agent_cards_lob async function."""
 
-    def _make_fragment(self, name: str, ord_id: str, url: str) -> MagicMock:
+    def _make_fragment(self, name: str, url: str) -> MagicMock:
         fragment = MagicMock()
         fragment.name = name
-        fragment.properties = {"ordId": ord_id, "URL": url}
+        fragment.properties = {"URL": url}
         return fragment
 
     @pytest.mark.asyncio
     async def test_returns_agents_for_all_fragments(self):
         """Return one Agent per A2A fragment with fetched card."""
         card_payload = {"name": "MyAgent"}
-        fragment = self._make_fragment("frag-1", "sap.s4:agent:v1", "https://agw.example.com/v1/a2a/sap.s4:agent:v1/tenant-abc")
+        fragment = self._make_fragment(
+            "frag-1", "https://agw.example.com/v1/a2a/sap.s4:agent:v1/tenant-abc"
+        )
 
         with (
             patch(
@@ -869,8 +901,8 @@ class TestGetAgentCardsLob:
     @pytest.mark.asyncio
     async def test_filters_by_names(self):
         """Only include fragments whose name is in the names filter."""
-        frag_1 = self._make_fragment("frag-1", "ord-1", "https://agw.example.com/a2a/1/t1")
-        frag_2 = self._make_fragment("frag-2", "ord-2", "https://agw.example.com/a2a/2/t2")
+        frag_1 = self._make_fragment("frag-1", "https://agw.example.com/v1/a2a/ord-1/t1")
+        frag_2 = self._make_fragment("frag-2", "https://agw.example.com/v1/a2a/ord-2/t2")
 
         with (
             patch(
@@ -893,9 +925,9 @@ class TestGetAgentCardsLob:
 
     @pytest.mark.asyncio
     async def test_filters_by_ord_ids(self):
-        """Only include fragments whose ordId is in the ord_ids filter."""
-        frag_1 = self._make_fragment("frag-1", "ord-1", "https://agw.example.com/a2a/1/t1")
-        frag_2 = self._make_fragment("frag-2", "ord-2", "https://agw.example.com/a2a/2/t2")
+        """Only include fragments whose ordId (from URL) is in the ord_ids filter."""
+        frag_1 = self._make_fragment("frag-1", "https://agw.example.com/v1/a2a/ord-1/t1")
+        frag_2 = self._make_fragment("frag-2", "https://agw.example.com/v1/a2a/ord-2/t2")
 
         with (
             patch(
@@ -917,11 +949,11 @@ class TestGetAgentCardsLob:
         assert mock_fetch.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_skips_fragment_missing_ord_id(self):
-        """Skip fragment that has no ordId property."""
+    async def test_skips_fragment_with_unparseable_ord_id(self):
+        """Skip fragment whose URL has fewer than two path segments (no ordId)."""
         fragment = MagicMock()
-        fragment.name = "frag-no-ord"
-        fragment.properties = {"URL": "https://agw.example.com/base"}
+        fragment.name = "frag-bad-url"
+        fragment.properties = {"URL": "https://agw.example.com"}
 
         with patch(
             "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
@@ -936,7 +968,7 @@ class TestGetAgentCardsLob:
         """Skip fragment that has no URL property."""
         fragment = MagicMock()
         fragment.name = "frag-no-url"
-        fragment.properties = {"ordId": "ord-1"}
+        fragment.properties = {}
 
         with patch(
             "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
@@ -949,11 +981,15 @@ class TestGetAgentCardsLob:
     @pytest.mark.asyncio
     async def test_skips_fragment_on_fetch_error(self):
         """Skip fragment when agent card fetch fails, continue with others."""
-        frag_ok = self._make_fragment("frag-ok", "ord-ok", "https://agw.example.com/ok")
-        frag_err = self._make_fragment("frag-err", "ord-err", "https://agw.example.com/err")
+        frag_ok = self._make_fragment(
+            "frag-ok", "https://agw.example.com/v1/a2a/ord-ok/t-ok"
+        )
+        frag_err = self._make_fragment(
+            "frag-err", "https://agw.example.com/v1/a2a/ord-err/t-err"
+        )
 
         async def _selective_fetch(fragment_url, token, timeout):
-            if "err" in fragment_url:
+            if "ord-err" in fragment_url:
                 raise RuntimeError("server unreachable")
             return AgentCard(raw={"name": "OK"})
 

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -5,26 +5,39 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
+from sap_cloud_sdk.agentgateway._fragments import (
+    LABEL_KEY,
+    MCP_LABEL_VALUE,
+    IAS_LABEL_VALUE,
+    IAS_USER_LABEL_VALUE,
+    A2A_LABEL_VALUE,
+    get_ias_fragment_name,
+    get_ias_user_fragment_name,
+    list_mcp_fragments,
+    list_a2a_fragments,
+)
 from sap_cloud_sdk.agentgateway._lob import (
     _ias_dest_name,
     _fetch_auth_token,
-    list_mcp_fragments,
-    get_ias_fragment_name,
-    get_ias_user_fragment_name,
     fetch_system_auth,
     fetch_user_auth,
     get_mcp_tools_lob,
+    get_agent_cards_lob,
+    _fetch_agent_card,
     call_mcp_tool_lob,
-    _LABEL_KEY,
-    _MCP_LABEL_VALUE,
-    _IAS_LABEL_VALUE,
-    _IAS_USER_LABEL_VALUE,
 )
-from sap_cloud_sdk.agentgateway._models import MCPTool
+from sap_cloud_sdk.agentgateway._models import Agent, AgentCard, MCPTool
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
 from sap_cloud_sdk.agentgateway.config import ClientConfig
-from sap_cloud_sdk.agentgateway.exceptions import MCPServerNotFoundError
+from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError, MCPServerNotFoundError
 from sap_cloud_sdk.destination import ConsumptionLevel
+
+# Aliases kept for backward compat within this test file
+_LABEL_KEY = LABEL_KEY
+_MCP_LABEL_VALUE = MCP_LABEL_VALUE
+_IAS_LABEL_VALUE = IAS_LABEL_VALUE
+_IAS_USER_LABEL_VALUE = IAS_USER_LABEL_VALUE
+_A2A_LABEL_VALUE = A2A_LABEL_VALUE
 
 
 # ============================================================
@@ -180,7 +193,7 @@ class TestListMcpFragments:
         fragment2.name = "mcp-server-b"
 
         with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_fragment_client"
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
         ) as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = [
                 fragment1,
@@ -196,7 +209,7 @@ class TestListMcpFragments:
     def test_uses_correct_filter_labels(self):
         """Use correct label filter for MCP fragments."""
         with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_fragment_client"
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
         ) as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = []
 
@@ -225,7 +238,7 @@ class TestGetIasFragmentName:
         fragment.name = "sap-managed-runtime-agw-subscriber-ias-abc123"
 
         with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_fragment_client"
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
         ) as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = [fragment]
 
@@ -239,7 +252,7 @@ class TestGetIasFragmentName:
         fragment.name = "ias-fragment"
 
         with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_fragment_client"
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
         ) as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = [fragment]
 
@@ -255,7 +268,7 @@ class TestGetIasFragmentName:
     def test_raises_when_no_fragment_found(self):
         """Raise MCPServerNotFoundError when no IAS fragment exists."""
         with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_fragment_client"
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
         ) as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = []
 
@@ -276,7 +289,7 @@ class TestGetIasUserFragmentName:
         fragment = MagicMock()
         fragment.name = "sap-managed-runtime-agw-subscriber-ias-user-abc123"
 
-        with patch("sap_cloud_sdk.agentgateway._lob.create_fragment_client") as mock_client:
+        with patch("sap_cloud_sdk.agentgateway._fragments.create_fragment_client") as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = [fragment]
 
             result = get_ias_user_fragment_name("tenant-sub")
@@ -288,7 +301,7 @@ class TestGetIasUserFragmentName:
         fragment = MagicMock()
         fragment.name = "ias-user-fragment"
 
-        with patch("sap_cloud_sdk.agentgateway._lob.create_fragment_client") as mock_client:
+        with patch("sap_cloud_sdk.agentgateway._fragments.create_fragment_client") as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = [fragment]
 
             get_ias_user_fragment_name("tenant-sub")
@@ -302,7 +315,7 @@ class TestGetIasUserFragmentName:
 
     def test_raises_when_no_fragment_found(self):
         """Raise MCPServerNotFoundError when no IAS user fragment exists."""
-        with patch("sap_cloud_sdk.agentgateway._lob.create_fragment_client") as mock_client:
+        with patch("sap_cloud_sdk.agentgateway._fragments.create_fragment_client") as mock_client:
             mock_client.return_value.list_instance_fragments.return_value = []
 
             with pytest.raises(MCPServerNotFoundError, match="No IAS user fragment found"):
@@ -685,3 +698,279 @@ class TestCallMcpToolLob:
             result = await call_mcp_tool_lob(tool, "user-auth-token", 60.0)
 
             assert result == ""
+
+
+# ============================================================
+# Test: list_a2a_fragments
+# ============================================================
+
+
+class TestListA2aFragments:
+    """Tests for list_a2a_fragments function."""
+
+    def test_lists_fragments_with_a2a_label(self):
+        """Return fragments filtered by agw.a2a label."""
+        mock_fragment = MagicMock()
+        mock_fragment.name = "a2a-fragment"
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
+        ) as mock_client:
+            mock_client.return_value.list_instance_fragments.return_value = [mock_fragment]
+            result = list_a2a_fragments("tenant-sub")
+
+        assert result == [mock_fragment]
+        call_kwargs = mock_client.return_value.list_instance_fragments.call_args
+        filter_obj = call_kwargs[1]["filter"]
+        assert filter_obj.filter_labels[0].key == _LABEL_KEY
+        assert _A2A_LABEL_VALUE in filter_obj.filter_labels[0].values
+
+    def test_returns_empty_list_when_no_fragments(self):
+        """Return empty list when no A2A fragments exist."""
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client"
+        ) as mock_client:
+            mock_client.return_value.list_instance_fragments.return_value = []
+            result = list_a2a_fragments("tenant-sub")
+
+        assert result == []
+
+
+# ============================================================
+# Test: _fetch_agent_card
+# ============================================================
+
+
+class TestFetchAgentCard:
+    """Tests for _fetch_agent_card async function."""
+
+    @pytest.mark.asyncio
+    async def test_fetches_agent_card_successfully(self):
+        """Fetch and parse agent card JSON from well-known endpoint."""
+        card_payload = {"name": "TestAgent", "version": "1.0", "capabilities": {}}
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = card_payload
+
+        with patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http:
+            mock_http_instance = AsyncMock()
+            mock_http_instance.get = AsyncMock(return_value=mock_response)
+            mock_http.return_value.__aenter__.return_value = mock_http_instance
+
+            result = await _fetch_agent_card(
+                "https://agw.example.com/v1/a2a/sap.s4:apiAccess:agent:v1/tenant-123",
+                "auth-token",
+                60.0,
+            )
+
+        assert isinstance(result, AgentCard)
+        assert result.raw == card_payload
+        mock_http_instance.get.assert_called_once_with(
+            "https://agw.example.com/v1/a2a/sap.s4:apiAccess:agent:v1/tenant-123/.well-known/agent-card.json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_strips_trailing_slash_from_fragment_url(self):
+        """Strip trailing slash from fragment URL before appending well-known path."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+
+        with patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http:
+            mock_http_instance = AsyncMock()
+            mock_http_instance.get = AsyncMock(return_value=mock_response)
+            mock_http.return_value.__aenter__.return_value = mock_http_instance
+
+            await _fetch_agent_card("https://agw.example.com/base/", "token", 60.0)
+
+        mock_http_instance.get.assert_called_once_with(
+            "https://agw.example.com/base/.well-known/agent-card.json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_on_non_200_status(self):
+        """Raise AgentGatewaySDKError when response status is not 200."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.text = "Not found"
+
+        with patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http:
+            mock_http_instance = AsyncMock()
+            mock_http_instance.get = AsyncMock(return_value=mock_response)
+            mock_http.return_value.__aenter__.return_value = mock_http_instance
+
+            with pytest.raises(AgentGatewaySDKError, match="404"):
+                await _fetch_agent_card("https://agw.example.com/base", "auth-token", 60.0)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_request_error(self):
+        """Raise AgentGatewaySDKError when HTTP request fails."""
+        import httpx
+
+        with patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http:
+            mock_http_instance = AsyncMock()
+            mock_http_instance.get = AsyncMock(
+                side_effect=httpx.RequestError("connection refused")
+            )
+            mock_http.return_value.__aenter__.return_value = mock_http_instance
+
+            with pytest.raises(AgentGatewaySDKError, match="Agent card request failed"):
+                await _fetch_agent_card("https://agw.example.com/base", "auth-token", 60.0)
+
+
+# ============================================================
+# Test: get_agent_cards_lob
+# ============================================================
+
+
+class TestGetAgentCardsLob:
+    """Tests for get_agent_cards_lob async function."""
+
+    def _make_fragment(self, name: str, ord_id: str, url: str) -> MagicMock:
+        fragment = MagicMock()
+        fragment.name = name
+        fragment.properties = {"ordId": ord_id, "URL": url}
+        return fragment
+
+    @pytest.mark.asyncio
+    async def test_returns_agents_for_all_fragments(self):
+        """Return one Agent per A2A fragment with fetched card."""
+        card_payload = {"name": "MyAgent"}
+        fragment = self._make_fragment("frag-1", "sap.s4:agent:v1", "https://agw.example.com/v1/a2a/sap.s4:agent:v1/tenant-abc")
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+                return_value=[fragment],
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_agent_card",
+                new_callable=AsyncMock,
+                return_value=AgentCard(raw=card_payload),
+            ),
+        ):
+            result = await get_agent_cards_lob(
+                "tenant-sub", "system-token", 60.0
+            )
+
+        assert len(result) == 1
+        assert isinstance(result[0], Agent)
+        assert result[0].ord_id == "sap.s4:agent:v1"
+        assert result[0].agent_card.raw == card_payload
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_fragments(self):
+        """Return empty list when no A2A fragments exist."""
+        with patch(
+            "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+            return_value=[],
+        ):
+            result = await get_agent_cards_lob("tenant-sub", "system-token", 60.0)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filters_by_names(self):
+        """Only include fragments whose name is in the names filter."""
+        frag_1 = self._make_fragment("frag-1", "ord-1", "https://agw.example.com/a2a/1/t1")
+        frag_2 = self._make_fragment("frag-2", "ord-2", "https://agw.example.com/a2a/2/t2")
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+                return_value=[frag_1, frag_2],
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_agent_card",
+                new_callable=AsyncMock,
+                return_value=AgentCard(raw={}),
+            ) as mock_fetch,
+        ):
+            result = await get_agent_cards_lob(
+                "tenant-sub", "token", 60.0, names=["frag-1"]
+            )
+
+        assert len(result) == 1
+        assert result[0].ord_id == "ord-1"
+        assert mock_fetch.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_filters_by_ord_ids(self):
+        """Only include fragments whose ordId is in the ord_ids filter."""
+        frag_1 = self._make_fragment("frag-1", "ord-1", "https://agw.example.com/a2a/1/t1")
+        frag_2 = self._make_fragment("frag-2", "ord-2", "https://agw.example.com/a2a/2/t2")
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+                return_value=[frag_1, frag_2],
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_agent_card",
+                new_callable=AsyncMock,
+                return_value=AgentCard(raw={}),
+            ) as mock_fetch,
+        ):
+            result = await get_agent_cards_lob(
+                "tenant-sub", "token", 60.0, ord_ids=["ord-2"]
+            )
+
+        assert len(result) == 1
+        assert result[0].ord_id == "ord-2"
+        assert mock_fetch.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_fragment_missing_ord_id(self):
+        """Skip fragment that has no ordId property."""
+        fragment = MagicMock()
+        fragment.name = "frag-no-ord"
+        fragment.properties = {"URL": "https://agw.example.com/base"}
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+            return_value=[fragment],
+        ):
+            result = await get_agent_cards_lob("tenant-sub", "token", 60.0)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_skips_fragment_missing_url(self):
+        """Skip fragment that has no URL property."""
+        fragment = MagicMock()
+        fragment.name = "frag-no-url"
+        fragment.properties = {"ordId": "ord-1"}
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+            return_value=[fragment],
+        ):
+            result = await get_agent_cards_lob("tenant-sub", "token", 60.0)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_skips_fragment_on_fetch_error(self):
+        """Skip fragment when agent card fetch fails, continue with others."""
+        frag_ok = self._make_fragment("frag-ok", "ord-ok", "https://agw.example.com/ok")
+        frag_err = self._make_fragment("frag-err", "ord-err", "https://agw.example.com/err")
+
+        async def _selective_fetch(fragment_url, token, timeout):
+            if "err" in fragment_url:
+                raise RuntimeError("server unreachable")
+            return AgentCard(raw={"name": "OK"})
+
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.list_a2a_fragments",
+                return_value=[frag_ok, frag_err],
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._lob._fetch_agent_card",
+                side_effect=_selective_fetch,
+            ),
+        ):
+            result = await get_agent_cards_lob("tenant-sub", "token", 60.0)
+
+        assert len(result) == 1
+        assert result[0].ord_id == "ord-ok"

--- a/tests/core/unit/telemetry/test_operation.py
+++ b/tests/core/unit/telemetry/test_operation.py
@@ -211,6 +211,6 @@ class TestOperation:
         """Test that we have the expected number of operations."""
         all_operations = list(Operation)
         # 3 auditlog + 11 destination + 10 certificate + 10 fragment + 8 objectstore
-        # + 2 extensibility + 2 aicore + 23 dms + 4 agentgateway + 13 agent_memory
-        # + 5 data_anonymization + 52 adms + 6 print = 149
-        assert len(all_operations) == 149
+        # + 2 extensibility + 2 aicore + 23 dms + 5 agentgateway + 13 agent_memory
+        # + 5 data_anonymization + 52 adms + 6 print = 150
+        assert len(all_operations) == 150

--- a/uv.lock
+++ b/uv.lock
@@ -3699,7 +3699,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.29.0"
+version = "0.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "grpcio" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Adds A2A agent card discovery to the Agent Gateway module. A new `list_agent_cards()` method on `AgentGatewayClient` discovers destination fragments labelled `agw.a2a.server` and fetches each agent's card from `{fragment_url}/.well-known/agent-card.json`. Results can be filtered by fragment name or ORD ID via the new `AgentCardFilter` dataclass.

This release also extracts all fragment-listing logic into a dedicated `_fragments.py` module, centralising label constants and BTP Destination Service fragment operations that were previously scattered across `_lob.py`.

Changes:

- `_models.py`: new `AgentCard`, `Agent`, and `AgentCardFilter` dataclasses.
- `_fragments.py` (new): centralised fragment discovery — label constants (`LABEL_KEY`, `MCP_LABEL_VALUE`, `IAS_LABEL_VALUE`, `IAS_USER_LABEL_VALUE`, `A2A_LABEL_VALUE`), `list_mcp_fragments`, `list_a2a_fragments`, `get_ias_fragment_name`, `get_ias_user_fragment_name`.
- `_lob.py`: new `_fetch_agent_card` and `get_agent_cards_lob` functions; fragment helpers removed (now in `_fragments.py`).
- `agw_client.py`: new `list_agent_cards(filter: AgentCardFilter | None)` method with telemetry; customer agent path raises `AgentGatewaySDKError` (not yet supported).
- `operation.py`: new `AGENTGATEWAY_LIST_AGENT_CARDS` telemetry operation.
- `user-guide.md`: new A2A Agent Cards section, Fragments and Labels table, updated API reference.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Code refactoring
- [ ] Dependency update

## How to Test

1. Create a LoB agent client:
   ```python
   from sap_cloud_sdk.agentgateway import create_client
   agw_client = create_client(tenant_subdomain="my-tenant")
   ```
2. Call `agents = await agw_client.list_agent_cards()` — should return one `Agent` per A2A fragment (label `agw.a2a.server`).
3. Verify each `agent.ord_id` matches the `ordId` property on the fragment and `agent.agent_card.raw` contains the parsed JSON from `{fragment_url}/.well-known/agent-card.json`.
4. Call with a filter:
   ```python
   from sap_cloud_sdk.agentgateway import AgentCardFilter
   agents = await agw_client.list_agent_cards(
       filter=AgentCardFilter(names=["my-fragment"], ord_ids=["sap.s4:apiAccess:agent:v1"])
   )
   ```
   Only matching fragments should be returned.
5. Call from a customer agent environment (credentials file present) — should raise `AgentGatewaySDKError` with "not yet supported for customer agents".
6. Run unit tests:
   ```bash
   uv run pytest tests/agentgateway/unit/ -q
   ```
   Expected: all 89 tests pass.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

- `list_agent_cards` is currently LoB-only. Customer agent support is tracked with a TODO in `agw_client.py` and will be added in a follow-up.
- `_fragments.py` is internal (`_`-prefixed) and not part of the public API. All functions previously accessible via `_lob` continue to work as before.
- `AgentCardFilter` uses AND semantics when both `names` and `ord_ids` are set. Empty lists behave the same as `None` (no filtering on that field).
- Each A2A fragment must have `URL` (base URL) and `ordId` properties. Fragments missing either are skipped with a warning log.
