### PR TITLE
fix(agentgateway): log correlation-id on mcp tool call failure

### DIFF
--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -584,7 +584,7 @@ async def call_mcp_tool_customer(
                     first = result.content[0]
                     return str(getattr(first, "text", ""))
     except Exception:
-        logger.error(
+        logger.exception(
             "MCP tool call failed for '%s' (x-correlation-id: %s)",
             tool.name,
             correlation_id or "unknown",

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -551,26 +551,42 @@ async def call_mcp_tool_customer(
         Tool execution result as string.
     """
     logger.info("Calling tool '%s' on server '%s'", tool.name, tool.server_name)
+    correlation_id: str | None = None
 
-    async with httpx.AsyncClient(
-        headers={
-            "Authorization": f"Bearer {auth_token}",
-            "x-correlation-id": str(uuid.uuid4()),
-        },
-        timeout=timeout,
-    ) as http_client:
-        async with streamable_http_client(tool.url, http_client=http_client) as (
-            read,
-            write,
-            _,
-        ):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(tool.name, kwargs)
+    async def _capture_correlation_id(response: httpx.Response) -> None:
+        nonlocal correlation_id
+        cid = response.headers.get("x-correlation-id")
+        if cid:
+            correlation_id = cid
 
-                if not result.content:
-                    logger.warning("Tool '%s' returned empty content", tool.name)
-                    return ""
+    try:
+        async with httpx.AsyncClient(
+            headers={
+                "Authorization": f"Bearer {auth_token}",
+                "x-correlation-id": str(uuid.uuid4()),
+            },
+            timeout=timeout,
+            event_hooks={"response": [_capture_correlation_id]},
+        ) as http_client:
+            async with streamable_http_client(tool.url, http_client=http_client) as (
+                read,
+                write,
+                _,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool.name, kwargs)
 
-                first = result.content[0]
-                return str(getattr(first, "text", ""))
+                    if not result.content:
+                        logger.warning("Tool '%s' returned empty content", tool.name)
+                        return ""
+
+                    first = result.content[0]
+                    return str(getattr(first, "text", ""))
+    except Exception:
+        logger.error(
+            "MCP tool call failed for '%s' (x-correlation-id: %s)",
+            tool.name,
+            correlation_id or "unknown",
+        )
+        raise

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -383,26 +383,43 @@ async def call_mcp_tool_lob(
     Returns:
         Tool execution result as string.
     """
-    async with httpx.AsyncClient(
-        headers={
-            "Authorization": f"Bearer {user_auth_token}",
-            "x-correlation-id": str(uuid.uuid4()),
-        },
-        timeout=timeout,
-    ) as http_client:
-        async with streamable_http_client(tool.url, http_client=http_client) as (
-            read,
-            write,
-            _,
-        ):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                result = await session.call_tool(tool.name, kwargs)
-                if not result.content:
-                    logger.warning("Tool '%s' returned empty content", tool.name)
-                    return ""
-                first = result.content[0]
-                return str(getattr(first, "text", ""))
+    correlation_id: str | None = None
+
+    async def _capture_correlation_id(response: httpx.Response) -> None:
+        nonlocal correlation_id
+        cid = response.headers.get("x-correlation-id")
+        if cid:
+            correlation_id = cid
+
+    try:
+        async with httpx.AsyncClient(
+            headers={
+                "Authorization": f"Bearer {user_auth_token}",
+                "x-correlation-id": str(uuid.uuid4()),
+            },
+            timeout=timeout,
+            event_hooks={"response": [_capture_correlation_id]},
+        ) as http_client:
+            async with streamable_http_client(tool.url, http_client=http_client) as (
+                read,
+                write,
+                _,
+            ):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool.name, kwargs)
+                    if not result.content:
+                        logger.warning("Tool '%s' returned empty content", tool.name)
+                        return ""
+                    first = result.content[0]
+                    return str(getattr(first, "text", ""))
+    except Exception:
+        logger.error(
+            "MCP tool call failed for '%s' (x-correlation-id: %s)",
+            tool.name,
+            correlation_id or "unknown",
+        )
+        raise
 
 
 async def _fetch_agent_card(


### PR DESCRIPTION
## Description

Log the x-correlation-id from AGW response headers when an MCP tool call fails, so users can search AGW logs for debugging. The correlation-id is captured via httpx event hooks in both the LoB and Customer agent flows.

## Related Issue

Closes #195

[Link to the issue](https://github.com/SAP/cloud-sdk-python/issues/195)

## Type of Change

Please check the relevant option:

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

Describe how reviewers can test your changes:

1. Configure an AGW client (LoB or Customer)
2. Call an MCP tool that fails (e.g., invalid parameters, server error)
3. Check logs for: MCP tool call failed for '<tool-name>' (x-correlation-id: <uuid>)

## Checklist

Before submitting your PR, please review and check the following:

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
