### PR TITLE
docs(aicore): correct content filtering enabled-by-default version to 0.32.0

### DIFF
--- a/src/sap_cloud_sdk/aicore/user-guide.md
+++ b/src/sap_cloud_sdk/aicore/user-guide.md
@@ -228,7 +228,7 @@ rejections. All other exceptions surface unchanged.
 ### Migration from prior versions
 
 If your agent previously imported from `sap_cloud_sdk.orchestration` (an
-in-flight name during 0.28 development) or used the keyword form
+in-flight name during 0.32 development) or used the keyword form
 `set_filtering(hate=...)`, update to:
 
 ```python

--- a/src/sap_cloud_sdk/aicore/user-guide.md
+++ b/src/sap_cloud_sdk/aicore/user-guide.md
@@ -56,11 +56,11 @@ The `set_aicore_config()` function:
 2. **Configures environment variables** for LiteLLM to use AI Core
 3. **Normalizes URLs** by adding required suffixes (`/oauth/token` for auth, `/v2` for base URL)
 4. **Sets resource group** (defaults to "default" if not specified)
-5. **Activates content filtering** — Azure Content Safety + prompt shield enabled by default *(new in 0.28.0)*
+5. **Activates content filtering** — Azure Content Safety + prompt shield enabled by default *(new in 0.32.0)*
 
 ---
 
-## Content Filtering (enabled by default from 0.28.0)
+## Content Filtering (enabled by default from 0.32.0)
 
 `set_aicore_config()` automatically activates content filtering for all `sap/*`
 model calls. No additional code is required. Filtering applies Azure Content


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Corrects three version references in the AI Core user guide that incorrectly stated `0.28` in relation to content filtering and the `orchestration` namespace. All three were introduced in `v0.32.0` (commit `6c042e1`).

**Changes:**
- Line 59: `*(new in 0.28.0)*` → `*(new in 0.32.0)*`
- Line 63: `## Content Filtering (enabled by default from 0.28.0)` → `## Content Filtering (enabled by default from 0.32.0)`
- Line 231: `in-flight name during 0.28 development` → `in-flight name during 0.32 development`

At v0.28.0, the user guide had no filtering section at all — the feature, the `orchestration` namespace, and the migration note were all introduced together in v0.32.0.

## Related Issue

N/A — documentation correction only.

## Type of Change

- [x] Documentation update

## How to Test

1. Open `src/sap_cloud_sdk/aicore/user-guide.md`
2. Verify lines 59, 63, and 231 all reference `0.32` (not `0.28`)

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages
- [x] My code does not contain sensitive information (credentials, tokens, etc.)

## Additional Notes

No Python source files were changed, so no version bump is required.