### PR TITLE
test(destination): skip flaky http client test on non-2xx echo response

### DIFF
--- a/tests/destination/integration/test_destination_bdd.py
+++ b/tests/destination/integration/test_destination_bdd.py
@@ -1615,10 +1615,15 @@ def send_get_request(context, path):
     import requests
     try:
         context.http_response = context.http_client.request("GET", path)
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
         pytest.skip(f"External endpoint unreachable — skipping: {e}")
-    except requests.exceptions.Timeout as e:
-        pytest.skip(f"External endpoint timed out — skipping: {e}")
+
+    # skip if the echo service itself returned an error
+    if not context.http_response.ok:
+        pytest.skip(
+            f"External endpoint returned {context.http_response.status_code}: "
+            f"{context.http_response.text[:200]}"
+        )
 
 
 @then("the response contains an Authorization header")


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Fixes a flaky destination integration test (`test_destinationhttpclient_sends_an_authenticated_request_using_token_fetched_from_btp`) that occasionally failed with `JSONDecodeError` because the test called `response.json()` on the reply from `httpbin.org`, but httpbin sometimes returned a non-JSON error body (CDN 502/503 HTML, rate-limit page)

The fix adds a `response.ok` check after the request: if the echo service returned a non-2xx status, `pytest.skip` with the status code and a body preview

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. uv run pytest tests/destination/integration -v

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes — N/A, this is
      itself a test-only change
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable) — N/A
- [x] I have added type hints for all public APIs — N/A (test code)
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None

## Additional Notes

None
