### PR TITLE
fix(agentgateway): remove telemetry source attribution from _lob.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.35.0"
+version = "0.35.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -18,8 +18,6 @@ from sap_cloud_sdk.destination import (
     ConsumptionLevel,
     ConsumptionOptions,
 )
-from sap_cloud_sdk.core.telemetry import Module
-
 from sap_cloud_sdk.agentgateway._fragments import (
     LABEL_KEY,
     FragmentLabel,
@@ -89,10 +87,7 @@ def _fetch_auth_token(
     Raises:
         MCPServerNotFoundError: If no auth token is returned.
     """
-    client = create_destination_client(
-        instance=_DESTINATION_INSTANCE,
-        _telemetry_source=Module.AGENTGATEWAY,
-    )
+    client = create_destination_client(instance=_DESTINATION_INSTANCE)
     dest = client.get_destination(
         dest_name,
         level=ConsumptionLevel.PROVIDER_SUBACCOUNT,
@@ -134,10 +129,7 @@ def get_ias_client_id_lob() -> str:
         Any exception raised by the destination client.
     """
     dest_name = _ias_dest_name()
-    client = create_destination_client(
-        instance=_DESTINATION_INSTANCE,
-        _telemetry_source=Module.AGENTGATEWAY,
-    )
+    client = create_destination_client(instance=_DESTINATION_INSTANCE)
     dest = client.get_destination(
         dest_name,
         level=ConsumptionLevel.PROVIDER_SUBACCOUNT,


### PR DESCRIPTION
## Summary

Requested by @smahr (PR #220) to remove telemetry source attribution from `_lob.py` specifically, so that internal destination calls made by the LoB auth helpers are not counted as cross-module traffic from `AGENTGATEWAY` in observability dashboards.

**What changes:**
- Remove `_telemetry_source=Module.AGENTGATEWAY` from `create_destination_client()` in `_fetch_auth_token` and `get_ias_client_id_lob`
- Drop the now-unused `from sap_cloud_sdk.core.telemetry import Module` import
- Bump version to `0.35.1`

**Why:**
Without `_telemetry_source`, `record_metrics` treats these calls as user-facing (`source=None`) rather than internal SDK plumbing. The intent is that the auth/IAS resolution steps in the LoB flow should not show up as `AGENTGATEWAY → DESTINATION` cross-module metrics — they are transparent infrastructure calls on behalf of the consumer.

**Scope intentionally limited to `_lob.py`:**
`_fragments.py` retains `_telemetry_source=Module.AGENTGATEWAY` on `create_fragment_client()` — fragment discovery is a distinct step and that attribution is considered correct. Aligning `_fragments.py` is out of scope for this PR.

## Test plan

- [ ] Verify `_fetch_auth_token` still resolves auth tokens correctly
- [ ] Verify `get_ias_client_id_lob` still returns the client ID correctly
- [ ] Confirm telemetry metrics for these paths no longer show `source=AGENTGATEWAY`