### PR TITLE
fix(agentgateway): address sdk-review quality findings from PR #220

### DIFF
--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -59,6 +59,10 @@ _AGW_RESOURCE_URN = "urn:sap:identity:application:provider:name:agent-gateway"
 _GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials"
 _GRANT_TYPE_JWT_BEARER = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
+# Token response field keys
+_TOKEN_FIELD_CLIENT_ID = "client_id"
+_TOKEN_FIELD_ACCESS_TOKEN = "access_token"
+
 
 def _cache_scope_key(credentials: CustomerCredentials) -> str:
     """Build a cache scope key for customer-flow tokens."""
@@ -324,7 +328,7 @@ def _request_token_mtls(
     ssl_context = _create_ssl_context(credentials.certificate, credentials.private_key)
 
     data = {
-        "client_id": credentials.client_id,
+        _TOKEN_FIELD_CLIENT_ID: credentials.client_id,
         "grant_type": grant_type,
         "resource": _AGW_RESOURCE_URN,
     }
@@ -363,7 +367,7 @@ def _request_token_mtls(
             )
 
         token_data = response.json()
-        access_token = token_data.get("access_token")
+        access_token = token_data.get(_TOKEN_FIELD_ACCESS_TOKEN)
 
         if not access_token:
             raise AgentGatewaySDKError(
@@ -374,7 +378,7 @@ def _request_token_mtls(
         return token_data
 
     except httpx.RequestError as e:
-        raise AgentGatewaySDKError(f"Token request failed: {e}")
+        raise AgentGatewaySDKError(f"Token request failed: {e}") from e
 
 
 def _request_token_transparent(
@@ -401,7 +405,7 @@ def _request_token_transparent(
         AgentGatewaySDKError: If token request fails.
     """
     data = {
-        "client_id": credentials.client_id,
+        _TOKEN_FIELD_CLIENT_ID: credentials.client_id,
         "grant_type": grant_type,
         "resource": _AGW_RESOURCE_URN,
     }
@@ -437,7 +441,7 @@ def _request_token_transparent(
             )
 
         token_data = response.json()
-        access_token = token_data.get("access_token")
+        access_token = token_data.get(_TOKEN_FIELD_ACCESS_TOKEN)
 
         if not access_token:
             raise AgentGatewaySDKError(
@@ -448,7 +452,7 @@ def _request_token_transparent(
         return token_data
 
     except httpx.RequestError as e:
-        raise AgentGatewaySDKError(f"Token request failed: {e}")
+        raise AgentGatewaySDKError(f"Token request failed: {e}") from e
 
 
 def get_system_token_mtls(
@@ -499,7 +503,7 @@ def get_system_token_mtls(
             extra_data={"response_type": "token"},
         )
 
-    access_token = token_data["access_token"]
+    access_token = token_data[_TOKEN_FIELD_ACCESS_TOKEN]
 
     if token_cache:
         token_cache.set_system_token(
@@ -571,7 +575,7 @@ def exchange_user_token(
             },
         )
 
-    access_token = token_data["access_token"]
+    access_token = token_data[_TOKEN_FIELD_ACCESS_TOKEN]
 
     if token_cache:
         token_cache.set_user_token(

--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -151,7 +151,7 @@ def load_customer_credentials_from_env(
 
     # Check required environment variables
     required_vars = {
-        _INTEGRATION_CLIENT_ID_ENV: "client_id",
+        _INTEGRATION_CLIENT_ID_ENV: _TOKEN_FIELD_CLIENT_ID,
         _INTEGRATION_AUTH_URL_ENV: "auth_url",
         _INTEGRATION_GATEWAY_URL_ENV: "gateway_url",
     }
@@ -204,7 +204,7 @@ def load_customer_credentials(path: str) -> CustomerCredentials:
     # Credential file uses camelCase, we use snake_case
     required_fields = {
         _CredentialFields.TOKEN_SERVICE_URL: "token_service_url",
-        _CredentialFields.CLIENT_ID: "client_id",
+        _CredentialFields.CLIENT_ID: _TOKEN_FIELD_CLIENT_ID,
         _CredentialFields.CERTIFICATE: "certificate",
         _CredentialFields.PRIVATE_KEY: "private_key",
         _CredentialFields.GATEWAY_URL: "gateway_url",

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -42,6 +42,8 @@ from sap_cloud_sdk.core._telemetry_compat import Module, Operation, record_metri
 
 logger = logging.getLogger(__name__)
 
+_LOG_TRANSPARENT_MODE = "Transparent mode credentials detected"
+
 
 class AgentGatewayClient:
     """Client for discovering and invoking MCP tools via SAP Agent Gateway.
@@ -197,7 +199,7 @@ class AgentGatewayClient:
 
             # Check for transparent mode
             if detect_transparent_credentials():
-                logger.info("Transparent mode credentials detected")
+                logger.info(_LOG_TRANSPARENT_MODE)
                 credentials = load_customer_credentials_from_env()
                 loop = asyncio.get_running_loop()
                 token = await loop.run_in_executor(
@@ -283,7 +285,7 @@ class AgentGatewayClient:
 
             # Check for transparent mode
             if detect_transparent_credentials():
-                logger.info("Transparent mode credentials detected")
+                logger.info(_LOG_TRANSPARENT_MODE)
                 credentials = load_customer_credentials_from_env()
                 loop = asyncio.get_running_loop()
                 token = await loop.run_in_executor(
@@ -406,7 +408,7 @@ class AgentGatewayClient:
 
             # Check for transparent mode
             if detect_transparent_credentials():
-                logger.info("Transparent mode credentials detected")
+                logger.info(_LOG_TRANSPARENT_MODE)
                 credentials = load_customer_credentials_from_env()
                 return await get_mcp_tools_customer(
                     credentials, auth.access_token, self._config.timeout
@@ -560,7 +562,7 @@ class AgentGatewayClient:
 
             # Check for transparent mode
             if detect_transparent_credentials():
-                logger.debug("Transparent mode credentials detected")
+                logger.debug(_LOG_TRANSPARENT_MODE)
 
                 return await call_mcp_tool_customer(
                     tool, auth.access_token, self._config.timeout, **kwargs

--- a/src/sap_cloud_sdk/core/_telemetry_compat.py
+++ b/src/sap_cloud_sdk/core/_telemetry_compat.py
@@ -4,18 +4,22 @@ This module provides a centralized way to handle optional telemetry dependencies
 When telemetry packages are not installed, it provides no-op implementations.
 """
 
+from typing import Any, Callable, TypeVar
+
+_F = TypeVar("_F", bound=Callable[..., Any])
+
 try:
     from sap_cloud_sdk.core.telemetry import Module, Operation, record_metrics
     TELEMETRY_AVAILABLE = True
 except ImportError:
+    # Telemetry packages not installed — provide no-op implementations
     TELEMETRY_AVAILABLE = False
-    # Provide no-op implementations when telemetry is not available
     Module = None  # type: ignore
     Operation = None  # type: ignore
 
-    def record_metrics(*args, **kwargs):  # type: ignore
+    def record_metrics(*args: Any, **kwargs: Any) -> Any:  # type: ignore
         """No-op decorator when telemetry is not available."""
-        def decorator(func):
+        def decorator(func: _F) -> _F:
             return func
         if args and callable(args[0]):
             # Called without parentheses: @record_metrics


### PR DESCRIPTION
## Summary

Quality improvements surfaced by sdk-review on the code introduced in PR #220 (Transparent TLS + ServiceBinding Envelope Support by @smahr). This PR is intended to be reviewed alongside #220 and merged after it.

**Changes (no functional impact):**

### `_customer.py`
- Extract `_TOKEN_FIELD_CLIENT_ID = "client_id"` and `_TOKEN_FIELD_ACCESS_TOKEN = "access_token"` as module-level constants — eliminates repeated string literals (PY-CON-01)
- Replace all bare `"client_id"` and `"access_token"` occurrences (token request payload, token response parsing, field mappings) with the constants
- Add `from e` to `raise AgentGatewaySDKError(...)` inside `except httpx.RequestError` blocks to preserve exception cause chain (PY-EL-01)

### `agw_client.py`
- Extract `_LOG_TRANSPARENT_MODE = "Transparent mode credentials detected"` constant — eliminates 4× repeated log string (PY-CON-01)

### `core/_telemetry_compat.py`
- Add `TypeVar` + type annotations to `record_metrics` and inner `decorator` functions (PY-PT-08)
- Add explicit comment justifying `except ImportError` suppression — this is an intentional optional-dependency shim; re-raising would break the no-op fallback for Kyma deployments without telemetry (PY-EL-02)

## Depends on

- PR #220 — merge that first

## Test plan

- [ ] All existing tests pass unchanged
- [ ] No import errors on module load with or without telemetry packages installed