### PR TITLE
feat(aicore): clear AICORE_CLIENT_SECRET after token acquisition (AFSDK-4291)

### DIFF
--- a/src/sap_cloud_sdk/aicore/completion.py
+++ b/src/sap_cloud_sdk/aicore/completion.py
@@ -14,15 +14,20 @@ wrappers fix it by catching the wrapped exception inside the SDK and
 re-raising as :class:`ContentFilteredError` so callers can rely on a
 single exception type for "filter blocked you."
 
-Credential rotation handling
-----------------------------
-When a credential (client_secret) is rotated while the pod is running,
-LiteLLM's cached token becomes invalid and the next token refresh attempt
-raises ``litellm.AuthenticationError``. The wrappers intercept this error,
-reload credentials from the mounted secret volume via
-:func:`sap_cloud_sdk.aicore.set_aicore_config`, and retry the call once.
-The caller is unaffected — rotation is transparent. If the retry also
-fails, the ``AuthenticationError`` propagates normally.
+Credential handling
+-------------------
+CLIENT_SECRET minimisation (AFSDK-4291):
+After the first successful LiteLLM call, ``AICORE_CLIENT_SECRET`` is removed
+from ``os.environ``. LiteLLM has already captured the secret inside its token
+creator closure at that point and no longer needs the env var. This minimises
+the window of exposure to child processes and container introspection.
+
+Credential rotation (reactive reload):
+When a credential is rotated while the pod is running, LiteLLM's cached token
+becomes invalid and the next token refresh raises ``litellm.AuthenticationError``.
+The wrappers intercept this, reload credentials from the mounted secret volume
+via :func:`sap_cloud_sdk.aicore.set_aicore_config`, and retry once. The secret
+is cleared again after the retry succeeds.
 
 Usage::
 
@@ -50,6 +55,8 @@ adoption of the SDK.
 from __future__ import annotations
 
 import logging
+import os
+import threading
 from typing import Any
 
 import litellm
@@ -57,6 +64,53 @@ import litellm
 from .filtering.filters import _parse_input_filter_error
 
 logger = logging.getLogger(__name__)
+
+# Tracks whether AICORE_CLIENT_SECRET has already been cleared after the first
+# successful LiteLLM call. Reset when credentials are reloaded so the secret
+# is cleared again after the retry succeeds.
+_secret_lock = threading.Lock()
+_secret_cleared = False
+
+
+def _clear_client_secret() -> None:
+    """Remove AICORE_CLIENT_SECRET from env after LiteLLM has cached the token.
+
+    Safe to call multiple times — subsequent calls are no-ops once cleared.
+    No-op in transparent TLS mode (secret was never written).
+    """
+    global _secret_cleared
+    with _secret_lock:
+        if not _secret_cleared:
+            if os.environ.pop("AICORE_CLIENT_SECRET", None) is not None:
+                logger.info(
+                    "AICORE_CLIENT_SECRET cleared from environment "
+                    "after token acquisition (AFSDK-4291)"
+                )
+            _secret_cleared = True
+
+
+def _reset_secret_cleared() -> None:
+    """Allow _clear_client_secret() to fire again after a credential reload."""
+    global _secret_cleared
+    with _secret_lock:
+        _secret_cleared = False
+
+
+def reload_aicore_credentials() -> None:
+    """Re-read AI Core credentials from the mounted secret volume.
+
+    Called automatically by :func:`completion` and :func:`acompletion` when
+    LiteLLM raises ``AuthenticationError`` — covers credential rotation
+    without requiring a pod restart.
+
+    Safe to call manually if the application needs to force a reload.
+    """
+    # Local import avoids circular dep: completion ← __init__ ← completion
+    from sap_cloud_sdk.aicore import set_aicore_config
+
+    _reset_secret_cleared()
+    logger.info("AI Core credentials reloading after authentication failure")
+    set_aicore_config()
 
 
 def _maybe_translate_filter_error(exc: BaseException) -> BaseException:
@@ -76,19 +130,23 @@ def completion(*args: Any, **kwargs: Any) -> Any:
     """Wrapper around :func:`litellm.completion` that normalises filter errors
     and handles credential rotation transparently.
 
+    After the first successful call, ``AICORE_CLIENT_SECRET`` is removed from
+    ``os.environ`` — LiteLLM has captured it in its token creator closure and
+    no longer needs the env var (AFSDK-4291).
+
     On ``AuthenticationError`` (e.g. rotated client_secret), reloads
     credentials from the mounted secret volume and retries once.
     All other exceptions surface verbatim after the filter-error translation.
     """
     try:
-        return litellm.completion(*args, **kwargs)
+        result = litellm.completion(*args, **kwargs)
+        _clear_client_secret()
+        return result
     except litellm.AuthenticationError:
-        # Local import avoids circular dep: completion ← __init__ ← completion
-        from sap_cloud_sdk.aicore import set_aicore_config
-
-        logger.info("AI Core credentials reloading after authentication failure")
-        set_aicore_config()
-        return litellm.completion(*args, **kwargs)
+        reload_aicore_credentials()
+        result = litellm.completion(*args, **kwargs)
+        _clear_client_secret()
+        return result
     except Exception as exc:
         translated = _maybe_translate_filter_error(exc)
         if translated is exc:
@@ -99,16 +157,17 @@ def completion(*args: Any, **kwargs: Any) -> Any:
 async def acompletion(*args: Any, **kwargs: Any) -> Any:
     """Async wrapper around :func:`litellm.acompletion`.
 
-    Same translation and credential-rotation semantics as :func:`completion`.
+    Same credential-minimisation and rotation semantics as :func:`completion`.
     """
     try:
-        return await litellm.acompletion(*args, **kwargs)
+        result = await litellm.acompletion(*args, **kwargs)
+        _clear_client_secret()
+        return result
     except litellm.AuthenticationError:
-        from sap_cloud_sdk.aicore import set_aicore_config
-
-        logger.info("AI Core credentials reloading after authentication failure")
-        set_aicore_config()
-        return await litellm.acompletion(*args, **kwargs)
+        reload_aicore_credentials()
+        result = await litellm.acompletion(*args, **kwargs)
+        _clear_client_secret()
+        return result
     except Exception as exc:
         translated = _maybe_translate_filter_error(exc)
         if translated is exc:

--- a/tests/aicore/unit/test_completion.py
+++ b/tests/aicore/unit/test_completion.py
@@ -23,12 +23,18 @@ from __future__ import annotations
 
 import asyncio
 import json
-from unittest.mock import MagicMock, call, patch
+import os
+from unittest.mock import MagicMock, patch
 
 import litellm
 import pytest
 
 from sap_cloud_sdk.aicore import acompletion, completion
+from sap_cloud_sdk.aicore.completion import (
+    reload_aicore_credentials,
+    _clear_client_secret,
+    _reset_secret_cleared,
+)
 from sap_cloud_sdk.aicore.filtering.exceptions import ContentFilteredError
 
 
@@ -202,8 +208,130 @@ class TestACompletionWrapper:
         assert ei.value is raised
 
 
+
+
 # ---------------------------------------------------------------------------
-# Reactive reload on AuthenticationError — sync
+# reload_aicore_credentials()
+# ---------------------------------------------------------------------------
+
+
+class TestReloadAICoreCredentials:
+    def test_calls_set_aicore_config(self):
+        with patch("sap_cloud_sdk.aicore.set_aicore_config") as mock_config:
+            reload_aicore_credentials()
+        mock_config.assert_called_once_with()
+
+    def test_resets_secret_cleared_flag(self):
+        """After reload, _clear_client_secret() must be able to clear the secret again."""
+        # Simulate: secret was cleared once already
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "old"}):
+            _clear_client_secret()
+        # Flag is now True — a second clear would be a no-op
+        with patch("sap_cloud_sdk.aicore.set_aicore_config"):
+            reload_aicore_credentials()
+        # After reload the flag is reset — clearing works again
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "new"}):
+            _clear_client_secret()
+            assert "AICORE_CLIENT_SECRET" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# CLIENT_SECRET minimisation — _clear_client_secret()
+# ---------------------------------------------------------------------------
+
+
+class TestClearClientSecret:
+    def setup_method(self):
+        _reset_secret_cleared()
+
+    def test_removes_secret_from_env(self):
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}):
+            _clear_client_secret()
+            assert "AICORE_CLIENT_SECRET" not in os.environ
+
+    def test_noop_when_secret_absent(self):
+        env = {}
+        with patch.dict("os.environ", env, clear=True):
+            _clear_client_secret()  # must not raise
+
+    def test_idempotent_second_call_is_noop(self):
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}):
+            _clear_client_secret()
+            os.environ["AICORE_CLIENT_SECRET"] = "restored"
+            _clear_client_secret()
+            # second call must not remove the restored value
+            assert os.environ.get("AICORE_CLIENT_SECRET") == "restored"
+
+    def test_reset_allows_clear_again(self):
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}):
+            _clear_client_secret()
+            _reset_secret_cleared()
+            os.environ["AICORE_CLIENT_SECRET"] = "new-secret"
+            _clear_client_secret()
+            assert "AICORE_CLIENT_SECRET" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# completion() clears secret on success
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionClearsSecret:
+    def setup_method(self):
+        _reset_secret_cleared()
+
+    def test_secret_cleared_after_successful_call(self):
+        sentinel = object()
+        with (
+            patch("sap_cloud_sdk.aicore.completion.litellm.completion", return_value=sentinel),
+            patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}),
+        ):
+            result = completion(model="sap/x", messages=[])
+        assert result is sentinel
+        assert "AICORE_CLIENT_SECRET" not in os.environ
+
+    def test_secret_not_cleared_on_filter_error(self):
+        """Filter errors are not successful calls — secret stays until next success."""
+        from sap_cloud_sdk.aicore.filtering.exceptions import ContentFilteredError
+        raised = ContentFilteredError(direction="input", details={}, request_id="r")
+        secret_present_after = {}
+        with patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}):
+            with pytest.raises(ContentFilteredError):
+                with patch(
+                    "sap_cloud_sdk.aicore.completion.litellm.completion",
+                    side_effect=raised,
+                ):
+                    completion(model="sap/x", messages=[])
+            secret_present_after["value"] = os.environ.get("AICORE_CLIENT_SECRET")
+        assert secret_present_after["value"] == "s3cr3t"
+
+    def test_secret_cleared_after_auth_error_and_retry(self):
+        """After reload + successful retry, secret must be cleared."""
+        sentinel = object()
+        auth_err = litellm.AuthenticationError(
+            message="401", llm_provider="sap", model="sap/x"
+        )
+        call_returns = [auth_err, sentinel]
+
+        def fake_completion(*args, **kwargs):
+            result = call_returns.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        with (
+            patch("sap_cloud_sdk.aicore.completion.litellm.completion", side_effect=fake_completion),
+            patch("sap_cloud_sdk.aicore.set_aicore_config"),
+            patch.dict("os.environ", {"AICORE_CLIENT_SECRET": "s3cr3t"}),
+        ):
+            result = completion(model="sap/x", messages=[])
+
+        assert result is sentinel
+        assert "AICORE_CLIENT_SECRET" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/aicore/unit/test_credential_rotation_flow.py
+++ b/tests/aicore/unit/test_credential_rotation_flow.py
@@ -140,6 +140,7 @@ class TestReactive401UpdatesEnv:
         with (
             patch("sap_cloud_sdk.aicore.completion.litellm.completion", side_effect=_fake_completion),
             patch("sap_cloud_sdk.aicore.set_filtering"),
+            patch("sap_cloud_sdk.aicore.completion._clear_client_secret"),
         ):
             result = completion(model="sap/x", messages=[])
 


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

**Stacked on #256** — merge that PR first, then retarget this one to `main`.

> **Tracking:** AFSDK-4413 / HASI2026203 (CVE 9.9)

After the first successful `litellm.completion()` / `litellm.acompletion()` call, `AICORE_CLIENT_SECRET` is removed from `os.environ`. At that point LiteLLM has already captured the secret inside its token creator closure and no longer reads it from the environment. Removing it minimises the window of exposure to child processes and container introspection APIs.

### Behaviour details

- **When:** after the first call that returns without `AuthenticationError`
- **Idempotent:** subsequent calls are no-ops once the secret is cleared
- **Rotation-safe:** `reload_aicore_credentials()` (from #256) resets the internal flag before re-calling `set_aicore_config()`, so the secret is written back temporarily and cleared again after the retry succeeds
- **Destination mode (PR #271):** compatible — the secret is written by `_configure_destination_mode()` and cleared after the first call; the deployer never needs to inject it into the K8s Secret

---

## ⚠️ BREAKING CHANGE

**`AICORE_CLIENT_SECRET` is removed from `os.environ` after the first successful completion call.**

Code that reads `os.environ["AICORE_CLIENT_SECRET"]` **after** calling `completion()` or `acompletion()` will receive a `KeyError` (or empty string via `.get()`).

**Affected pattern:**
```python
set_aicore_config()
completion(...)                              # secret cleared here
secret = os.environ["AICORE_CLIENT_SECRET"]  # ❌ KeyError after this PR
```

**Known affected agents — migration required before this PR merges:**

| Agent | File | Pattern |
|-------|------|---------|
| PMDRA / skills agent | `PMDRA/skills_agent.py` | reads `AICORE_CLIENT_SECRET` from env post-`completion()` |
| Billing anomaly agent | `billing-anomaly/_credentials.py` | reads `AICORE_CLIENT_SECRET` from env post-`completion()` |
| Finance agent | file path TBD (scan in progress) | manual AI Core credential rewrite, bypasses SDK |

Issues have been opened in the respective repos with the migration path below. This PR stays draft until all three confirm migration or provide a timeline.

**Migration path:**

Remove any code that reads `AICORE_CLIENT_SECRET` directly from `os.environ` after `set_aicore_config()` / `completion()`. The secret is an implementation detail of the LiteLLM integration — application code should not depend on it.

```python
# Before (breaks after this PR)
set_aicore_config()
response = completion(model="sap/gpt-4o", messages=[...])
secret = os.environ["AICORE_CLIENT_SECRET"]  # ❌

# After (correct pattern)
set_aicore_config()
response = completion(model="sap/gpt-4o", messages=[...])
# Do not read AICORE_CLIENT_SECRET — let the SDK manage it
```

If the secret is needed for a purpose outside LiteLLM (e.g. a separate HTTP call), read it directly from the mounted secret volume at `/etc/secrets/appfnd/aicore/<instance>/clientsecret` before calling `set_aicore_config()`.

---

## Related Issues

- AFSDK-4413 — clear client_secret BLI
- HASI2026203 (CVE 9.9 — internal tracking)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

```bash
python -m pytest tests/aicore/unit/ -v
# Expected: 73 passed
```

Manual verification:
1. Call `set_aicore_config()` followed by a successful `completion()` call
2. Assert `os.environ.get("AICORE_CLIENT_SECRET")` is `None`
3. Make a second `completion()` call — verify it succeeds (LiteLLM uses its cached token)
4. Simulate credential rotation: secret file updated, next call triggers `AuthenticationError`
5. Verify `completion()` recovers: reloads credentials, clears secret again after retry

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

This is the second in a series of stacked PRs addressing credential exposure in the `aicore` module:

1. **#256** — reactive reload on `AuthenticationError` + proactive watcher (`watch_aicore_config`)
2. **This PR** — clear `CLIENT_SECRET` from env after token acquisition
3. **#271** — Option 3: proxy routing + BTP Destination Service mode

When #256 is merged to `main`, this PR should be retargeted from `feat/aicore-transparent-tls` to `main` before merging.