### PR TITLE
Add listing of sanatized integrations.

### DIFF
--- a/src/sap_cloud_sdk/agentgateway/_fragments.py
+++ b/src/sap_cloud_sdk/agentgateway/_fragments.py
@@ -4,10 +4,12 @@ Centralises all BTP Destination Service fragment operations:
 - Label constants for managed-runtime fragment types
 - Fragment listing by label (MCP, A2A, IAS)
 - IAS fragment name lookup for auth flows
+- Active integration listing for tenant context
 """
 
 import logging
 from enum import Enum
+from typing import Optional
 
 from sap_cloud_sdk.destination import (
     create_fragment_client,
@@ -24,6 +26,9 @@ logger = logging.getLogger(__name__)
 LABEL_KEY = "sap-managed-runtime-type"
 
 _DESTINATION_INSTANCE = "default"
+
+# URL mode path segments used by system integration fragments
+_INTEGRATION_URL_MODES = ("mcp", "a2a")
 
 
 class FragmentLabel(str, Enum):
@@ -118,3 +123,91 @@ def get_ias_user_fragment_name(tenant_subdomain: str) -> str:
             f"for tenant '{tenant_subdomain}'"
         )
     return fragments[0].name
+
+
+def list_active_integrations(tenant_subdomain: str) -> list[dict]:
+    """List all active backend system integrations for the given tenant.
+
+    Reads Destination Service instance fragments to discover active backend
+    system integrations for the given tenant. Each fragment represents a
+    connected backend system (e.g. SAP PCE, SAP S/4HANA).
+
+    Extracts integration details from the fragment URL, which always has the form:
+        {agw_base_url}/v1/mcp/{ord_id}/{gtid}   (MCP integrations)
+        {agw_base_url}/v1/a2a/{ord_id}/{gtid}   (A2A integrations)
+
+    Args:
+        tenant_subdomain: Subscriber tenant subdomain.
+
+    Returns:
+        List of dicts, each with keys:
+            - global_tenant_id: GTID of the connected partner system.
+            - system_type: Application namespace of the partner (e.g. "sap.pce").
+            - integration_dependency: ORD ID of the integration dependency fulfilled.
+        Returns empty list if no active integrations exist.
+    """
+    client = create_fragment_client(
+        instance=_DESTINATION_INSTANCE,
+        _telemetry_source=Module.AGENTGATEWAY,
+    )
+    fragments = client.list_instance_fragments(
+        filter=ListOptions(
+            filter_labels=[
+                Label(
+                    key=LABEL_KEY,
+                    values=[FragmentLabel.MCP.value, FragmentLabel.A2A.value],
+                )
+            ]
+        ),
+        tenant=tenant_subdomain,
+    )
+
+    result = []
+    for fragment in fragments:
+        url = fragment.properties.get("URL", "")
+        entry = _parse_integration_from_url(url)
+        if entry is not None:
+            result.append(entry)
+    return result
+
+
+def _parse_integration_from_url(url: str) -> Optional[dict]:
+    """Extract integration metadata from a system fragment URL.
+
+    Fragment URLs have the form:
+        {base}/v1/{mode}/{ord_id}/{gtid}
+    where mode is "mcp" or "a2a", ord_id may contain colons and slashes,
+    and gtid is the last path segment.
+
+    Args:
+        url: The fragment URL property value.
+
+    Returns:
+        Dict with global_tenant_id, system_type, integration_dependency,
+        or None if the URL does not match the expected pattern.
+    """
+    parts = url.rstrip("/").split("/")
+
+    mode_idx = None
+    for i, part in enumerate(parts):
+        if i > 0 and parts[i - 1] == "v1" and part in _INTEGRATION_URL_MODES:
+            mode_idx = i
+            break
+
+    if mode_idx is None or mode_idx + 2 > len(parts) - 1:
+        logger.debug("Skipping fragment with unexpected URL pattern: %s", url)
+        return None
+
+    gtid = parts[-1]
+    ord_id = "/".join(parts[mode_idx + 1 : -1])
+    system_type = ord_id.split(":")[0]
+
+    if not gtid or not ord_id:
+        logger.debug("Skipping fragment with empty gtid or ord_id in URL: %s", url)
+        return None
+
+    return {
+        "global_tenant_id": gtid,
+        "system_type": system_type,
+        "integration_dependency": ord_id,
+    }

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -38,6 +38,7 @@ from sap_cloud_sdk.agentgateway._models import (
 )
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
 from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
+from sap_cloud_sdk.agentgateway import _fragments
 from sap_cloud_sdk.core.telemetry import Module, Operation, record_metrics
 
 logger = logging.getLogger(__name__)
@@ -497,6 +498,36 @@ class AgentGatewayClient:
         except Exception as e:
             logger.exception("Unexpected error during agent card discovery")
             raise AgentGatewaySDKError(f"Agent card discovery failed: {e}") from e
+
+    @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_LIST_ACTIVE_INTEGRATIONS)
+    def list_active_integrations(self) -> list[dict]:
+        """List all active backend system integrations for the current tenant.
+
+        Returns the connected backend systems (e.g. SAP PCE, SAP S/4HANA) that
+        are currently active for this tenant. Use this to determine which systems
+        are connected and which GTIDs to pass when loading MCP tools.
+
+        Requires tenant_subdomain to be configured on the client.
+
+        Returns:
+            List of dicts, each with:
+                - global_tenant_id: GTID of the connected partner system.
+                - system_type: Application namespace (e.g. "sap.pce", "sap.s4").
+                - integration_dependency: ORD ID fulfilled by this integration.
+            Returns empty list if no active integrations exist.
+
+        Raises:
+            AgentGatewaySDKError: If tenant_subdomain is not configured.
+
+        Example:
+            ```python
+            integrations = agw_client.list_active_integrations()
+            for i in integrations:
+                print(i["system_type"], i["global_tenant_id"])
+            ```
+        """
+        tenant = self._resolve_tenant_subdomain()
+        return _fragments.list_active_integrations(tenant)
 
     @record_metrics(Module.AGENTGATEWAY, Operation.AGENTGATEWAY_CALL_MCP_TOOL)
     async def call_mcp_tool(

--- a/src/sap_cloud_sdk/core/telemetry/operation.py
+++ b/src/sap_cloud_sdk/core/telemetry/operation.py
@@ -193,6 +193,7 @@ class Operation(str, Enum):
     AGENTGATEWAY_GET_USER_AUTH = "get_user_auth"
     AGENTGATEWAY_LIST_AGENT_CARDS = "list_agent_cards"
     AGENTGATEWAY_GET_IAS_CLIENT_ID = "get_ias_client_id"
+    AGENTGATEWAY_LIST_ACTIVE_INTEGRATIONS = "list_active_integrations"
 
     # Agent Memory Operations
     AGENT_MEMORY_ADD_MEMORY = "add_memory"

--- a/tests/agentgateway/unit/test_fragments.py
+++ b/tests/agentgateway/unit/test_fragments.py
@@ -1,0 +1,244 @@
+"""Unit tests for agentgateway._fragments — list_active_integrations and helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sap_cloud_sdk.agentgateway._fragments import (
+    _parse_integration_from_url,
+    list_active_integrations,
+)
+from sap_cloud_sdk.agentgateway import create_client, AgentGatewaySDKError
+from sap_cloud_sdk.destination._models import Fragment
+
+
+# ============================================================
+# Helpers
+# ============================================================
+
+
+def _fragment(url: str, name: str = "sap-managed-runtime-agw-mcp-abc") -> Fragment:
+    return Fragment(name=name, properties={"URL": url})
+
+
+# ============================================================
+# Tests: _parse_integration_from_url
+# ============================================================
+
+
+class TestParseIntegrationFromUrl:
+    def test_mcp_url_returns_correct_fields(self):
+        url = "https://agw.example.com/v1/mcp/sap.pce:apiResource:PA:v1/gtid-123"
+        result = _parse_integration_from_url(url)
+        assert result == {
+            "global_tenant_id": "gtid-123",
+            "system_type": "sap.pce",
+            "integration_dependency": "sap.pce:apiResource:PA:v1",
+        }
+
+    def test_a2a_url_returns_correct_fields(self):
+        url = "https://agw.example.com/v1/a2a/sap.s4:apiResource:BP:v1/gtid-456"
+        result = _parse_integration_from_url(url)
+        assert result == {
+            "global_tenant_id": "gtid-456",
+            "system_type": "sap.s4",
+            "integration_dependency": "sap.s4:apiResource:BP:v1",
+        }
+
+    def test_ord_id_with_slash_segments(self):
+        url = "https://agw.example.com/v1/mcp/sap.sf:apiResource:jobs/v1/gtid-789"
+        result = _parse_integration_from_url(url)
+        assert result == {
+            "global_tenant_id": "gtid-789",
+            "system_type": "sap.sf",
+            "integration_dependency": "sap.sf:apiResource:jobs/v1",
+        }
+
+    def test_trailing_slash_is_ignored(self):
+        url = "https://agw.example.com/v1/mcp/sap.pce:apiResource:PA:v1/gtid-123/"
+        result = _parse_integration_from_url(url)
+        assert result is not None
+        assert result["global_tenant_id"] == "gtid-123"
+
+    def test_returns_none_for_url_without_v1_mode(self):
+        url = "https://agw.example.com/some/other/path/gtid-123"
+        assert _parse_integration_from_url(url) is None
+
+    def test_returns_none_for_empty_url(self):
+        assert _parse_integration_from_url("") is None
+
+    def test_returns_none_when_nothing_after_mode(self):
+        url = "https://agw.example.com/v1/mcp/"
+        assert _parse_integration_from_url(url) is None
+
+    def test_returns_none_when_only_gtid_after_mode(self):
+        # mode_idx + 2 > len(parts) - 1  →  no ord_id between mode and gtid
+        url = "https://agw.example.com/v1/mcp/gtid-only"
+        assert _parse_integration_from_url(url) is None
+
+
+# ============================================================
+# Tests: list_active_integrations (module-level function)
+# ============================================================
+
+
+class TestListActiveIntegrations:
+    def test_returns_parsed_entries_for_matching_fragments(self):
+        fragments = [
+            _fragment("https://agw.example.com/v1/mcp/sap.pce:apiResource:PA:v1/gtid-1"),
+            _fragment("https://agw.example.com/v1/a2a/sap.s4:apiResource:BP:v1/gtid-2"),
+        ]
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = fragments
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            result = list_active_integrations("my-tenant")
+
+        assert len(result) == 2
+        assert result[0] == {
+            "global_tenant_id": "gtid-1",
+            "system_type": "sap.pce",
+            "integration_dependency": "sap.pce:apiResource:PA:v1",
+        }
+        assert result[1] == {
+            "global_tenant_id": "gtid-2",
+            "system_type": "sap.s4",
+            "integration_dependency": "sap.s4:apiResource:BP:v1",
+        }
+
+    def test_returns_empty_list_when_no_fragments(self):
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = []
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            result = list_active_integrations("my-tenant")
+
+        assert result == []
+
+    def test_skips_fragments_with_unparseable_url(self):
+        fragments = [
+            _fragment("https://agw.example.com/some/unrelated/path"),
+            _fragment("https://agw.example.com/v1/mcp/sap.pce:apiResource:PA:v1/gtid-1"),
+        ]
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = fragments
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            result = list_active_integrations("my-tenant")
+
+        assert len(result) == 1
+        assert result[0]["global_tenant_id"] == "gtid-1"
+
+    def test_skips_fragments_with_missing_url_property(self):
+        fragment = Fragment(name="sap-managed-runtime-agw-mcp-abc", properties={})
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = [fragment]
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            result = list_active_integrations("my-tenant")
+
+        assert result == []
+
+    def test_passes_tenant_subdomain_to_fragment_client(self):
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = []
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            list_active_integrations("specific-tenant")
+
+        call_kwargs = mock_client.list_instance_fragments.call_args.kwargs
+        assert call_kwargs["tenant"] == "specific-tenant"
+
+    def test_filters_by_mcp_and_a2a_label_types(self):
+        from sap_cloud_sdk.destination._models import Label, ListOptions
+
+        mock_client = MagicMock()
+        mock_client.list_instance_fragments.return_value = []
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._fragments.create_fragment_client",
+            return_value=mock_client,
+        ):
+            list_active_integrations("my-tenant")
+
+        call_kwargs = mock_client.list_instance_fragments.call_args.kwargs
+        filter_obj: ListOptions = call_kwargs["filter"]
+        assert filter_obj is not None
+        assert len(filter_obj.filter_labels) == 1
+        label: Label = filter_obj.filter_labels[0]
+        assert label.key == "sap-managed-runtime-type"
+        assert "agw.mcp.server" in label.values
+        assert "agw.a2a.server" in label.values
+
+
+# ============================================================
+# Tests: AgentGatewayClient.list_active_integrations
+# ============================================================
+
+
+class TestAgentGatewayClientListActiveIntegrations:
+    def test_delegates_to_fragments_helper(self):
+        expected = [
+            {
+                "global_tenant_id": "gtid-1",
+                "system_type": "sap.pce",
+                "integration_dependency": "sap.pce:apiResource:PA:v1",
+            }
+        ]
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_transparent_credentials",
+                return_value=False,
+            ),
+            patch.object(
+                __import__("sap_cloud_sdk.agentgateway._fragments", fromlist=["list_active_integrations"]),
+                "list_active_integrations",
+                return_value=expected,
+            ) as mock_fn,
+        ):
+            client = create_client(tenant_subdomain="my-tenant")
+            result = client.list_active_integrations()
+
+        assert result == expected
+        mock_fn.assert_called_once_with("my-tenant")
+
+    def test_returns_empty_list_when_no_integrations(self):
+        with (
+            patch(
+                "sap_cloud_sdk.agentgateway.agw_client.detect_transparent_credentials",
+                return_value=False,
+            ),
+            patch.object(
+                __import__("sap_cloud_sdk.agentgateway._fragments", fromlist=["list_active_integrations"]),
+                "list_active_integrations",
+                return_value=[],
+            ),
+        ):
+            client = create_client(tenant_subdomain="my-tenant")
+            result = client.list_active_integrations()
+
+        assert result == []
+
+    def test_raises_when_tenant_subdomain_not_configured(self):
+        with patch(
+            "sap_cloud_sdk.agentgateway.agw_client.detect_transparent_credentials",
+            return_value=False,
+        ):
+            client = create_client()
+            with pytest.raises(AgentGatewaySDKError):
+                client.list_active_integrations()


### PR DESCRIPTION
## Description

Adds a `list_active_integrations(tenant_subdomain)` method to `AgentGatewayClient` that returns all currently connected backend systems for a given tenant. Each entry contains the partner's Global Tenant ID, application namespace (system type), and the ORD ID of the integration dependency it fulfils.

The method reads Destination Service instance fragments for the tenant, filtering by `sap-managed-runtime-type` label values `agw.mcp.server` and `agw.a2a.server`. Integration metadata (GTID, ORD ID, system type) is extracted from the fragment URL.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Instantiate an `AgentGatewayClient` with a `tenant_subdomain` that has active backend system integrations
2. Call `client.list_active_integrations()`
3. Expected result: a list of dicts, each with `global_tenant_id`, `system_type`, and `integration_dependency`; empty list if no active integrations exist

Unit tests can be run locally with:
```
uv run pytest tests/agentgateway/unit/test_fragments.py -v
```

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [ ] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None.

## Additional Notes

None.