### PR TITLE
fix: authentication error log on agent gateway integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.43.0"
+version = "0.43.2"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.43.2"
+version = "0.43.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -112,6 +112,10 @@ def _fetch_auth_token(
         )
 
     auth_token = dest.auth_tokens[0]
+    if auth_token.error:
+        raise MCPServerNotFoundError(
+            f"Auth token error for destination '{dest_name}': {auth_token.error}"
+        )
     header_value = auth_token.http_header.get("value") or ""
     if not header_value:
         raise MCPServerNotFoundError(f"Empty auth header for destination '{dest_name}'")

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -112,10 +112,6 @@ def _fetch_auth_token(
         )
 
     auth_token = dest.auth_tokens[0]
-    if auth_token.error:
-        raise MCPServerNotFoundError(
-            f"Auth token error for destination '{dest_name}': {auth_token.error}"
-        )
     header_value = auth_token.http_header.get("value") or ""
     if not header_value:
         raise MCPServerNotFoundError(f"Empty auth header for destination '{dest_name}'")

--- a/src/sap_cloud_sdk/destination/_models.py
+++ b/src/sap_cloud_sdk/destination/_models.py
@@ -413,6 +413,7 @@ class AuthToken:
         type: Token type (e.g., "Bearer", "Basic")
         value: Base64 encoded token binary content
         http_header: Dictionary with 'key' and 'value' for the prepared HTTP header
+        error: Error message returned by the Destination Service when token retrieval fails
         refresh_token: Optional base64 encoded refresh token
         scope: Optional token scopes as space-delimited string
     """
@@ -420,6 +421,7 @@ class AuthToken:
     type: str
     value: str
     http_header: Dict[str, str]
+    error: Optional[str] = None
     refresh_token: Optional[str] = None
     scope: Optional[str] = None
 
@@ -434,15 +436,16 @@ class AuthToken:
             AuthToken: Parsed auth token dataclass.
 
         Raises:
-            DestinationOperationError: If required fields are missing.
+            DestinationOperationError: If required fields are missing and no error is present.
         """
         token_type = obj.get("type") or ""
         value = obj.get("value") or ""
         http_header = obj.get("http_header") or {}
+        error = obj.get("error") or None
         refresh_token = obj.get("refresh_token")
         scope = obj.get("scope")
 
-        if not token_type or not value or not http_header:
+        if not error and (not token_type or not value or not http_header):
             raise DestinationOperationError(
                 "auth token is missing required fields (type/value/http_header)"
             )
@@ -451,6 +454,7 @@ class AuthToken:
             type=token_type,
             value=value,
             http_header=http_header,
+            error=error,
             refresh_token=refresh_token,
             scope=scope,
         )

--- a/src/sap_cloud_sdk/destination/_models.py
+++ b/src/sap_cloud_sdk/destination/_models.py
@@ -436,7 +436,8 @@ class AuthToken:
             AuthToken: Parsed auth token dataclass.
 
         Raises:
-            DestinationOperationError: If required fields are missing and no error is present.
+            DestinationOperationError: If required fields are missing, or if the token
+                carries an error from the Destination Service.
         """
         token_type = obj.get("type") or ""
         value = obj.get("value") or ""
@@ -448,6 +449,10 @@ class AuthToken:
         if not error and (not token_type or not value or not http_header):
             raise DestinationOperationError(
                 "auth token is missing required fields (type/value/http_header)"
+            )
+        if error and (not token_type or not value or not http_header):
+            raise DestinationOperationError(
+                f"auth token retrieval failed: {error}"
             )
 
         return cls(

--- a/src/sap_cloud_sdk/destination/_models.py
+++ b/src/sap_cloud_sdk/destination/_models.py
@@ -451,9 +451,7 @@ class AuthToken:
                 "auth token is missing required fields (type/value/http_header)"
             )
         if error and (not token_type or not value or not http_header):
-            raise DestinationOperationError(
-                f"auth token retrieval failed: {error}"
-            )
+            raise DestinationOperationError(f"auth token retrieval failed: {error}")
 
         return cls(
             type=token_type,

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -89,6 +89,7 @@ class TestFetchAuthToken:
         header_value = "Bearer my-raw-jwt-token-123"
         mock_dest = MagicMock()
         mock_dest.auth_tokens = [MagicMock()]
+        mock_dest.auth_tokens[0].error = None
         mock_dest.auth_tokens[0].http_header = {"value": header_value}
         mock_dest.url = "https://agw.example.com/"
 
@@ -112,6 +113,7 @@ class TestFetchAuthToken:
         header_value = "Bearer token"
         mock_dest = MagicMock()
         mock_dest.auth_tokens = [MagicMock()]
+        mock_dest.auth_tokens[0].error = None
         mock_dest.auth_tokens[0].http_header = {"value": header_value}
         mock_dest.url = "https://agw.example.com/v1/mcp///"
 
@@ -149,6 +151,7 @@ class TestFetchAuthToken:
         """Raise MCPServerNotFoundError when http_header value is empty."""
         mock_dest = MagicMock()
         mock_dest.auth_tokens = [MagicMock()]
+        mock_dest.auth_tokens[0].error = None
         mock_dest.auth_tokens[0].http_header = {"value": ""}
 
         with patch(
@@ -159,10 +162,29 @@ class TestFetchAuthToken:
             with pytest.raises(MCPServerNotFoundError, match="Empty auth header"):
                 _fetch_auth_token("dest-name", "tenant-sub")
 
+    def test_raises_with_error_field_from_destination(self):
+        """Raise MCPServerNotFoundError with the error message from the auth token."""
+        mock_dest = MagicMock()
+        mock_dest.auth_tokens = [MagicMock()]
+        mock_dest.auth_tokens[0].error = "No consumed apis matching provided resource parameter found."
+        mock_dest.auth_tokens[0].http_header = {"value": ""}
+
+        with patch(
+            "sap_cloud_sdk.agentgateway._lob.create_destination_client"
+        ) as mock_client:
+            mock_client.return_value.get_destination.return_value = mock_dest
+
+            with pytest.raises(
+                MCPServerNotFoundError,
+                match="No consumed apis matching provided resource parameter found.",
+            ):
+                _fetch_auth_token("dest-name", "tenant-sub")
+
     def test_passes_options_to_destination(self):
         """Pass consumption options to get_destination."""
         mock_dest = MagicMock()
         mock_dest.auth_tokens = [MagicMock()]
+        mock_dest.auth_tokens[0].error = None
         mock_dest.auth_tokens[0].http_header = {"value": "Bearer token"}
         mock_dest.url = "https://agw.example.com"
         mock_options = MagicMock()

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -162,24 +162,6 @@ class TestFetchAuthToken:
             with pytest.raises(MCPServerNotFoundError, match="Empty auth header"):
                 _fetch_auth_token("dest-name", "tenant-sub")
 
-    def test_raises_with_error_field_from_destination(self):
-        """Raise MCPServerNotFoundError with the error message from the auth token."""
-        mock_dest = MagicMock()
-        mock_dest.auth_tokens = [MagicMock()]
-        mock_dest.auth_tokens[0].error = "No consumed apis matching provided resource parameter found."
-        mock_dest.auth_tokens[0].http_header = {"value": ""}
-
-        with patch(
-            "sap_cloud_sdk.agentgateway._lob.create_destination_client"
-        ) as mock_client:
-            mock_client.return_value.get_destination.return_value = mock_dest
-
-            with pytest.raises(
-                MCPServerNotFoundError,
-                match="No consumed apis matching provided resource parameter found.",
-            ):
-                _fetch_auth_token("dest-name", "tenant-sub")
-
     def test_passes_options_to_destination(self):
         """Pass consumption options to get_destination."""
         mock_dest = MagicMock()

--- a/tests/destination/unit/test_models.py
+++ b/tests/destination/unit/test_models.py
@@ -308,15 +308,17 @@ class TestAuthTokenModel:
         assert token.error is None
 
     def test_from_dict_with_error_field(self):
-        """Parse an auth token dict that contains an error from the Destination Service."""
-        token = AuthToken.from_dict({
-            "type": "",
-            "value": "",
-            "error": "No consumed apis matching provided resource parameter found.",
-            "expires_in": "0",
-        })
-        assert token.error == "No consumed apis matching provided resource parameter found."
-        assert token.value == ""
+        """Raise DestinationOperationError with the Destination Service error message."""
+        with pytest.raises(
+            DestinationOperationError,
+            match="No consumed apis matching provided resource parameter found.",
+        ):
+            AuthToken.from_dict({
+                "type": "",
+                "value": "",
+                "error": "No consumed apis matching provided resource parameter found.",
+                "expires_in": "0",
+            })
 
     def test_from_dict_missing_fields_without_error_raises(self):
         """Raise DestinationOperationError when required fields are missing and no error is set."""

--- a/tests/destination/unit/test_models.py
+++ b/tests/destination/unit/test_models.py
@@ -293,6 +293,37 @@ class TestDestinationModel:
         assert dest.get_headers()["Authorization"] == "Bearer eyJ123"
 
 
+class TestAuthTokenModel:
+    """Tests for AuthToken dataclass."""
+
+    def test_from_dict_valid(self):
+        """Parse a valid auth token dict."""
+        token = AuthToken.from_dict({
+            "type": "Bearer",
+            "value": "eyJ123",
+            "http_header": {"key": "Authorization", "value": "Bearer eyJ123"},
+        })
+        assert token.type == "Bearer"
+        assert token.value == "eyJ123"
+        assert token.error is None
+
+    def test_from_dict_with_error_field(self):
+        """Parse an auth token dict that contains an error from the Destination Service."""
+        token = AuthToken.from_dict({
+            "type": "",
+            "value": "",
+            "error": "No consumed apis matching provided resource parameter found.",
+            "expires_in": "0",
+        })
+        assert token.error == "No consumed apis matching provided resource parameter found."
+        assert token.value == ""
+
+    def test_from_dict_missing_fields_without_error_raises(self):
+        """Raise DestinationOperationError when required fields are missing and no error is set."""
+        with pytest.raises(DestinationOperationError, match="missing required fields"):
+            AuthToken.from_dict({"type": "", "value": "", "http_header": {}})
+
+
 class TestFragmentModel:
     """Tests for Fragment dataclass."""
 


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

When the Destination Service returns an auth token with a non-empty `error` field (e.g. `"No consumed apis matching provided resource parameter found."`), the Agent Gateway LoB flow previously raised a generic `"Empty auth header"` error with no indication of the underlying cause.

This fix surfaces the Destination Service error message directly in the raised exception:

- Adds `error: Optional[str]` field to the `AuthToken` dataclass, populated from the `"error"` key in the Destination Service v2 API response.
- Updates `AuthToken.from_dict` to raise `DestinationOperationError` with the Destination Service error message when a token carries an `error` field alongside empty `type`/`value`/`http_header`.
- Since the error now surfaces at parse time (inside `Destination.from_dict`), it propagates naturally through `get_destination` to the caller without any special handling in the Agent Gateway layer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Configure a destination whose token service returns a failure (e.g. a mismatched `resource` parameter causing `"No consumed apis matching provided resource parameter found."`).
2. Invoke the Agent Gateway LoB flow (`fetch_system_auth` or `fetch_user_auth`).
3. Observe that the raised exception now includes the exact error message from the Destination Service instead of a generic `"Empty auth header"` message.

Alternatively, run the unit tests:

```bash
uv run pytest tests/destination/unit/test_models.py::TestAuthTokenModel tests/agentgateway/unit/test_lob.py::TestFetchAuthToken -v
```

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

The `error` field is part of the Destination Service OpenAPI spec for `authTokens` but was previously not modelled in `AuthToken`. The fix is fully backward-compatible: tokens without an `error` field parse as before, and `AuthToken.error` defaults to `None`. Tokens that carry a non-empty `error` alongside empty required fields now raise `DestinationOperationError` at parse time with the service-provided message included.