### PR TITLE
fix: add validation for empty ias client id

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.45.2"
+version = "0.45.3"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -151,7 +151,12 @@ def get_ias_client_id_lob() -> str:
     )
     if not dest:
         raise AgentGatewaySDKError(f"IAS destination '{dest_name}' not found")
-    return dest.properties.get("clientId", "")
+    client_id = dest.properties.get("clientId", "")
+    if not client_id:
+        raise AgentGatewaySDKError(
+            f"IAS destination '{dest_name}' does not contain a 'clientId' property"
+        )
+    return client_id
 
 
 async def fetch_system_auth(

--- a/src/sap_cloud_sdk/agentgateway/agw_client.py
+++ b/src/sap_cloud_sdk/agentgateway/agw_client.py
@@ -347,6 +347,10 @@ class AgentGatewayClient:
                     "Customer agent credentials detected at '%s'", credentials_path
                 )
                 credentials = load_customer_credentials(credentials_path)
+                if not credentials.client_id:
+                    raise AgentGatewaySDKError(
+                        "Customer agent credentials file does not contain a 'client_id'"
+                    )
                 return credentials.client_id
 
             # LoB flow — read clientId from the IAS destination properties

--- a/tests/agentgateway/unit/test_agw_client.py
+++ b/tests/agentgateway/unit/test_agw_client.py
@@ -1209,6 +1209,17 @@ class TestGetIasClientId:
             with pytest.raises(AgentGatewaySDKError, match="Could not resolve IAS client ID"):
                 create_client().get_ias_client_id()
 
+    def test_customer_raises_when_client_id_empty(self):
+        mock_creds = MagicMock()
+        mock_creds.client_id = ""
+
+        with (
+            patch(_DETECT_CREDS_PATCH, return_value="/etc/ums/credentials/credentials"),
+            patch(_LOAD_CREDS_PATCH, return_value=mock_creds),
+        ):
+            with pytest.raises(AgentGatewaySDKError, match="client_id"):
+                create_client().get_ias_client_id()
+
     # --- LoB flow ---
 
     @_NO_CUSTOMER_CREDS
@@ -1225,11 +1236,10 @@ class TestGetIasClientId:
                 create_client(tenant_subdomain="my-tenant").get_ias_client_id()
 
     @_NO_CUSTOMER_CREDS
-    def test_lob_returns_empty_string_when_property_absent(self, _mock_detect):
-        with patch(_GET_IAS_CLIENT_ID_LOB_PATCH, return_value=""):
-            result = create_client(tenant_subdomain="my-tenant").get_ias_client_id()
-
-        assert result == ""
+    def test_lob_raises_when_client_id_property_absent(self, _mock_detect):
+        with patch(_GET_IAS_CLIENT_ID_LOB_PATCH, side_effect=AgentGatewaySDKError("does not contain a 'clientId' property")):
+            with pytest.raises(AgentGatewaySDKError, match="clientId"):
+                create_client(tenant_subdomain="my-tenant").get_ias_client_id()
 
     @_NO_CUSTOMER_CREDS
     def test_lob_raises_on_exception(self, _mock_detect):

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -1252,7 +1252,7 @@ class TestGetIasClientIdLob:
             with pytest.raises(AgentGatewaySDKError, match="sap-managed-runtime-ias-eu10"):
                 get_ias_client_id_lob()
 
-    def test_returns_empty_string_when_property_absent(self):
+    def test_raises_when_client_id_property_absent(self):
         mock_dest = MagicMock()
         mock_dest.properties = {}
         mock_dest_client = MagicMock()
@@ -1262,9 +1262,8 @@ class TestGetIasClientIdLob:
             patch("sap_cloud_sdk.agentgateway._lob._ias_dest_name", return_value="sap-managed-runtime-ias-eu10"),
             patch("sap_cloud_sdk.agentgateway._lob.create_destination_client", return_value=mock_dest_client),
         ):
-            result = get_ias_client_id_lob()
-
-        assert result == ""
+            with pytest.raises(AgentGatewaySDKError, match="clientId"):
+                get_ias_client_id_lob()
 
     def test_raises_when_landscape_env_not_set(self):
         with patch("sap_cloud_sdk.agentgateway._lob._ias_dest_name", side_effect=EnvironmentError("APPFND_CONHOS_LANDSCAPE not set")):


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

`AgentGatewayClient.get_ias_client_id()` previously returned an empty string silently when the IAS `clientId` was missing from the destination properties (LoB flow) or when `client_id` was empty in the customer credentials file. Callers had no way to distinguish a valid empty-string result from a misconfiguration, and would typically fail later with an opaque error.

This fix adds explicit validation at both resolution paths:

- **LoB flow** (`get_ias_client_id_lob` in `_lob.py`): raises `AgentGatewaySDKError` if the `clientId` property is absent or empty on the IAS destination.
- **Customer flow** (`AgentGatewayClient.get_ias_client_id` in `agw_client.py`): raises `AgentGatewaySDKError` if `credentials.client_id` is empty after loading the credentials file.

Tests are updated to assert the new error behaviour, and a new test case covers the empty customer `client_id` scenario.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

1. Run the unit tests for the affected classes:
   ```
   uv run pytest tests/agentgateway/unit/test_lob.py::TestGetIasClientIdLob tests/agentgateway/unit/test_agw_client.py::TestGetIasClientId -v
   ```
2. Confirm all 11 tests pass, including:
   - `test_raises_when_client_id_property_absent` (LoB flow — missing `clientId` destination property)
   - `test_customer_raises_when_client_id_empty` (Customer flow — empty `client_id` in credentials)
3. Confirm that when a valid `clientId` / `client_id` is present, the value is returned unchanged.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [x] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

This is a purely additive validation change. The happy path (non-empty `client_id`) is unaffected. Any caller that was previously handling an empty string return now needs to handle `AgentGatewaySDKError` instead — but in practice no legitimate call site would treat an empty client ID as a success.
