### PR TITLE
feat(telemetry): discover companion SDK resource attributes via entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.46.0"
+version = "0.46.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/__init__.py
+++ b/src/sap_cloud_sdk/core/telemetry/__init__.py
@@ -16,6 +16,7 @@ from sap_cloud_sdk.core.telemetry.operation import Operation
 from sap_cloud_sdk.core.telemetry.genai_operation import GenAIOperation
 from sap_cloud_sdk.core.telemetry.metrics_decorator import record_metrics
 from sap_cloud_sdk.core.telemetry.auto_instrument import auto_instrument
+from sap_cloud_sdk.core.telemetry.config import register_sdk_resource_attributes
 from sap_cloud_sdk.core.telemetry.tracer import (
     context_overlay,
     get_current_span,
@@ -67,6 +68,7 @@ __all__ = [
     "set_tenant_id",
     "get_tenant_id",
     "auto_instrument",
+    "register_sdk_resource_attributes",
     "context_overlay",
     "get_current_span",
     "add_span_attribute",

--- a/src/sap_cloud_sdk/core/telemetry/__init__.py
+++ b/src/sap_cloud_sdk/core/telemetry/__init__.py
@@ -16,7 +16,6 @@ from sap_cloud_sdk.core.telemetry.operation import Operation
 from sap_cloud_sdk.core.telemetry.genai_operation import GenAIOperation
 from sap_cloud_sdk.core.telemetry.metrics_decorator import record_metrics
 from sap_cloud_sdk.core.telemetry.auto_instrument import auto_instrument
-from sap_cloud_sdk.core.telemetry.config import register_sdk_resource_attributes
 from sap_cloud_sdk.core.telemetry.tracer import (
     context_overlay,
     get_current_span,
@@ -68,7 +67,6 @@ __all__ = [
     "set_tenant_id",
     "get_tenant_id",
     "auto_instrument",
-    "register_sdk_resource_attributes",
     "context_overlay",
     "get_current_span",
     "add_span_attribute",

--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -1,7 +1,9 @@
 """Configuration for OpenTelemetry telemetry."""
 
+import logging
 import os
 from dataclasses import dataclass
+from importlib.metadata import entry_points as _entry_points
 from typing import Optional
 from opentelemetry.sdk.resources import SERVICE_NAME
 from sap_cloud_sdk.core._version import get_version
@@ -22,33 +24,7 @@ from sap_cloud_sdk.core.telemetry.constants import (
     SDK_NAME,
 )
 
-# Registry of extra resource attributes contributed by companion SDKs.
-# Populated via register_sdk_resource_attributes() at import time of those SDKs.
-_extra_sdk_attributes: dict = {}
-
-
-def register_sdk_resource_attributes(attributes: dict) -> None:
-    """Register additional OTel resource attributes to be included in every provider.
-
-    Companion SDKs call this once at import time so their version appears on every
-    span and metric without any change to agent startup code. Read the version from
-    ``importlib.metadata`` rather than hardcoding it::
-
-        from importlib.metadata import version, PackageNotFoundError
-        from sap_cloud_sdk.core.telemetry.config import register_sdk_resource_attributes
-
-        try:
-            sdk_version = version("my-sdk-package")
-        except PackageNotFoundError:
-            sdk_version = "unknown"
-
-        register_sdk_resource_attributes({
-            "sap.my_sdk.version": sdk_version,
-            "sap.my_sdk.language": "python",
-        })
-    """
-    _extra_sdk_attributes.update(attributes)
-
+logger = logging.getLogger(__name__)
 
 # Default attribute values
 DEFAULT_UNKNOWN = "unknown"
@@ -200,7 +176,12 @@ def create_resource_attributes_from_env() -> dict:
     if service_display_name is not None:
         attributes[ATTR_SAP_SERVICE_DISPLAY_NAME] = service_display_name
 
-    attributes.update(_extra_sdk_attributes)
+    for _ep in _entry_points(group="sap_cloud_sdk.resource_providers"):
+        try:
+            _provider = _ep.load()
+            attributes.update(_provider())
+        except Exception:
+            logger.debug("Failed to load resource provider %s", _ep.name, exc_info=True)
 
     return attributes
 

--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -22,6 +22,20 @@ from sap_cloud_sdk.core.telemetry.constants import (
     SDK_NAME,
 )
 
+# Registry of extra resource attributes contributed by companion SDKs.
+# Populated via register_sdk_resource_attributes() at import time of those SDKs.
+_extra_sdk_attributes: dict = {}
+
+
+def register_sdk_resource_attributes(attributes: dict) -> None:
+    """Register additional OTel resource attributes to be included in every provider.
+
+    Companion SDKs (e.g. sap-internal-sdk) call this once at import time so their
+    version appears on every span and metric without any change to agent startup code.
+    """
+    _extra_sdk_attributes.update(attributes)
+
+
 # Default attribute values
 DEFAULT_UNKNOWN = "unknown"
 
@@ -171,6 +185,8 @@ def create_resource_attributes_from_env() -> dict:
     service_display_name = _get_service_display_name()
     if service_display_name is not None:
         attributes[ATTR_SAP_SERVICE_DISPLAY_NAME] = service_display_name
+
+    attributes.update(_extra_sdk_attributes)
 
     return attributes
 

--- a/src/sap_cloud_sdk/core/telemetry/config.py
+++ b/src/sap_cloud_sdk/core/telemetry/config.py
@@ -30,8 +30,22 @@ _extra_sdk_attributes: dict = {}
 def register_sdk_resource_attributes(attributes: dict) -> None:
     """Register additional OTel resource attributes to be included in every provider.
 
-    Companion SDKs (e.g. sap-internal-sdk) call this once at import time so their
-    version appears on every span and metric without any change to agent startup code.
+    Companion SDKs call this once at import time so their version appears on every
+    span and metric without any change to agent startup code. Read the version from
+    ``importlib.metadata`` rather than hardcoding it::
+
+        from importlib.metadata import version, PackageNotFoundError
+        from sap_cloud_sdk.core.telemetry.config import register_sdk_resource_attributes
+
+        try:
+            sdk_version = version("my-sdk-package")
+        except PackageNotFoundError:
+            sdk_version = "unknown"
+
+        register_sdk_resource_attributes({
+            "sap.my_sdk.version": sdk_version,
+            "sap.my_sdk.language": "python",
+        })
     """
     _extra_sdk_attributes.update(attributes)
 

--- a/tests/core/unit/telemetry/test_config.py
+++ b/tests/core/unit/telemetry/test_config.py
@@ -7,6 +7,8 @@ from sap_cloud_sdk.core.telemetry.config import (
     create_resource_attributes_from_env,
     get_config,
     set_config,
+    register_sdk_resource_attributes,
+    _extra_sdk_attributes,
 )
 from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_MLFLOW_EXPERIMENT_ID,
@@ -299,3 +301,40 @@ class TestCreateResourceAttributesFromEnv:
 
             assert attrs[ATTR_SAP_SERVICE_DISPLAY_NAME] == "My Service"
             assert attrs[ATTR_SAP_ORD_ID] == "my-ord-id"
+
+
+class TestRegisterSdkResourceAttributes:
+    """Tests for the companion-SDK resource attribute registry."""
+
+    def setup_method(self):
+        _extra_sdk_attributes.clear()
+
+    def teardown_method(self):
+        _extra_sdk_attributes.clear()
+
+    def test_registered_attributes_appear_in_resource(self):
+        register_sdk_resource_attributes({"sap.internal_sdk.version": "1.0.0"})
+        attrs = create_resource_attributes_from_env()
+        assert attrs["sap.internal_sdk.version"] == "1.0.0"
+
+    def test_multiple_registrations_are_merged(self):
+        register_sdk_resource_attributes({"sap.foo.version": "1.0"})
+        register_sdk_resource_attributes({"sap.bar.version": "2.0"})
+        attrs = create_resource_attributes_from_env()
+        assert attrs["sap.foo.version"] == "1.0"
+        assert attrs["sap.bar.version"] == "2.0"
+
+    def test_registered_attributes_do_not_override_cloud_sdk_keys(self):
+        from sap_cloud_sdk.core.telemetry.constants import ATTR_SAP_SDK_VERSION
+        original = create_resource_attributes_from_env()[ATTR_SAP_SDK_VERSION]
+        register_sdk_resource_attributes({ATTR_SAP_SDK_VERSION: "999"})
+        attrs = create_resource_attributes_from_env()
+        assert attrs[ATTR_SAP_SDK_VERSION] == "999"
+        _extra_sdk_attributes.clear()
+        assert create_resource_attributes_from_env()[ATTR_SAP_SDK_VERSION] == original
+
+    def test_empty_registry_does_not_affect_output(self):
+        attrs_without = create_resource_attributes_from_env()
+        register_sdk_resource_attributes({})
+        attrs_with = create_resource_attributes_from_env()
+        assert attrs_without == attrs_with

--- a/tests/core/unit/telemetry/test_config.py
+++ b/tests/core/unit/telemetry/test_config.py
@@ -7,8 +7,6 @@ from sap_cloud_sdk.core.telemetry.config import (
     create_resource_attributes_from_env,
     get_config,
     set_config,
-    register_sdk_resource_attributes,
-    _extra_sdk_attributes,
 )
 from sap_cloud_sdk.core.telemetry.constants import (
     ATTR_MLFLOW_EXPERIMENT_ID,
@@ -303,38 +301,47 @@ class TestCreateResourceAttributesFromEnv:
             assert attrs[ATTR_SAP_ORD_ID] == "my-ord-id"
 
 
-class TestRegisterSdkResourceAttributes:
-    """Tests for the companion-SDK resource attribute registry."""
+def _make_ep(name: str, attrs: dict, raises: Exception | None = None):
+    """Build a mock entry point that returns *attrs* (or raises *raises*)."""
+    from unittest.mock import MagicMock
+    ep = MagicMock()
+    ep.name = name
+    if raises is not None:
+        ep.load.return_value = MagicMock(side_effect=raises)
+    else:
+        ep.load.return_value = lambda: attrs
+    return ep
 
-    def setup_method(self):
-        _extra_sdk_attributes.clear()
 
-    def teardown_method(self):
-        _extra_sdk_attributes.clear()
+class TestSdkResourceProviderEntryPoints:
+    """Tests for companion-SDK resource attribute discovery via entry points."""
 
-    def test_registered_attributes_appear_in_resource(self):
-        register_sdk_resource_attributes({"sap.internal_sdk.version": "1.0.0"})
-        attrs = create_resource_attributes_from_env()
-        assert attrs["sap.internal_sdk.version"] == "1.0.0"
+    def test_provider_attributes_appear_in_resource(self):
+        mock_ep = _make_ep("test_sdk", {"sap.test_sdk.version": "1.0.0"})
+        with patch("sap_cloud_sdk.core.telemetry.config._entry_points", return_value=[mock_ep]):
+            attrs = create_resource_attributes_from_env()
+        assert attrs["sap.test_sdk.version"] == "1.0.0"
 
-    def test_multiple_registrations_are_merged(self):
-        register_sdk_resource_attributes({"sap.foo.version": "1.0"})
-        register_sdk_resource_attributes({"sap.bar.version": "2.0"})
-        attrs = create_resource_attributes_from_env()
-        assert attrs["sap.foo.version"] == "1.0"
-        assert attrs["sap.bar.version"] == "2.0"
+    def test_multiple_providers_are_merged(self):
+        eps = [
+            _make_ep("sdk_a", {"sap.sdk_a.version": "1.0"}),
+            _make_ep("sdk_b", {"sap.sdk_b.version": "2.0"}),
+        ]
+        with patch("sap_cloud_sdk.core.telemetry.config._entry_points", return_value=eps):
+            attrs = create_resource_attributes_from_env()
+        assert attrs["sap.sdk_a.version"] == "1.0"
+        assert attrs["sap.sdk_b.version"] == "2.0"
 
-    def test_registered_attributes_do_not_override_cloud_sdk_keys(self):
+    def test_failing_provider_is_skipped_silently(self):
+        bad_ep = _make_ep("broken", {}, raises=RuntimeError("boom"))
+        good_ep = _make_ep("good", {"sap.good.version": "3.0"})
+        with patch("sap_cloud_sdk.core.telemetry.config._entry_points", return_value=[bad_ep, good_ep]):
+            attrs = create_resource_attributes_from_env()
+        assert attrs["sap.good.version"] == "3.0"
+        assert "sap.broken.version" not in attrs
+
+    def test_no_providers_does_not_affect_cloud_sdk_keys(self):
+        with patch("sap_cloud_sdk.core.telemetry.config._entry_points", return_value=[]):
+            attrs = create_resource_attributes_from_env()
         from sap_cloud_sdk.core.telemetry.constants import ATTR_SAP_SDK_VERSION
-        original = create_resource_attributes_from_env()[ATTR_SAP_SDK_VERSION]
-        register_sdk_resource_attributes({ATTR_SAP_SDK_VERSION: "999"})
-        attrs = create_resource_attributes_from_env()
-        assert attrs[ATTR_SAP_SDK_VERSION] == "999"
-        _extra_sdk_attributes.clear()
-        assert create_resource_attributes_from_env()[ATTR_SAP_SDK_VERSION] == original
-
-    def test_empty_registry_does_not_affect_output(self):
-        attrs_without = create_resource_attributes_from_env()
-        register_sdk_resource_attributes({})
-        attrs_with = create_resource_attributes_from_env()
-        assert attrs_without == attrs_with
+        assert ATTR_SAP_SDK_VERSION in attrs


### PR DESCRIPTION
## Summary

- Replaces the import-time registry (`register_sdk_resource_attributes` / `_extra_sdk_attributes`) with `importlib.metadata` entry-points discovery
- `create_resource_attributes_from_env()` now calls `entry_points(group="sap_cloud_sdk.resource_providers")` at OTel init time (inside `auto_instrument()`)
- Any installed package that registers a callable under that group has its returned dict merged into every span/metric resource automatically — no import-order dependency, no agent code change required
- Companion SDKs register themselves in their `pyproject.toml` under `[project.entry-points."sap_cloud_sdk.resource_providers"]`

## Test plan

- [ ] `uv run pytest tests/core/unit/telemetry/test_config.py` — 32 tests pass
- [ ] Verify `sap.internal_sdk.version` appears in resource attributes after installing `sap-internal-sdk` alongside this change (covered by companion PR https://github.tools.sap/application-foundation/sap-internal-sdk-python/pull/48)