### PR TITLE
chore(release): bump version to v0.45.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.45.3"
+version = "0.45.4"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3925,7 +3925,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.45.3"
+version = "0.45.4"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

Bumps version to 0.45.4 to release the protobuf compatibility fix from #285.

## Related Issue

Closes #266

## Type of Change

- [x] Dependency update
- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Install both `sap-cloud-sdk` and `a2a-sdk==1.1.2` in a project: `uv add sap-cloud-sdk a2a-sdk==1.1.2`
2. Verify `uv lock` resolves successfully (picks `protobuf` in the `>=5.29.5,<7` range)
3. Confirm `protobuf` resolves to a 6.x version when `a2a-sdk` is present

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] All tests pass locally
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

The actual fix (`protobuf>=5.29.5`, `protovalidate>=0.14.1`) was merged in #285. This PR is the version bump to cut the release.