### PR TITLE
chore: version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.47.0"
+version = "0.48.0"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3925,7 +3925,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.47.0"
+version = "0.48.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Bumps version to 0.48.0 for a new release. Refers to https://github.com/SAP/cloud-sdk-python/pull/294