### PR TITLE
fix: support langchain upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.48.3"
+version = "0.48.4"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -112,7 +112,9 @@ def mcp_tool_to_langchain(
     async def run(**kwargs) -> str:
         tool_kwargs = {k: v for k, v in kwargs.items() if k in allowed_keys}
         resolved = (
-            {k: v for k, v in tool_kwargs.items() if v is not None} if omit_none else tool_kwargs
+            {k: v for k, v in tool_kwargs.items() if v is not None}
+            if omit_none
+            else tool_kwargs
         )
         return await call_tool(
             mcp_tool,

--- a/src/sap_cloud_sdk/agentgateway/converters.py
+++ b/src/sap_cloud_sdk/agentgateway/converters.py
@@ -91,16 +91,6 @@ def mcp_tool_to_langchain(
             "Install it with: pip install sap-cloud-sdk[langchain]"
         ) from None
 
-    async def run(**kwargs) -> str:
-        resolved = (
-            {k: v for k, v in kwargs.items() if v is not None} if omit_none else kwargs
-        )
-        return await call_tool(
-            mcp_tool,
-            user_token=get_user_token,
-            **resolved,
-        )
-
     # Build args schema from input_schema
     properties = mcp_tool.input_schema.get("properties", {})
     required = set(mcp_tool.input_schema.get("required", []))
@@ -113,6 +103,22 @@ def mcp_tool_to_langchain(
         else:
             fields[k] = (py_type, ...)
     args_schema = create_model(f"{mcp_tool.name}_args", **fields) if fields else None
+
+    # Closed over at conversion time: only keys declared in the MCP schema are
+    # forwarded, so any kwargs LangChain injects (config, run_manager, …) are
+    # silently ignored without needing an explicit deny-list.
+    allowed_keys = frozenset(properties)
+
+    async def run(**kwargs) -> str:
+        tool_kwargs = {k: v for k, v in kwargs.items() if k in allowed_keys}
+        resolved = (
+            {k: v for k, v in tool_kwargs.items() if v is not None} if omit_none else tool_kwargs
+        )
+        return await call_tool(
+            mcp_tool,
+            user_token=get_user_token,
+            **resolved,
+        )
 
     return StructuredTool.from_function(
         coroutine=run,

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -298,6 +298,7 @@ class TestMcpToolToLangchainInvocation:
         call_tool = AsyncMock(return_value="ok")
         lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
+        assert lc_tool.coroutine is not None
         await lc_tool.coroutine(eventid="E001", config={"configurable": {}})
 
         assert "config" not in call_tool.call_args.kwargs
@@ -308,6 +309,7 @@ class TestMcpToolToLangchainInvocation:
         call_tool = AsyncMock(return_value="ok")
         lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
+        assert lc_tool.coroutine is not None
         await lc_tool.coroutine(eventid="E001", run_manager=object())
 
         assert "run_manager" not in call_tool.call_args.kwargs
@@ -318,6 +320,7 @@ class TestMcpToolToLangchainInvocation:
         call_tool = AsyncMock(return_value="ok")
         lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
 
+        assert lc_tool.coroutine is not None
         await lc_tool.coroutine(
             eventid="E001",
             showdeclinedreason="true",

--- a/tests/agentgateway/unit/test_converters.py
+++ b/tests/agentgateway/unit/test_converters.py
@@ -291,3 +291,42 @@ class TestMcpToolToLangchainInvocation:
         kwargs = call_tool.call_args.kwargs
         assert "showdeclinedreason" in kwargs
         assert kwargs["showdeclinedreason"] is None
+
+    @pytest.mark.asyncio
+    async def test_langchain_config_kwarg_not_forwarded_to_call_tool(self):
+        """LangChain >= 0.3 injects 'config' into _arun; it must not reach call_tool."""
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
+
+        await lc_tool.coroutine(eventid="E001", config={"configurable": {}})
+
+        assert "config" not in call_tool.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_langchain_run_manager_kwarg_not_forwarded_to_call_tool(self):
+        """LangChain injects 'run_manager' into _arun; it must not reach call_tool."""
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
+
+        await lc_tool.coroutine(eventid="E001", run_manager=object())
+
+        assert "run_manager" not in call_tool.call_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_langchain_injected_kwargs_stripped_while_tool_params_pass_through(self):
+        """Both 'config' and 'run_manager' are stripped; real tool params still reach call_tool."""
+        call_tool = AsyncMock(return_value="ok")
+        lc_tool = mcp_tool_to_langchain(_make_tool(), call_tool, lambda: "token")
+
+        await lc_tool.coroutine(
+            eventid="E001",
+            showdeclinedreason="true",
+            config={"configurable": {}},
+            run_manager=object(),
+        )
+
+        kwargs = call_tool.call_args.kwargs
+        assert kwargs["eventid"] == "E001"
+        assert kwargs["showdeclinedreason"] == "true"
+        assert "config" not in kwargs
+        assert "run_manager" not in kwargs


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

`mcp_tool_to_langchain` in `converters.py` produced a `StructuredTool` whose inner `run` coroutine forwarded all `**kwargs` directly to `call_tool`. Starting with `langchain-core` 0.3.x, `StructuredTool._arun()` injects two extra keyword arguments — `config` (a `RunnableConfig`) and `run_manager` — into every coroutine call. Because those keys are not accepted by `call_tool`, every MCP tool invocation raised:

```
TypeError: StructuredTool._arun() missing 1 required keyword-only argument: 'config'
```

The fix changes the filtering strategy from a deny-list (explicitly popping known LangChain internals) to an allow-list: `run` now closes over `allowed_keys = frozenset(properties)` — the set of parameter names declared in the MCP tool's `input_schema` — and only forwards kwargs that appear in that set. Any kwarg LangChain injects, now or in future versions, is silently ignored without requiring code changes.

Three regression tests were added to `test_converters.py` to verify that `config`, `run_manager`, and any combination thereof are stripped while real tool parameters still pass through correctly.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring

## How to Test

1. Create a LangChain agent that uses `mcp_tool_to_langchain` with any `MCPTool`.
2. Invoke a tool through the agent (e.g. `agent.ainvoke(...)`).
3. Confirm no `TypeError: StructuredTool._arun() missing 1 required keyword-only argument: 'config'` is raised.

Or run the unit tests directly:

```bash
uv run python3 -m pytest tests/agentgateway/unit/test_converters.py -v
```

All 27 tests should pass, including the three new regression tests:
- `test_langchain_config_kwarg_not_forwarded_to_call_tool`
- `test_langchain_run_manager_kwarg_not_forwarded_to_call_tool`
- `test_langchain_injected_kwargs_stripped_while_tool_params_pass_through`

## Checklist

- [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [x] I have added/updated automated tests to cover my changes
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)
- [x] I have added type hints for all public APIs
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Additional Notes

The bug manifests on `langchain-core >= 0.3.x` and was confirmed from production logs where the agent recovered by returning the error as a string to the LLM, so it appeared as degraded behaviour rather than a hard crash. The fix is backwards-compatible: on older `langchain-core` versions where `config` and `run_manager` are never injected, the allow-list filter is a no-op.
