### PR TITLE
fix(telemetry): merge SDK resource attrs into pre-installed MeterProvider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sap-cloud-sdk"
-version = "0.52.0"
+version = "0.52.1"
 description = "SAP Cloud SDK for Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -30,14 +30,14 @@ from opentelemetry.sdk.metrics import (
     ObservableUpDownCounter,
     UpDownCounter,
 )
-
-# Stable reference for isinstance checks — not overwritten when tests patch MeterProvider
-_SDKMeterProvider = MeterProvider
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     PeriodicExportingMetricReader,
 )
 from opentelemetry.sdk.resources import Resource
+
+# Stable reference for isinstance checks — not overwritten when tests patch MeterProvider
+_SDKMeterProvider = MeterProvider
 
 from sap_cloud_sdk.core.telemetry.config import (
     get_config,

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -56,20 +56,10 @@ def _merge_sdk_resource_into_meter_provider(
 ) -> None:
     """Merge SDK resource attrs into an already-installed MeterProvider.
 
-    OTel exposes no public API to swap a MeterProvider's Resource after
-    construction, so we mutate the private SdkConfiguration. This is safe and
-    needs no lock (unlike _merge_sdk_resource_into_log_provider):
-
-    - SdkConfiguration is a dataclass; _sdk_config.resource is mutable in place.
-    - MetricReaderStorage.collect() reads _sdk_config.resource live at export
-      time via the same object reference (_measurement_consumer and every
-      MetricReaderStorage share it), so this single reassignment propagates.
-    - Meters do not cache their own resource, so there is no active-instances
-      collection to iterate under a lock. The log provider needs its
-      _active_loggers_lock only because each Logger caches its own _resource.
-    - The reassignment is a GIL-atomic single store, runs once at startup, and
-      Resource.merge preserves schema_url, so a race with the periodic collect
-      thread is negligible and self-heals on the next export cycle.
+    No lock needed (unlike the log provider): meters don't cache a resource, so
+    there's no per-instance collection to iterate. collect() reads
+    _sdk_config.resource live at export time via the same shared reference we
+    mutate here, so this single reassignment propagates.
     """
     provider._sdk_config.resource = provider._sdk_config.resource.merge(sdk_resource)
     logger.info(

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -54,9 +54,23 @@ logger = logging.getLogger(__name__)
 def _merge_sdk_resource_into_meter_provider(
     provider: MeterProvider, sdk_resource: Resource
 ) -> None:
-    """OTel SDK has no public API to swap a MeterProvider's Resource after construction.
-    SdkConfiguration is a dataclass so _sdk_config.resource is mutable in-place;
-    _measurement_consumer holds the same object reference so it sees the update too."""
+    """Merge SDK resource attrs into an already-installed MeterProvider.
+
+    OTel exposes no public API to swap a MeterProvider's Resource after
+    construction, so we mutate the private SdkConfiguration. This is safe and
+    needs no lock (unlike _merge_sdk_resource_into_log_provider):
+
+    - SdkConfiguration is a dataclass; _sdk_config.resource is mutable in place.
+    - MetricReaderStorage.collect() reads _sdk_config.resource live at export
+      time via the same object reference (_measurement_consumer and every
+      MetricReaderStorage share it), so this single reassignment propagates.
+    - Meters do not cache their own resource, so there is no active-instances
+      collection to iterate under a lock. The log provider needs its
+      _active_loggers_lock only because each Logger caches its own _resource.
+    - The reassignment is a GIL-atomic single store, runs once at startup, and
+      Resource.merge preserves schema_url, so a race with the periodic collect
+      thread is negligible and self-heals on the next export cycle.
+    """
     provider._sdk_config.resource = provider._sdk_config.resource.merge(sdk_resource)
     logger.info(
         "Merged sap-cloud-sdk resource attrs onto wrapper-installed MeterProvider"

--- a/src/sap_cloud_sdk/core/telemetry/_provider.py
+++ b/src/sap_cloud_sdk/core/telemetry/_provider.py
@@ -30,6 +30,9 @@ from opentelemetry.sdk.metrics import (
     ObservableUpDownCounter,
     UpDownCounter,
 )
+
+# Stable reference for isinstance checks — not overwritten when tests patch MeterProvider
+_SDKMeterProvider = MeterProvider
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     PeriodicExportingMetricReader,
@@ -46,6 +49,18 @@ from sap_cloud_sdk.core.telemetry.constants import SDK_PACKAGE_NAME
 from sap_cloud_sdk.core.telemetry.log_filters.identity import IdentityLogFilter
 
 logger = logging.getLogger(__name__)
+
+
+def _merge_sdk_resource_into_meter_provider(
+    provider: MeterProvider, sdk_resource: Resource
+) -> None:
+    """OTel SDK has no public API to swap a MeterProvider's Resource after construction.
+    SdkConfiguration is a dataclass so _sdk_config.resource is mutable in-place;
+    _measurement_consumer holds the same object reference so it sees the update too."""
+    provider._sdk_config.resource = provider._sdk_config.resource.merge(sdk_resource)
+    logger.info(
+        "Merged sap-cloud-sdk resource attrs onto wrapper-installed MeterProvider"
+    )
 
 
 def _merge_sdk_resource_into_log_provider(
@@ -214,6 +229,21 @@ def _setup_meter_provider() -> Optional[MeterProvider]:
 
     try:
         resource = Resource.create(create_resource_attributes_from_env())
+        existing = cast(MeterProvider, metrics.get_meter_provider())
+
+        if isinstance(existing, _SDKMeterProvider):
+            logger.warning(
+                "Global MeterProvider was already set by another library. "
+                "Merging sap.cloud_sdk.* resource attributes into the existing provider."
+            )
+            _merge_sdk_resource_into_meter_provider(existing, resource)
+            logger.info(
+                f"OpenTelemetry meter provider merged. "
+                f"Service: {config.service_name}, "
+                f"Endpoint: {config.otlp_endpoint}"
+            )
+            return existing
+
         exporter = _create_metric_exporter()
         reader = PeriodicExportingMetricReader(exporter=exporter)
         provider = MeterProvider(resource=resource, metric_readers=[reader])

--- a/tests/core/unit/telemetry/test_provider.py
+++ b/tests/core/unit/telemetry/test_provider.py
@@ -21,6 +21,7 @@ from sap_cloud_sdk.core.telemetry._provider import (
     shutdown,
     _setup_meter_provider,
     _create_metric_exporter,
+    _merge_sdk_resource_into_meter_provider,
     setup_log_provider,
     _create_log_exporter,
     _merge_sdk_resource_into_log_provider,
@@ -173,30 +174,64 @@ class TestSetupMeterProvider:
         mock_exporter = MagicMock()
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
             with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter", return_value=mock_exporter) as mock_create:
-                    with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader") as mock_reader:
-                        with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
-                            with patch("opentelemetry.metrics.set_meter_provider"):
+                with patch("sap_cloud_sdk.core.telemetry._provider.metrics") as mock_metrics:
+                    mock_metrics.get_meter_provider.return_value = MagicMock()
+                    with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter", return_value=mock_exporter) as mock_create:
+                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader") as mock_reader:
+                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider"):
                                 _setup_meter_provider()
 
-                        mock_create.assert_called_once_with()
-                        mock_reader.assert_called_once_with(exporter=mock_exporter)
+                            mock_create.assert_called_once_with()
+                            mock_reader.assert_called_once_with(exporter=mock_exporter)
 
     def test_unsupported_protocol_returns_none(self):
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
             with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}):
-                    assert _setup_meter_provider() is None
+                with patch("sap_cloud_sdk.core.telemetry._provider.metrics") as mock_metrics:
+                    mock_metrics.get_meter_provider.return_value = MagicMock()
+                    with patch.dict("os.environ", {"OTEL_EXPORTER_OTLP_PROTOCOL": "http/json"}):
+                        assert _setup_meter_provider() is None
 
     def test_returns_configured_provider(self):
         mock_provider = MagicMock()
         with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
             with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
-                with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter"):
-                    with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
-                        with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider", return_value=mock_provider):
-                            with patch("opentelemetry.metrics.set_meter_provider"):
+                with patch("sap_cloud_sdk.core.telemetry._provider.metrics") as mock_metrics:
+                    mock_metrics.get_meter_provider.return_value = MagicMock()
+                    with patch("sap_cloud_sdk.core.telemetry._provider._create_metric_exporter"):
+                        with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader"):
+                            with patch("sap_cloud_sdk.core.telemetry._provider.MeterProvider", return_value=mock_provider):
                                 assert _setup_meter_provider() is mock_provider
+
+
+    def test_reuses_existing_sdk_meter_provider(self):
+        """When a MeterProvider is already set, merge into it instead of creating a new one."""
+        from opentelemetry.sdk.metrics import MeterProvider as _MP
+        existing = MagicMock(spec=_MP)
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch("sap_cloud_sdk.core.telemetry._provider.metrics") as mock_metrics:
+                    mock_metrics.get_meter_provider.return_value = existing
+                    with patch("sap_cloud_sdk.core.telemetry._provider._merge_sdk_resource_into_meter_provider") as mock_merge:
+                        with patch("sap_cloud_sdk.core.telemetry._provider._SDKMeterProvider", _MP):
+                            result = _setup_meter_provider()
+                            assert result is existing
+                            mock_merge.assert_called_once()
+                            mock_metrics.set_meter_provider.assert_not_called()
+
+    def test_existing_provider_no_new_reader(self):
+        """Reuse path must not create a new PeriodicExportingMetricReader."""
+        from opentelemetry.sdk.metrics import MeterProvider as _MP
+        existing = MagicMock(spec=_MP)
+        with patch("sap_cloud_sdk.core.telemetry._provider.get_config", return_value=_ENABLED_CONFIG):
+            with patch("sap_cloud_sdk.core.telemetry._provider.Resource"):
+                with patch("sap_cloud_sdk.core.telemetry._provider.metrics") as mock_metrics:
+                    mock_metrics.get_meter_provider.return_value = existing
+                    with patch("sap_cloud_sdk.core.telemetry._provider._merge_sdk_resource_into_meter_provider"):
+                        with patch("sap_cloud_sdk.core.telemetry._provider._SDKMeterProvider", _MP):
+                            with patch("sap_cloud_sdk.core.telemetry._provider.PeriodicExportingMetricReader") as mock_reader:
+                                _setup_meter_provider()
+                                mock_reader.assert_not_called()
 
 
 _LOGGING_HANDLER = "sap_cloud_sdk.core.telemetry._provider.LoggingHandler"
@@ -328,6 +363,44 @@ class TestSetupLogProvider:
                                     setup_log_provider()
                                     external.add_log_record_processor.assert_not_called()
                                     mock_handler_cls.assert_called_once_with(logger_provider=external)
+
+
+class TestMergeSdkResourceIntoMeterProvider:
+    def test_updates_sdk_config_resource(self):
+        from opentelemetry.sdk.metrics import MeterProvider as _MP
+        from opentelemetry.sdk.resources import Resource as _R
+
+        sdk_resource = _R({"sap.cloud_sdk.language": "python"})
+        existing_resource = _R({"service.name": "svc"})
+        provider = _MP(resource=existing_resource)
+
+        _merge_sdk_resource_into_meter_provider(provider, sdk_resource)
+
+        assert provider._sdk_config.resource.attributes["sap.cloud_sdk.language"] == "python"
+        assert provider._sdk_config.resource.attributes["service.name"] == "svc"
+
+    def test_measurement_consumer_sees_update(self):
+        """_measurement_consumer shares the same SdkConfiguration object."""
+        from opentelemetry.sdk.metrics import MeterProvider as _MP
+        from opentelemetry.sdk.resources import Resource as _R
+
+        sdk_resource = _R({"sap.cloud_sdk.language": "python"})
+        provider = _MP(resource=_R({"service.name": "svc"}))
+
+        _merge_sdk_resource_into_meter_provider(provider, sdk_resource)
+
+        assert provider._measurement_consumer._sdk_config.resource is provider._sdk_config.resource
+
+    def test_sdk_attrs_win_on_collision(self):
+        from opentelemetry.sdk.metrics import MeterProvider as _MP
+        from opentelemetry.sdk.resources import Resource as _R
+
+        sdk_resource = _R({"service.name": "sdk-name"})
+        provider = _MP(resource=_R({"service.name": "platform-name"}))
+
+        _merge_sdk_resource_into_meter_provider(provider, sdk_resource)
+
+        assert provider._sdk_config.resource.attributes["service.name"] == "sdk-name"
 
 
 class TestMergeSdkResourceIntoLogProvider:

--- a/uv.lock
+++ b/uv.lock
@@ -4285,7 +4285,7 @@ wheels = [
 
 [[package]]
 name = "sap-cloud-sdk"
-version = "0.52.0"
+version = "0.52.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Problem

Reported: `sap.internal_sdk.version` and `sap.cloud_sdk.name` were missing from **metrics** when OTel auto-instrumentation was active, even though they appeared correctly on traces and logs.

Root cause: when the OTel auto-instrumentation wrapper installs a `MeterProvider` before `auto_instrument()` is called, `metrics.set_meter_provider()` is a silent no-op (`WARNING: Overriding of current MeterProvider is not allowed`). The new provider with our resource attributes is created but never registered, so the global provider (owned by the wrapper) never gets our attributes.

Traces and logs already had a fix for this — they detect the pre-installed provider and merge resource attributes into it. Metrics had no equivalent.

## Fix

Mirror the log/trace pattern: at `_setup_meter_provider()` time, check if an SDK `MeterProvider` is already set globally. If so, merge our resource attributes into it instead of trying to create a new one.

`SdkConfiguration` (which stores the resource) is a dataclass, so `_sdk_config.resource` is mutable in-place. `_measurement_consumer` holds a reference to the same object, so it sees the update automatically — no additional patching needed.

## Tests

- `TestMergeSdkResourceIntoMeterProvider` — unit tests for the merge function itself (resource update, measurement consumer sees it, SDK attrs win on collision)
- `TestSetupMeterProvider.test_reuses_existing_sdk_meter_provider` — verifies merge path is taken and `set_meter_provider` is not called again
- `TestSetupMeterProvider.test_existing_provider_no_new_reader` — verifies no extra `PeriodicExportingMetricReader` is created on the reuse path