### PR TITLE
fix(agentgateway): raise AgentGatewayServerError on isError tool results

### DIFF
--- a/src/sap_cloud_sdk/agentgateway/_customer.py
+++ b/src/sap_cloud_sdk/agentgateway/_customer.py
@@ -46,7 +46,10 @@ from sap_cloud_sdk.agentgateway._models import (
     MCPToolFilter,
 )
 from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
-from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
+from sap_cloud_sdk.agentgateway.exceptions import (
+    AgentGatewaySDKError,
+    AgentGatewayServerError,
+)
 from sap_cloud_sdk.core.secret_resolver import resolve_base_mount
 
 logger = logging.getLogger(__name__)
@@ -841,11 +844,8 @@ async def call_mcp_tool_customer(
                 text = str(getattr(first, "text", ""))
 
                 if mcp_is_error(result):
-                    logger.error(
-                        "Tool '%s' on '%s' returned an error: %s",
-                        tool.name,
-                        tool.url,
-                        text,
+                    raise AgentGatewayServerError(
+                        f"Tool '{tool.name}' on '{tool.url}' returned an error: {text}"
                     )
 
                 return text

--- a/src/sap_cloud_sdk/agentgateway/_lob.py
+++ b/src/sap_cloud_sdk/agentgateway/_lob.py
@@ -50,6 +50,7 @@ from sap_cloud_sdk.agentgateway._models import (
 from sap_cloud_sdk.agentgateway._token_cache import _GatewayUrlCache, _TokenCache
 from sap_cloud_sdk.agentgateway.exceptions import (
     AgentGatewaySDKError,
+    AgentGatewayServerError,
     MCPServerNotFoundError,
 )
 
@@ -526,11 +527,8 @@ async def call_mcp_tool_lob(
                 text = str(getattr(first, "text", ""))
 
                 if mcp_is_error(result):
-                    logger.error(
-                        "Tool '%s' on '%s' returned an error: %s",
-                        tool.name,
-                        tool.url,
-                        text,
+                    raise AgentGatewayServerError(
+                        f"Tool '{tool.name}' on '{tool.url}' returned an error: {text}"
                     )
 
                 return text

--- a/tests/agentgateway/unit/test_customer.py
+++ b/tests/agentgateway/unit/test_customer.py
@@ -27,7 +27,10 @@ from sap_cloud_sdk.agentgateway._models import (
 )
 from sap_cloud_sdk.agentgateway._token_cache import _TokenCache
 from sap_cloud_sdk.agentgateway.config import ClientConfig
-from sap_cloud_sdk.agentgateway.exceptions import AgentGatewaySDKError
+from sap_cloud_sdk.agentgateway.exceptions import (
+    AgentGatewaySDKError,
+    AgentGatewayServerError,
+)
 
 
 # ============================================================
@@ -766,6 +769,8 @@ class TestCallMcpToolCustomer:
             mock_content = MagicMock()
             mock_content.text = "Order created successfully"
             mock_result.content = [mock_content]
+            mock_result.is_error = False
+            mock_result.isError = False
             mock_session.call_tool = AsyncMock(return_value=mock_result)
             mock_session_ctx = AsyncMock()
             mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
@@ -823,6 +828,58 @@ class TestCallMcpToolCustomer:
             )
 
             assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_raises_server_error_on_is_error(
+        self, credentials, mock_tool
+    ):
+        """Raise AgentGatewayServerError when tool returns isError."""
+        tool = MCPTool(
+            name="test-tool",
+            server_name="test-server",
+            description="Test tool",
+            input_schema={},
+            url="https://example.com/mcp",
+            fragment_name="test-fragment",
+        )
+
+        with (
+            patch(
+                "httpx.AsyncClient",
+            ),
+            patch(
+                "sap_cloud_sdk.agentgateway._customer.streamable_http_client",
+            ) as mock_stream,
+            patch(
+                "sap_cloud_sdk.agentgateway._customer.ClientSession",
+            ) as mock_session_class,
+        ):
+            mock_stream_ctx = AsyncMock()
+            mock_stream_ctx.__aenter__ = AsyncMock(
+                return_value=(AsyncMock(), AsyncMock(), None)
+            )
+            mock_stream_ctx.__aexit__ = AsyncMock(return_value=None)
+            mock_stream.return_value = mock_stream_ctx
+
+            mock_session = AsyncMock()
+            mock_session.initialize = AsyncMock()
+            mock_result = MagicMock()
+            mock_result.content = [MagicMock()]
+            mock_result.content[0].text = "backend exploded"
+            mock_result.is_error = True
+            mock_result.isError = True
+            mock_session.call_tool = AsyncMock(return_value=mock_result)
+            mock_session_ctx = AsyncMock()
+            mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_ctx.__aexit__ = AsyncMock(return_value=None)
+            mock_session_class.return_value = mock_session_ctx
+
+            with pytest.raises(
+                AgentGatewayServerError, match="backend exploded"
+            ):
+                await call_mcp_tool_customer(tool, "auth-token", 60.0)
+
+            mock_session.call_tool.assert_called_once()
 
 
 # ============================================================

--- a/tests/agentgateway/unit/test_lob.py
+++ b/tests/agentgateway/unit/test_lob.py
@@ -41,6 +41,7 @@ from sap_cloud_sdk.agentgateway.config import ClientConfig
 from sap_cloud_sdk.destination import ConsumptionOptions, ConsumptionLevel
 from sap_cloud_sdk.agentgateway.exceptions import (
     AgentGatewaySDKError,
+    AgentGatewayServerError,
     MCPServerNotFoundError,
 )
 from sap_cloud_sdk.destination import ConsumptionLevel
@@ -953,6 +954,8 @@ class TestCallMcpToolLob:
         mock_result = MagicMock()
         mock_result.content = [MagicMock()]
         mock_result.content[0].text = "Tool result"
+        mock_result.is_error = False
+        mock_result.isError = False
 
         with (
             patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient") as mock_http,
@@ -1029,6 +1032,53 @@ class TestCallMcpToolLob:
             result = await call_mcp_tool_lob(tool, "user-auth-token", 60.0)
 
             assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_raises_server_error_on_is_error(self):
+        """Raise AgentGatewayServerError when tool returns isError."""
+        tool = MCPTool(
+            name="test-tool",
+            server_name="test-server",
+            description="Test tool",
+            input_schema={},
+            url="https://example.com/mcp",
+            fragment_name="test-fragment",
+        )
+
+        mock_result = MagicMock()
+        mock_result.content = [MagicMock()]
+        mock_result.content[0].text = "backend exploded"
+        mock_result.is_error = True
+        mock_result.isError = True
+
+        with (
+            patch("sap_cloud_sdk.agentgateway._lob.httpx.AsyncClient"),
+            patch(
+                "sap_cloud_sdk.agentgateway._lob.streamable_http_client"
+            ) as mock_stream,
+            patch("sap_cloud_sdk.agentgateway._lob.ClientSession") as mock_session,
+        ):
+            mock_stream.return_value.__aenter__.return_value = (
+                AsyncMock(),
+                AsyncMock(),
+                None,
+            )
+
+            mock_session_instance = AsyncMock()
+            mock_session_instance.initialize = AsyncMock()
+            mock_session_instance.call_tool = AsyncMock(
+                return_value=mock_result
+            )
+            mock_session.return_value.__aenter__.return_value = (
+                mock_session_instance
+            )
+
+            with pytest.raises(
+                AgentGatewayServerError, match="backend exploded"
+            ):
+                await call_mcp_tool_lob(tool, "user-auth-token", 60.0)
+
+            mock_session_instance.call_tool.assert_called_once()
 
 
 # ============================================================


### PR DESCRIPTION
## What

`AgentGatewayClient.call_mcp_tool` silently swallowed MCP tool errors. When the MCP server returns a spec-compliant error response (`isError: true`, HTTP 200, SSE `event: message` with `result.isError == true`), both `call_mcp_tool_lob` (LoB flow) and `call_mcp_tool_customer` (customer flow) logged the error and returned the raw error text as if it were a successful tool result. Callers could not distinguish success from failure — any caller inspecting `result.isError` on the return value crashed with `AttributeError` (reported as `'NoneType' object has no attribute 'isError'`).

## Why

The SDK already documents the intended contract in `src/sap_cloud_sdk/agentgateway/exceptions.py`: `AgentGatewayServerError` is raised when "A tool invocation returns an error result (isError=True)". The implementation violated its own documented contract — the exception was never raised on this path. Silently returning a value that crashes `.isError` accessors is never a valid outcome for a tool call that failed server-side.

## How

- `src/sap_cloud_sdk/agentgateway/_lob.py`: in `call_mcp_tool_lob`, replace the log-and-return block with `raise AgentGatewayServerError(f"Tool '{tool.name}' on '{tool.url}' returned an error: {text}")` when `mcp_is_error(result)` is true.
- `src/sap_cloud_sdk/agentgateway/_customer.py`: identical fix in `call_mcp_tool_customer` so both flows behave consistently.
- Success path unchanged (still returns the tool text); empty-content path unchanged (still returns `""`).
- Tests: added `test_raises_server_error_on_is_error` to `TestCallMcpToolLob` and `TestCallMcpToolCustomer`; set explicit `is_error=False`/`isError=False` on the existing success-path mocks (a plain `MagicMock` is truthy, so those tests were implicitly passing through the error branch before).

## Verification

- Reproduced the bug at the wire level: a local HTTP server answering the exact SSE payload from the issue (`event: message` / `data: {"result": {"content": [...], "isError": true}, "jsonrpc": "2.0", "id": 3}`) against `call_mcp_tool_lob` returned the error text as a plain `str` and `.isError` raised `AttributeError: 'str' object has no attribute 'isError'`.
- Targeted suite: `pytest tests/agentgateway/unit/test_lob.py tests/agentgateway/unit/test_customer.py` → 103 passed.
- Full agentgateway unit suite: 220 passed, 24 failed — the 24 failures are in `test_converters.py` and **pre-exist on a clean `origin/main` checkout** (verified via a fresh worktree: same 24 failures, unrelated to this change).
- Mutation check: reverted only the fix's behavior in `_lob.py` (restored log-and-return) → `test_raises_server_error_on_is_error` fails (1 failed); restored the fix → passes. The new test guards this behavior.

## Notes

- The reporter's exact stack (`'NoneType' object has no attribute 'isError'`) comes from an older SDK version; on current main the returned value is a `str`, producing `'str' object has no attribute 'isError'` — same class of defect, same fix.
- No new dependencies; no formatting churn.

Fixes #326

### AI-generated code disclosure

This change was implemented with AI assistance (OpenCode + muse-spark) and reviewed/verified for correctness, security, and license compatibility per SAP GenAI guidelines.