### PR TITLE
fix(ci): make version-bump check against merge-base

### DIFF
--- a/.github/workflows/check-version-bump.yaml
+++ b/.github/workflows/check-version-bump.yaml
@@ -22,11 +22,12 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
 
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")
 
           if echo "$CHANGED_FILES" | grep -qE "^src/.*\.(py|pyi|proto)$"; then
-            BASE_VERSION=$(git show "$BASE_SHA:pyproject.toml" | grep "^version = " | cut -d'"' -f2)
+            BASE_VERSION=$(git show "$MERGE_BASE:pyproject.toml" | grep "^version = " | cut -d'"' -f2)
             HEAD_VERSION=$(git show "$HEAD_SHA:pyproject.toml" | grep "^version = " | cut -d'"' -f2)
 
             if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then


### PR DESCRIPTION
> **Disclaimer:** Do not include SAP-internal or customer-specific information in this PR (e.g. internal system URLs, customer names, tenant IDs, or confidential configurations). This is a public repository.

## Description

The **Check Version Bump** workflow diffs `github.event.pull_request.base.sha` against `head.sha` to decide whether a version bump is required. That base SHA is the commit `main` pointed at when the PR was last synced, and it drifts behind `main` as other PRs merge. As a result the diff includes `src/**/*.py` files from already-merged PRs that the current branch never touched, so the check wrongly demands a version bump and a documentation-only PR ends up failing because unrelated source files appear in the comparison.

This changes the check to diff against the **merge-base** of the base and head commits (the point where the branch actually diverged from `main`) instead of the raw base ref. 

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Dependency update

## How to Test

Reproduced locally using the workflow's own logic against a drifted PR's real SHAs:

1. Old behavior (raw `base.sha`): source files from already-merged PRs appear in the diff → check **FAILS** demanding a version bump.
2. New behavior (merge-base): only the branch's own files appear → docs-only diff prints `No source file changes under src/. Version bump not required.` → check **PASSES**.
3. Negative case preserved: a diff that genuinely contains a `src/**/*.py` change without a version bump still matches the regex and **FAILS** with the existing error — enforcement is unchanged for real source changes.

Also tested end-to-end : applying the fix to docs-only PR branch (#329) flipped **Check Version Bump** from failing to passing.

## Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have verified that my changes solve the issue
- [ ] I have added/updated automated tests to cover my changes  
- [x] All tests pass locally
- [x] I have verified that my code follows the [Code Guidelines](../docs/GUIDELINES.md)
- [ ] I have updated documentation (if applicable)  <!-- N/A -->
- [ ] I have added type hints for all public APIs  <!-- N/A: no code -->
- [x] My code does not contain sensitive information (credentials, tokens, etc.)
- [x] I have followed [Conventional Commits](https://www.conventionalcommits.org/) for commit messages

## Breaking Changes

None

## Additional Notes

None
